### PR TITLE
Add tick box to prompt people to assign PR/issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,6 @@ Resolves #NUMBER
 
 _PR changes summary to go here._
 
+- [ ] I have assigned myself to this PR and the corresponding issues
 - [ ] Tests added for new features
 - [ ] Test engineer approval


### PR DESCRIPTION
When using the github projects board it can be confusing who is working on an issue/PR as the creator of the item is displayed. This can become misleading when person X created an issue and person Y picked up the issue. Therefore adding a tick box to prompt people to assign themselves.

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
