### PR TITLE
Add ignore pattern for jest tests, to avoid running tests against dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     ],
     "testMatch": [
       "**/__tests__/**/*.js?(x)",
-      "**/*.test.{js,jsx}"
+      "**/*.test.{js,jsx}",
+      "!**/dist/**"
     ]
   },
   "spec": {


### PR DESCRIPTION
Resolves #N/A. Follows up on #155.

We ensured that we don't generate test coverage on `dist/` directories, but not that we don't run any tests that manage to sneak their way into `dist/`directories. This simply adds a rule to ignore any test with `/dist/` in it's path.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
