### PR TITLE
Fix deprecated usage of styled-components attrs function

### DIFF
--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -21,11 +21,10 @@ export const Headline = styled.h1`
 const regexPunctuationSymbols = /[^a-z0-9\s-]/gi;
 const regexSpaces = /\s+/g;
 
-export const SubHeading = styled.h2.attrs({
-  id: ({ text }) =>
-    text.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-'),
+export const SubHeading = styled.h2.attrs(({ text }) => ({
+  id: text.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-'),
   tabIndex: '-1',
-})`
+}))`
   color: ${C_STORM};
   font-family: ${FF_NEWS_SANS_REG};
   margin: 0; /* Reset */


### PR DESCRIPTION
Resolves #86 

This PR simply adopts a change to styled-components' supported usage of the attrs function, as it will not be supported as of V5 & was causing warnings.

Before:
![screenshot 2018-12-04 at 14 30 27](https://user-images.githubusercontent.com/11646957/49448694-5751bc00-f7d1-11e8-83bb-989e18f5c0ba.png)

After:
![screenshot 2018-12-04 at 14 31 17](https://user-images.githubusercontent.com/11646957/49448698-59b41600-f7d1-11e8-8979-1dd884515c1e.png)


- [ ] Tests added for new features
- [ ] Test engineer approval