### PR TITLE
Documentation / script process for adding custom tests to Psammead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,17 @@ For example, if your component's main entry-point is `src/foo.jsx`, you should p
 - No JS or CSS lint errors should be present.
 - Your component should be fully accessibility-tested. There's a [test guide for testers](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-testers) and a [checklist for developers](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-developers) as well as guides for [designers](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-designers), [business analysts](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-business-analysts), [product owners](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-product-owners) and [project managers](https://bbc-news.github.io/accessibility-news-and-you/accessibility-news-and-project-managers).
 
+
+***Creating custom tests***
+By default, Psammead's `npm run test` runs unit tests through Jest. However, so long as adequate test coverage exists, it's not mandatory to test a component with Jest.
+
+Custom tests must adhere to the following conventions: 
+* The component's test script must be named `test`. This ensures the test script will be run by Psammead's root level `npm test` command. 
+* The component's testing framework and/or assertion libraries must be installed as devDependencies in the component's `package.json`.
+* Test files cannot be prefixed with ".test", as Psammead's Jest configuration looks for files ending in `.test.jsx` and `.test.js`. 
+
+For a sample usage of custom Mocha/Chai tests with Psammead, please refer to [PR 247](https://github.com/BBC-News/psammead/pull/247).
+
 **Accessibility Swarms**
 
 When you add a component to this repository, you should carry out an Accessibility Swarm, ideally including team members from multiple disciplines and using [the Assistive Technology we support](./README.md#assistive-technology-support).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ For example, if your component's main entry-point is `src/foo.jsx`, you should p
 By default, Psammead's `npm run test` runs unit tests through Jest. However, so long as adequate test coverage exists, it's not mandatory to test a component with Jest.
 
 Custom tests must adhere to the following conventions: 
+
 * The component's test script must be named `test`. This ensures the test script will be run by Psammead's root level `npm test` command. 
 * The component's testing framework and/or assertion libraries must be installed as devDependencies in the component's `package.json`.
 * Test files cannot be prefixed with ".test", as Psammead's Jest configuration looks for files ending in `.test.jsx` and `.test.js`. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Custom tests must adhere to the following conventions:
 * The component's testing framework and/or assertion libraries must be installed as devDependencies in the component's `package.json`.
 * Test files cannot be prefixed with ".test", as Psammead's Jest configuration looks for files ending in `.test.jsx` and `.test.js`. 
 
-For a sample usage of custom Mocha/Chai tests with Psammead, please refer to [PR 247](https://github.com/BBC-News/psammead/pull/247).
+For a sample usage of custom Mocha/Chai tests with Psammead, please refer to [#247](https://github.com/BBC-News/psammead/pull/247).
 
 **Accessibility Swarms**
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
       "!**/.eslintrc.js",
       "!**/dist/**"
     ],
-    "testMatch": "**/*.test.{js,jsx}"
+    "testMatch": ["**/*.test.{js,jsx}"]
   },
   "spec": {
     "prune": false,

--- a/package.json
+++ b/package.json
@@ -95,10 +95,7 @@
       "!**/.eslintrc.js",
       "!**/dist/**"
     ],
-    "testMatch": [
-      "**/__tests__/**/*.js?(x)",
-      "**/*.test.{js,jsx}"
-    ]
+    "testMatch": "**/*.test.{js,jsx}"
   },
   "spec": {
     "prune": false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "npm run build",
     "publish": "node scripts/publish",
     "storybook": "npm run clear_styled_components && NODE_ENV=development start-storybook -p 8080 -c .storybook",
-    "test": "npm run test:lint && npm run test:lint:css && npm run test:unit",
+    "test": "npm run test:lint && npm run test:lint:css && npm run test:unit && npm run test:packages",
+    "test:packages": "lerna run test",
     "test:lint": "eslint --ext .js,jsx,json ./packages ./scripts",
     "test:lint:css": "stylelint 'packages/**/*.js' 'packages/**/*.jsx' 'scripts/**/*.js'",
     "test:unit": "jest --verbose --coverage"


### PR DESCRIPTION
Resolves https://github.com/BBC-News/psammead/issues/193

1. Adds "Creating custom tests" documentation to `CONTRIBUTING.md`
2. Adds a`test:packages`script to the root level `package.json`, which which will look for a script of name 'test' in each package and will run it (see [lerna run](https://github.com/lerna/lerna/tree/master/commands/run#readme) docs). This script is wired into Psammead's `test` script. `test:packages` will run even if it finds no package test scripts. 
3. Removes the unneeded search for a `__tests__/`directory from Jest config

See proof of concept PR https://github.com/BBC-News/psammead/pull/247 for an example of how to add Mocha/Chai tests.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval

** Dev insight re: testing: ** 
1.  Verify that the "Creating custom tests" section in `CONTRIBUTING.md` is clear. 
2. Checkout the branch and do the following steps: 

- `npm install --g lerna` if lerna is not installed
- In one of psammead's components, add a test script that does: `"test": "echo \"test has run!\""`
- `npm test`
- You should see "test has run!" echoed to the console
