### PR TITLE
Fix psammead-paragraph styling

### DIFF
--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -6,6 +6,15 @@ exports[`Paragraph should render a correctly 1`] = `
   font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   padding-bottom: 1rem;
   margin: 0;
+  font-size: 0.9375em;
+  line-height: 1.25rem;
+}
+
+@media (min-width:20em) {
+  .c0 {
+    font-size: 1em;
+    line-height: 1.375rem;
+  }
 }
 
 <p

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -2,14 +2,14 @@ import styled from 'styled-components';
 import { C_STORM } from '@bbc/psammead-styles/colours';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
 import { GEL_SPACING_DBL } from '@bbc/gel-constants/spacings';
-import { T_BODY_COPY } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_BODY_COPY } from '@bbc/gel-foundations-styled-components/typography';
 
 const Paragraph = styled.p`
   color: ${C_STORM};
   font-family: ${FF_NEWS_SANS_REG};
   padding-bottom: ${GEL_SPACING_DBL};
   margin: 0; /* Reset */
-  ${T_BODY_COPY};
+  ${GEL_BODY_COPY};
 `;
 
 export default Paragraph;


### PR DESCRIPTION
Part of #124?

Font size was being imported with `T_` prefix, not `GEL_` prefix. Doing this fixes the issue described in 124, but there may be additional issues that haven't been captured in that ticket?

Should this block [Simorgh#1051](
https://github.com/BBC-News/simorgh/pull/1051)?

```
npm run storybook
visit http://localhost:8080/
Navigate to Paragraph component
View broken styles (on `latest`)
Repeat for this branch `fix_paragraph_styling` Styles should be fixed
```
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
