### PR TITLE
Revert "Add ignore pattern for jest tests, to avoid running tests against dist/"

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
     ],
     "testMatch": [
       "**/__tests__/**/*.js?(x)",
-      "**/*.test.{js,jsx}",
-      "!**/dist/**"
+      "**/*.test.{js,jsx}"
     ]
   },
   "spec": {


### PR DESCRIPTION
Reverts BBC-News/psammead#192

This should not be necessary, as `npm run build` ignores `**/dist**/` directories, & the interaction between this change & the coverage seemed to be causing issues with the coverage table.