### PR TITLE
Bump Psammead Paragraph

### DIFF
--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.3   | [PR#](https://github.com/BBC-News/psammead/pull/) Bump to ensure `dist` includes Typography fix from 0.1.2. |
+| 0.1.3   | [PR#164](https://github.com/BBC-News/psammead/pull/164) Bump to ensure `dist` includes Typography fix from 0.1.2. |
 | 0.1.2   | [PR#134](https://github.com/BBC-News/psammead/pull/134) Import correct Typography variable `GEL_BODY_COPY` |
 | 0.1.1   | [PR#127](https://github.com/BBC-News/psammead/pull/127) Bump to ensure built with Babel 7, introduced in #94 |
 | 0.1.0   | [PR#93](https://github.com/BBC-News/psammead/pull/93) Create initial package with Paragraph component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.3   | [PR#](https://github.com/BBC-News/psammead/pull/) Bump to ensure `dist` includes Typography fix from 0.1.2. |
+| 0.1.2   | [PR#134](https://github.com/BBC-News/psammead/pull/134) Import correct Typography variable `GEL_BODY_COPY` |
 | 0.1.1   | [PR#127](https://github.com/BBC-News/psammead/pull/127) Bump to ensure built with Babel 7, introduced in #94 |
 | 0.1.0   | [PR#93](https://github.com/BBC-News/psammead/pull/93) Create initial package with Paragraph component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION

Part of #52  
Blocking https://github.com/BBC-News/simorgh/pull/1051

Bump to ensure published package's dist includes typography fix from 0.1.2

Note - there are no code changes in this PR. 
Steps to take post-merge:
```
git checkout latest
git pull origin latest
npm ci
npm run build
npm publish packages/components/psammead-paragraph --otp=<NPM_2FA_CODE>
```

To ensure we don't need to do this again, I've opened a separate issue here: https://github.com/BBC-News/psammead/issues/160


**Testing Notes**
Assuming you have [Simorgh](https://github.com/BBC-News/simorgh) locally at the same level as psammead:
```
cd psammead && git checkout publish-correct-dist
npm ci && npm run build 
cd ../simorgh && git checkout use-psammead-paragraph
npm ci
npm link ../psammead/packages/components/psammead-paragraph
npm run dev
```
Visit http://localhost:7080/news/articles/c9rpqy7pmypo
& https://www.test.bbc.com/news/articles/c9rpqy7pmypo
- Compare the paragraph styles locally with those on the Test environment 
The localhost version should have the correct mediaquery. 

I've done these steps and it's worked for me.
Screenshot of psammead-paragraph with correct `dist` files giving the correct typography styles:

<img width="1129" alt="screen shot simorgh article with paragraph with correct styling" src="https://user-images.githubusercontent.com/3028997/49698769-4a154280-fbc0-11e8-8656-9b4e2e5237a0.png">

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
