### PR TITLE
Psammead-Paragraph - Bump to use @babel 7

### DIFF
--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.1   | [PR#127](https://github.com/BBC-News/psammead/pull/127) Bump to ensure built with Babel 7, introduced in #94 |
 | 0.1.0   | [PR#93](https://github.com/BBC-News/psammead/pull/93) Create initial package with Paragraph component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
Part of: https://github.com/BBC-News/simorgh/issues/997

Bump package version to use new @babel v7 setup for transpiling into the dist directory. 

**Test instructions**
This will be needed to be used in https://github.com/BBC-News/simorgh/pull/1051

- [ ] ~Tests added for new features~ N/A
- [ ] Test engineer approval
