### PR TITLE
Add common sections to Visually Hidden Text README

### DIFF
--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 | --------------------- |
+| 0.1.3   | [PR#172](https://github.com/BBC-News/psammead/pull/172) Update README.md to include common sections. |
 | 0.1.2   | [PR#125](https://github.com/BBC-News/psammead/pull/125) Bump to ensure built with Babel 7 |
 | 0.1.1   | [PR#113](https://github.com/BBC-News/psammead/pull/113) Fix links to repo and homepage |
 | 0.1.0 | [PR#91](https://github.com/BBC-News/psammead/pull/91) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-visually-hidden-text/README.md
+++ b/packages/components/psammead-visually-hidden-text/README.md
@@ -19,3 +19,15 @@ Similarly, when adding hidden text that will occur partway through an article, a
 ### Additional notes
 
 Please bear in mind that if CSS is disabled, the text will be shown inline. Testing your usage of the component should include disabling page styling.
+
+## Contributing
+
+Psammead is completely open source. We are grateful for any contributions, whether they be new components, bug fixes or general improvements. Please see our primary contributing guide which can be found at [the root of the Psammead respository](https://github.com/BBC-News/psammead/blob/latest/CONTRIBUTING.md).
+
+### [Code of Conduct](https://github.com/BBC-News/psammead/blob/latest/CODE_OF_CONDUCT.md)
+
+We welcome feedback and help on this work. By participating in this project, you agree to abide by the [code of conduct](https://github.com/BBC-News/psammead/blob/latest/CODE_OF_CONDUCT.md). Please take a moment to read it.
+
+### License
+
+Psammead is [Apache 2.0 licensed](https://github.com/BBC-News/psammead/blob/latest/LICENSE).

--- a/packages/components/psammead-visually-hidden-text/package-lock.json
+++ b/packages/components/psammead-visually-hidden-text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-visually-hidden-text/package.json
+++ b/packages/components/psammead-visually-hidden-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "description": "React styled component for visually hidden text (for screen readers)",
   "repository": {


### PR DESCRIPTION
Resolves #N/A

Just a quick change, as I spotted the VHT readme is inconsistent with other components'.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
