### PR TITLE
Use @bbc/gel-foundations in Psammead

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 | Version | Description                                                                                                                                                            |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.2   | [PR#227](https://github.com/BBC-News/psammead/pull/227) [Use @bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.2   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.1   | [PR#202](https://github.com/BBC-News/psammead/pull/202) Fixes a styling bug caused by an [incorrect constant import](https://github.com/BBC-News/psammead/issues/201). |
 | 0.1.0   | [PR#105](https://github.com/BBC-News/psammead/pull/105) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh).                         |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description                                                                                                                                                            |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.2   | [PR#227](https://github.com/BBC-News/psammead/pull/227) [Use @bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.1   | [PR#202](https://github.com/BBC-News/psammead/pull/202) Fixes a styling bug caused by an [incorrect constant import](https://github.com/BBC-News/psammead/issues/201). |
 | 0.1.0   | [PR#105](https://github.com/BBC-News/psammead/pull/105) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh).                         |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 | Version | Description                                                                                                                                                            |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.2   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.2   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.1   | [PR#202](https://github.com/BBC-News/psammead/pull/202) Fixes a styling bug caused by an [incorrect constant import](https://github.com/BBC-News/psammead/issues/201). |
 | 0.1.0   | [PR#105](https://github.com/BBC-News/psammead/pull/105) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh).                         |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -22,10 +22,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bbc/gel-constants": {
+    "@bbc/gel-foundations": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.2.tgz",
-      "integrity": "sha512-QNCSNe9PasApNIm9cira3pbk5y3CrYtlm5jukLRUo70O5IXMYQw9xaaMbB083Y5qZzP//3UeMjU94S1ZwsHExg=="
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-styles": {
       "version": "0.1.4",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "description": "Provides the BBC News logo (as SVG), nested a hardcoded link to https://www.bbc.co.uk/news",
   "repository": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3",
     "@bbc/psammead-visually-hidden-text": "^0.1.0",
     "react": "^16.6.3",

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -6,14 +6,14 @@ import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MAX,
-} from '@bbc/gel-constants/breakpoints';
+} from '@bbc/gel-foundations/breakpoints';
 import {
   GEL_MARGIN_BELOW_400PX,
   GEL_MARGIN_ABOVE_400PX,
   GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_HLF,
-} from '@bbc/gel-constants/spacings';
+} from '@bbc/gel-foundations/spacings';
 
 const layoutWrapperWithoutGrid = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.0 | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.0 | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -22,19 +22,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bbc/gel-constants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.1.tgz",
-      "integrity": "sha512-12arxbBpW+uIFxebVyvmVHw8KdQQ53X9ZZLXOfp2n5iRBdYr87cg5NrEQLCW6URfy7b2DLet8oPFF6zCoT6ilw=="
-    },
-    "@bbc/gel-foundations-styled-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations-styled-components/-/gel-foundations-styled-components-0.1.0.tgz",
-      "integrity": "sha512-n0DNLA1ogJ+sQWtyFjcJDDgpbb90iA1P4At7cF32/Ck1jyom0Uelx5WYJ5Pa20+K7xDcmpV38tHWRIR+8CXTIw==",
-      "requires": {
-        "@bbc/gel-constants": "^0.1.1",
-        "styled-components": "^4.1.1"
-      }
+    "@bbc/gel-foundations": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-inline-link": {
       "version": "0.1.0",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
-    "@bbc/gel-foundations-styled-components": "^0.1.0",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-constants/spacings';
-import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-constants/breakpoints';
-import { GEL_LONG_PRIMER } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
+import { GEL_LONG_PRIMER } from '@bbc/gel-foundations/typography';
 import { C_STONE, C_STORM } from '@bbc/psammead-styles/colours';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
 

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.2.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.2.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.2.0   | [PR#187](https://github.com/BBC-News/psammead/pull/187) Change PRs Welcome link, creating src directory. |
 | 0.1.0   | [PR#129](https://github.com/BBC-News/psammead/pull/129) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.2.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.2.0   | [PR#187](https://github.com/BBC-News/psammead/pull/187) Change PRs Welcome link, creating src directory. |
 | 0.1.0   | [PR#129](https://github.com/BBC-News/psammead/pull/129) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -4,37 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==",
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@bbc/gel-constants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.1.tgz",
-      "integrity": "sha512-12arxbBpW+uIFxebVyvmVHw8KdQQ53X9ZZLXOfp2n5iRBdYr87cg5NrEQLCW6URfy7b2DLet8oPFF6zCoT6ilw=="
-    },
-    "@bbc/gel-foundations-styled-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations-styled-components/-/gel-foundations-styled-components-0.1.0.tgz",
-      "integrity": "sha512-n0DNLA1ogJ+sQWtyFjcJDDgpbb90iA1P4At7cF32/Ck1jyom0Uelx5WYJ5Pa20+K7xDcmpV38tHWRIR+8CXTIw==",
-      "requires": {
-        "@bbc/gel-constants": "^0.1.1",
-        "styled-components": "^4.1.1"
-      }
+    "@bbc/gel-foundations": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-styles": {
       "version": "0.1.3",
@@ -51,54 +24,11 @@
         "react-test-renderer": "^16.6.3"
       }
     },
