### PR TITLE
Add README decorator to Image & ImagePlaceholder stories

### DIFF
--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.2 | [PR#230](https://github.com/BBC-News/psammead/pull/230) Add README to Storybook |
 | 0.1.1   | [PR#228](https://github.com/BBC-News/psammead/pull/228) Ensure package-lock is https. |
 | 0.1.0   | [PR#213](https://github.com/BBC-News/psammead/pull/213) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "description": "Provides a 'BBC' image placeholder",
   "repository": {

--- a/packages/components/psammead-image-placeholder/src/index.stories.jsx
+++ b/packages/components/psammead-image-placeholder/src/index.stories.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import ImagePlaceholder from '.';
 
 const landscapeImageRatio = 56.25;
@@ -7,6 +9,7 @@ const squareImageRatio = 100;
 const portraitImageRatio = 177.78;
 
 storiesOf('ImagePlaceholder', module)
+  .addDecorator(withReadme(Readme))
   .add('16x9 image placeholder', () => (
     <ImagePlaceholder ratio={landscapeImageRatio} />
   ))

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.1 | [PR#230](https://github.com/BBC-News/psammead/pull/230) Add README to Storybook |
 | 0.1.0 | [PR#225](https://github.com/BBC-News/psammead/pull/225) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -82,12 +82,12 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "css": {

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -82,12 +82,12 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "css": {

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "description": "React styled components for an Image",
   "repository": {

--- a/packages/components/psammead-image/src/index.stories.jsx
+++ b/packages/components/psammead-image/src/index.stories.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import Readme from '../README.md';
 import Image from './index';
 
 const imageAlt =
@@ -9,11 +11,13 @@ const imageSrc =
 const imageWidth = 853;
 const imageHeight = 1067;
 
-storiesOf('Image', module).add('default', () => (
-  <Image
-    alt={imageAlt}
-    src={imageSrc}
-    width={imageWidth}
-    height={imageHeight}
-  />
-));
+storiesOf('Image', module)
+  .addDecorator(withReadme(Readme))
+  .add('default', () => (
+    <Image
+      alt={imageAlt}
+      src={imageSrc}
+      width={imageWidth}
+      height={imageHeight}
+    />
+  ));


### PR DESCRIPTION
Resolves #N/A

The ImagePlaceholder story doesn't display the README, which is noticeably inconsistent with all other stories. This PR fixes that.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~Tests added for new features~
- [ ] Test engineer approval
