### PR TITLE
Add Readme to all storybook stories

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,4 @@
+import 'storybook-readme/register';
 import '@storybook/addon-options/register';
 import '@storybook/addon-knobs/register'
 import '@storybook/addon-viewport/register'
-import 'storybook-readme/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,8 +6,8 @@ import { createGlobalStyle } from 'styled-components';
 
 // Option defaults:
 setOptions({
-  name: 'Psammead',
-  url: 'https:github.com/bbc/carl',
+  name: 'BBC Psammead',
+  url: 'https:github.com/BBC-News/psammead',
   addonPanelInRight: true,
   sidebarAnimations: true,
 });

--- a/packages/components/psammead-brand/src/index.stories.jsx
+++ b/packages/components/psammead-brand/src/index.stories.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import Brand from './index';
 
-storiesOf('Brand', module).add('default', () => (
-  <Brand brandName="Default Brand Name" />
-));
+storiesOf('Brand', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => <Brand brandName="Default Brand Name" />);

--- a/packages/components/psammead-caption/src/index.stories.jsx
+++ b/packages/components/psammead-caption/src/index.stories.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InlineLink from '@bbc/psammead-inline-link';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import Caption from '.';
 
 storiesOf('Caption', module)
+  .addDecorator(withReadme(Readme))
   .add('default', () => <Caption>This is a caption.</Caption>)
   .add('with offscreen text', () => (
     <Caption>

--- a/packages/components/psammead-copyright/src/index.stories.jsx
+++ b/packages/components/psammead-copyright/src/index.stories.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import Copyright from './index';
 
-storiesOf('Copyright', module).add('default', () => (
-  <Copyright>Getty Images</Copyright>
-));
+storiesOf('Copyright', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => <Copyright>Getty Images</Copyright>);

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import { Headline, SubHeading } from './index';
 
-storiesOf('Headline', module).add('default', () => (
-  <Headline>This is my headline.</Headline>
-));
+storiesOf('Headline', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => <Headline>This is my headline.</Headline>);
 
-storiesOf('SubHeading', module).add('default', () => (
-  <SubHeading text="This is a SubHeading">This is a SubHeading</SubHeading>
-));
+storiesOf('SubHeading', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => (
+    <SubHeading text="This is a SubHeading">This is a SubHeading</SubHeading>
+  ));

--- a/packages/components/psammead-inline-link/src/index.stories.jsx
+++ b/packages/components/psammead-inline-link/src/index.stories.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import InlineLink from './index';
 
-storiesOf('InlineLink', module).add('default', () => (
-  <InlineLink href="https://www.bbc.com/news">BBC News</InlineLink>
-));
+storiesOf('InlineLink', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => (
+    <InlineLink href="https://www.bbc.com/news">BBC News</InlineLink>
+  ));

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import Paragraph from './index';
 
-storiesOf('Paragraph', module).add('default', () => (
-  <Paragraph>This is text in a paragraph.</Paragraph>
-));
+storiesOf('Paragraph', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => <Paragraph>This is text in a paragraph.</Paragraph>);

--- a/packages/components/psammead-sitewide-links/src/index.stories.jsx
+++ b/packages/components/psammead-sitewide-links/src/index.stories.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import SitewideLinks from './index';
 
 const link = name => ({
@@ -9,10 +11,12 @@ const link = name => ({
 
 const links = [link(1), link(2), link(3), link(4), link(5), link(6), link(7)];
 
-storiesOf('SitewideLinks', module).add('default', () => (
-  <SitewideLinks
-    links={links}
-    copyrightText="Text here. "
-    externalLink={link('last')}
-  />
-));
+storiesOf('SitewideLinks', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => (
+    <SitewideLinks
+      links={links}
+      copyrightText="Text here. "
+      externalLink={link('last')}
+    />
+  ));

--- a/packages/components/psammead-visually-hidden-text/src/index.stories.jsx
+++ b/packages/components/psammead-visually-hidden-text/src/index.stories.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import VisuallyHiddenText from './index';
 
-storiesOf('VisuallyHiddenText', module).add('default', () => (
-  <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
-));
+storiesOf('VisuallyHiddenText', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => (
+    <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
+  ));


### PR DESCRIPTION
Resolves #157

Adds package README.md file to all storybook stories

- Also reorders the addons so the Readme is first (as we dont use knobs atm)
- Changes Primary link to not be carl

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
