### PR TITLE
Scope psammead to @bbc/psammead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "psammead",
+  "name": "@bbc/psammead",
   "version": "0.1.0",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",


### PR DESCRIPTION
Resolves https://github.com/BBC-News/psammead/issues/65

Adds `@bbc` namespace to psammead's name in the package.json

- [n/a] Tests added for new features
- [ ] Test engineer approval