-    "@emotion/is-prop-valid": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
-      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
-      "requires": {
-        "@emotion/memoize": "^0.6.6"
-      }
-    },
-    "@emotion/memoize": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "babel-plugin-styled-components": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.2.tgz",
-      "integrity": "sha512-McnheW8RkBkur/mQw7rEwQO/oUUruQ/nIIj5LIRpsVL8pzG1oo1Y53xyvAYeOfamIrl4/ta7g1G/kuTR1ekO3A==",
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.10"
-      }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "css": {
       "version": "2.2.4",
@@ -112,86 +42,17 @@
         "urix": "^0.1.0"
       }
     },
-    "css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
-    },
-    "css-to-react-native": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
-      "integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
-      "requires": {
-        "css-color-keywords": "^1.0.0",
-        "fbjs": "^0.8.5",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "jest-styled-components": {
       "version": "6.3.1",
@@ -205,57 +66,29 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "prop-types": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
@@ -264,7 +97,8 @@
     "react-is": {
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==",
+      "dev": true
     },
     "react-test-renderer": {
       "version": "16.6.3",
@@ -284,11 +118,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "scheduler": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
@@ -298,11 +127,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "source-map": {
       "version": "0.6.1",
@@ -329,61 +153,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "styled-components": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.1.2.tgz",
-      "integrity": "sha512-NdvWatJ2WLqZxAvto+oH0k7GAC/TlAUJTrHoXJddjbCrU6U23EmVbb9LXJBF+d6q6hH+g9nQYOWYPUeX/Vlc2w==",
-      "requires": {
-        "@emotion/is-prop-valid": "^0.6.8",
-        "@emotion/unitless": "^0.7.0",
-        "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^4.0.0",
-        "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^5.5.0"
-      }
-    },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-    },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     }
   }
 }

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
-    "@bbc/gel-foundations-styled-components": "^0.1.0",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3"
   },
   "keywords": [

--- a/packages/components/psammead-copyright/src/index.jsx
+++ b/packages/components/psammead-copyright/src/index.jsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
-import { GEL_SPACING, GEL_SPACING_HLF } from '@bbc/gel-constants/spacings';
-import { GEL_MINION } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_SPACING, GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
+import { GEL_MINION } from '@bbc/gel-foundations/typography';
 
 const Copyright = styled.p.attrs({
   role: 'text',

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.4   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.3   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.2   | [PR#119](https://github.com/BBC-News/psammead/pull/119) Publish as babel 7 |
 | 0.1.1   | [PR#100](https://github.com/BBC-News/psammead/pull/100) Fix links to repo and homepage |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.4   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.4   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.3   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.2   | [PR#119](https://github.com/BBC-News/psammead/pull/119) Publish as babel 7 |
 | 0.1.1   | [PR#100](https://github.com/BBC-News/psammead/pull/100) Fix links to repo and homepage |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -22,19 +22,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bbc/gel-constants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.1.tgz",
-      "integrity": "sha512-12arxbBpW+uIFxebVyvmVHw8KdQQ53X9ZZLXOfp2n5iRBdYr87cg5NrEQLCW6URfy7b2DLet8oPFF6zCoT6ilw=="
-    },
-    "@bbc/gel-foundations-styled-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations-styled-components/-/gel-foundations-styled-components-0.1.0.tgz",
-      "integrity": "sha512-n0DNLA1ogJ+sQWtyFjcJDDgpbb90iA1P4At7cF32/Ck1jyom0Uelx5WYJ5Pa20+K7xDcmpV38tHWRIR+8CXTIw==",
-      "requires": {
-        "@bbc/gel-constants": "^0.1.1",
-        "styled-components": "^4.1.1"
-      }
+    "@bbc/gel-foundations": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-styles": {
       "version": "0.1.3",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
-    "@bbc/gel-foundations-styled-components": "^0.1.0",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -4,11 +4,11 @@ import {
   FF_NEWS_SERIF_MDM,
   FF_NEWS_SANS_REG,
 } from '@bbc/psammead-styles/fonts';
-import { GEL_SPACING_DBL, GEL_SPACING_QUAD } from '@bbc/gel-constants/spacings';
 import {
-  GEL_CANON,
-  GEL_TRAFALGAR,
-} from '@bbc/gel-foundations-styled-components/typography';
+  GEL_SPACING_DBL,
+  GEL_SPACING_QUAD,
+} from '@bbc/gel-foundations/spacings';
+import { GEL_CANON, GEL_TRAFALGAR } from '@bbc/gel-foundations/typography';
 
 export const Headline = styled.h1`
   color: ${C_EBON};

--- a/packages/components/psammead-inline-link/README.md
+++ b/packages/components/psammead-inline-link/README.md
@@ -56,7 +56,7 @@ Alternatively, if you want to just extend existing styles with other GEL Typogra
 
 ```jsx
 import InlineLink from '@bbc/psammead-inline-link';
-import { GEL_PARAGON } from '@bbc/gel-foundations-styled-components';
+import { GEL_PARAGON } from '@bbc/gel-foundations';
 
 const GelParagonLink = styled(InlineLink)`
   ${GEL_PARAGON};

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.5   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.5   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.4   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.3   | [PR#164](https://github.com/BBC-News/psammead/pull/164) Bump to ensure `dist` includes Typography fix from 0.1.2. |
 | 0.1.2   | [PR#134](https://github.com/BBC-News/psammead/pull/134) Import correct Typography variable `GEL_BODY_COPY` |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.5   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.4   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.3   | [PR#164](https://github.com/BBC-News/psammead/pull/164) Bump to ensure `dist` includes Typography fix from 0.1.2. |
 | 0.1.2   | [PR#134](https://github.com/BBC-News/psammead/pull/134) Import correct Typography variable `GEL_BODY_COPY` |

--- a/packages/components/psammead-paragraph/README.md
+++ b/packages/components/psammead-paragraph/README.md
@@ -4,7 +4,7 @@
 
 The `@bbc/psammead-paragraph` package exports a single Paragraph component. It uses a `p` HTML element.
 
-It uses `@bbc/psammead-styles` for colours and font family, `@bbc/gel-constants` for spacing and `@bbc/gel-foundations-styled-components` for GEL Typography implemented in Styled Components.
+It uses `@bbc/psammead-styles` for colours and font family and `@bbc/gel-foundations` for spacing and for GEL Typography implemented in Styled Components.
 
 ## Installation
 

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -22,19 +22,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bbc/gel-constants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.1.tgz",
-      "integrity": "sha512-12arxbBpW+uIFxebVyvmVHw8KdQQ53X9ZZLXOfp2n5iRBdYr87cg5NrEQLCW6URfy7b2DLet8oPFF6zCoT6ilw=="
-    },
-    "@bbc/gel-foundations-styled-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations-styled-components/-/gel-foundations-styled-components-0.1.0.tgz",
-      "integrity": "sha512-n0DNLA1ogJ+sQWtyFjcJDDgpbb90iA1P4At7cF32/Ck1jyom0Uelx5WYJ5Pa20+K7xDcmpV38tHWRIR+8CXTIw==",
-      "requires": {
-        "@bbc/gel-constants": "^0.1.1",
-        "styled-components": "^4.1.1"
-      }
+    "@bbc/gel-foundations": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-styles": {
       "version": "0.1.3",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
-    "@bbc/gel-foundations-styled-components": "^0.1.0",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { C_STORM } from '@bbc/psammead-styles/colours';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
-import { GEL_SPACING_DBL } from '@bbc/gel-constants/spacings';
-import { GEL_BODY_COPY } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { GEL_BODY_COPY } from '@bbc/gel-foundations/typography';
 
 const Paragraph = styled.p`
   color: ${C_STORM};

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.0   | [PR#154](https://github.com/BBC-News/psammead/pull/154) Create initial package with SitewideLinks component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with[@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
 | 0.1.0   | [PR#154](https://github.com/BBC-News/psammead/pull/154) Create initial package with SitewideLinks component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -22,19 +22,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bbc/gel-constants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-constants/-/gel-constants-0.1.1.tgz",
-      "integrity": "sha512-12arxbBpW+uIFxebVyvmVHw8KdQQ53X9ZZLXOfp2n5iRBdYr87cg5NrEQLCW6URfy7b2DLet8oPFF6zCoT6ilw=="
-    },
-    "@bbc/gel-foundations-styled-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations-styled-components/-/gel-foundations-styled-components-0.1.0.tgz",
-      "integrity": "sha512-n0DNLA1ogJ+sQWtyFjcJDDgpbb90iA1P4At7cF32/Ck1jyom0Uelx5WYJ5Pa20+K7xDcmpV38tHWRIR+8CXTIw==",
-      "requires": {
-        "@bbc/gel-constants": "^0.1.1",
-        "styled-components": "^4.1.1"
-      }
+    "@bbc/gel-foundations": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.2.tgz",
+      "integrity": "sha512-OXIxdYBeJ0dt0iMyGxhCmqiywpo5gg/nubaI+5ANMIVchqF68oCY72KU7DYKvTkBOfWxTDnsDApn60c28d07Dw=="
     },
     "@bbc/psammead-styles": {
       "version": "0.1.3",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -23,8 +23,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-constants": "^0.1.1",
-    "@bbc/gel-foundations-styled-components": "^0.1.0",
+    "@bbc/gel-foundations": "^0.1.2",
     "@bbc/psammead-styles": "^0.1.3",
     "nanoid": "^2.0.0",
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-sitewide-links/src/Link/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/Link/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { string, bool } from 'prop-types';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
-import { GEL_SPACING } from '@bbc/gel-constants/spacings';
+import { GEL_SPACING } from '@bbc/gel-foundations/spacings';
 
 const StyledLink = styled.a`
   padding: ${GEL_SPACING} 0 ${GEL_SPACING};

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { string, arrayOf, shape } from 'prop-types';
 import nanoid from 'nanoid';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
-import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-constants/spacings';
+import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MAX,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
@@ -11,7 +11,7 @@ import {
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
   GEL_GROUP_4_SCREEN_WIDTH_MAX,
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
-} from '@bbc/gel-constants/breakpoints';
+} from '@bbc/gel-foundations/breakpoints';
 
 import Link from '../Link';
 

--- a/packages/components/psammead-sitewide-links/src/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/index.jsx
@@ -3,13 +3,13 @@ import styled, { css } from 'styled-components';
 import { arrayOf, shape, string } from 'prop-types';
 import { C_ORBIT_GREY, C_WHITE } from '@bbc/psammead-styles/colours';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
-import { GEL_BREVIER } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_BREVIER } from '@bbc/gel-foundations/typography';
 import {
   GEL_SPACING_DBL,
   GEL_MARGIN_BELOW_400PX,
   GEL_MARGIN_ABOVE_400PX,
-} from '@bbc/gel-constants/spacings';
-import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-constants/breakpoints';
+} from '@bbc/gel-foundations/spacings';
+import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import Link from './Link';
 import List from './List';
 

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -4,8 +4,7 @@
 In addition to components, Psammead contains a selection of utility packages. These include dependencies common to many Psammead components or users, as well as more generic packages to aid the building of other BBC components in a GEL-compliant way.
 
 ### Overview
-* [gel-constants](./gel-constants) - A range of String constants for use in CSS, intended to help ensure GEL-compliance in components and other web-based projects in a consistent way.
-* [gel-foundations-styled-components](./gel-foundations-styled-components) - A range of styled-components, implementing GEL guidelines.
+* [gel-foundations](./gel-foundations) - A range of styled-components and String constants for use in CSS, intended to help ensure GEL-compliance in components and other web-based projects in a consistent way.
 * [psammead-assets](./psammead-assets) - A collection of common assets that are likely to be required by many Psammead components or users.
 * [psammead-styles](./psammead-styles) - A collection of String constants for use in CSS, containing non-GEL styling details.
 * [psammead-test-helpers](./psammead-test-helpers) - A collection of helper methods for implementing Jest snapshot tests for styled-components, required by many Psammead components.

--- a/packages/utilities/gel-foundations/README.md
+++ b/packages/utilities/gel-foundations/README.md
@@ -17,7 +17,7 @@ import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 
 import { GEL_GUTTER_BELOW_600PX } from '@bbc/gel-foundations/spacings';
 
-import { GEL_BREVIER } from '@bbc/gel-foundations-styled-components/typography';
+import { GEL_BREVIER } from '@bbc/gel-foundations/typography';
 ```
 
 To allow the typography to be fully accessible and responsive, please note that you should apply a default font-size to the document root (e.g. `html { font-size: 100% }`).


### PR DESCRIPTION
Resolves https://github.com/BBC-News/psammead/issues/226

Replaces references to `@bbc/gel-constants` and `@bbc/gel-foundations-styled-component` with `@bbc/gel-foundations`. Update affected READMEs, CHANGELOGs and package.json files.

- [x] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features - existing tests pass.
- [ ] Test engineer approval

Dev insight re: testing
As the functionality of `@bbc/gel-constants` and `@bbc/gel-foundations-styled-component` now are a part of `@bbc/gel-foundations`, this ticket should require regression testing.
