### PR TITLE
Configure Stylelint to error on !important

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,4 +1,7 @@
 {
+  "rules": {
+    "declaration-no-important": true
+  },
   "processors": ["stylelint-processor-styled-components"],
   "extends": [
     "stylelint-config-recommended",


### PR DESCRIPTION
Resolves #39 

Adds the [declaration-no-important rule](https://github.com/stylelint/stylelint/tree/master/lib/rules/declaration-no-important) to `.stylelintrc`.

- [ ] Tests added for new features
- [ ] Test engineer approval