### PR TITLE
Bump psammead-test-helpers version

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.2   | [PR#255](https://github.com/BBC-News/psammead/pull/255) Bumps package version to fix what appears to be an erroneously-published version. |
 | 0.1.2   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
 | 0.1.1   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.0   | [PR#80](https://github.com/BBC-News/psammead/pull/80) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.2   | [PR#255](https://github.com/BBC-News/psammead/pull/255) Bumps package version to fix what appears to be an erroneously-published version. |
+| 0.2.1   | [PR#255](https://github.com/BBC-News/psammead/pull/255) Bumps package version to fix what appears to be an erroneously-published version. |
 | 0.1.2   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
 | 0.1.1   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
 | 0.1.0   | [PR#80](https://github.com/BBC-News/psammead/pull/80) Create initial package, pulled in from [simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "description": "A collection of helper methods for implementing Jest snapshot tests for styled-components, required by many Psammead components.",
   "repository": {


### PR DESCRIPTION
Resolves #N/A

![screenshot 2019-01-03 at 15 30 43](https://user-images.githubusercontent.com/11646957/50646424-e804ee80-0f6d-11e9-9296-0f2c6024abe8.png)

In viewing the `psammead-test-helpers` package on NPM, I noticed the latest version has a different version to what is defined in the `package.json` (see above), & the history doesn't even include the current value in the `package.json`. 🤯 It looks like it was manually published in error from a branch. This PR bumps the version higher than that on NPM.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval