### PR TITLE
Bump VisuallyHiddenText package for Babel 7

### DIFF
--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 | --------------------- |
+| 0.1.2   | [PR#125](https://github.com/BBC-News/psammead/pull/125) Bump to ensure built with Babel 7 |
 | 0.1.1   | [PR#113](https://github.com/BBC-News/psammead/pull/113) Fix links to repo and homepage |
 | 0.1.0 | [PR#91](https://github.com/BBC-News/psammead/pull/91) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-visually-hidden-text/package-lock.json
+++ b/packages/components/psammead-visually-hidden-text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-visually-hidden-text/package.json
+++ b/packages/components/psammead-visually-hidden-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "description": "React styled component for visually hidden text (for screen readers)",
   "repository": {


### PR DESCRIPTION
Resolves #N/A

Bumping the VisuallyHiddenText package, as it was built (#91) & published prior to the Babel 7 PR being merged (#94).

- [ ] Tests added for new features
- [ ] Test engineer approval