### PR TITLE
Image stretching fix

### DIFF
--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.2.0 | [PR#](https://github.com/BBC-News/psammead/pull/) Change height prop to be optional. Update the storybook example. |
+| 0.2.0 | [PR#234](https://github.com/BBC-News/psammead/pull/234) Change height prop to be optional. Update the storybook example. |
 | 0.1.0 | [PR#225](https://github.com/BBC-News/psammead/pull/225) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.2.0 | [PR#](https://github.com/BBC-News/psammead/pull/) Change height prop to be optional. Update the storybook example. |
 | 0.1.0 | [PR#225](https://github.com/BBC-News/psammead/pull/225) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.2.0 | [PR#](https://github.com/BBC-News/psammead/pull/) Change height prop to be optional. Update the storybook example. |
+ | 0.2.0 | [PR#234](https://github.com/BBC-News/psammead/pull/234) Change height prop to be optional. Update the storybook example. |
 | 0.1.0 | [PR#225](https://github.com/BBC-News/psammead/pull/225) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -82,12 +82,12 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "css": {

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "description": "React styled components for an Image",
   "repository": {

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -8,7 +8,7 @@ const Image = styled.img`
 
 Image.propTypes = {
   alt: string.isRequired,
-  height: oneOfType([string, number]).isRequired,
+  height: oneOfType([string, number]),
   src: string.isRequired,
   width: oneOfType([string, number]).isRequired,
 };

--- a/packages/components/psammead-image/src/index.stories.jsx
+++ b/packages/components/psammead-image/src/index.stories.jsx
@@ -7,13 +7,7 @@ const imageAlt =
 const imageSrc =
   'https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png';
 const imageWidth = 853;
-const imageHeight = 1067;
 
 storiesOf('Image', module).add('default', () => (
-  <Image
-    alt={imageAlt}
-    src={imageSrc}
-    width={imageWidth}
-    height={imageHeight}
-  />
+  <Image alt={imageAlt} src={imageSrc} width={imageWidth} />
 ));


### PR DESCRIPTION
Resolves #232

Fixes the stretching issue by making the height prop optional.

Screenshot of the image scaling correctly with smaller breakpoints:
http://localhost:8080?selectedKind=Image
<img width="695" alt="screen shot storybook image" src="https://user-images.githubusercontent.com/3028997/50221294-93b61800-038c-11e9-8b47-71b49b116e08.png">

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
