### PR TITLE
Update psammead-headings repo and home urls

### DIFF
--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.1   | [PR#100](https://github.com/BBC-News/psammead/pull/100) Fix links to repo and homepage |
 | 0.1.0   | [PR#79](https://github.com/BBC-News/psammead/pull/79) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -5,7 +5,7 @@
   "description": "React styled components for a Headline and SubHeading",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BBC-News/psammead/tree/latest/packages/utilities/psammead-headings"
+    "url": "https://github.com/BBC-News/psammead/tree/latest/packages/components/psammead-headings"
   },
   "author": {
     "name": "Psammead Maintainers",
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/bbc/psammead/issues"
   },
-  "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/utilities/psammead-headings/README.md",
+  "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-constants": "^0.1.1",
     "@bbc/gel-foundations-styled-components": "^0.1.0",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {


### PR DESCRIPTION
Resolves https://github.com/BBC-News/psammead/issues/97

Fixes repo and homepage urls in the `package.json`

- [N/A] Tests added for new features
- [ ] Test engineer approval
