### PR TITLE
updates package-locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16682,7 +16682,7 @@
     },
     "regexpu-core": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
@@ -16708,7 +16708,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }

--- a/packages/components/example-button/package-lock.json
+++ b/packages/components/example-button/package-lock.json
@@ -25,7 +25,7 @@
 		},
 		"core-js": {
 			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
 		"css-color-keywords": {


### PR DESCRIPTION
Resolves N/A

As per the discussion in https://github.com/BBC-News/psammead/pull/151#pullrequestreview-182703417, the example-button package-lock.json generated locally is different than the one on `latest` because it was generated by a different version of Node/NPM than we recommend.

Every time we make a PR, we have to remember to not commit the package-lock changes for unrelated packages like this one, and someone is bound to forget!

This PR updates the package-lock files to be as they would be on our local machines, and should make future PRs simpler to create.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
