### PR TITLE
Fix link

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,7 +11,7 @@ import Helmet from 'react-helmet';
 
 setOptions({
   name: 'BBC Psammead',
-  url: 'https:github.com/BBC/psammead',
+  url: 'https://github.com/bbc/psammead',
   addonPanelInRight: true,
   sidebarAnimations: true,
   sortStoriesByKind: true,


### PR DESCRIPTION
Resolves #287

Fixes link. 

Testing notes:
- run storybook locally `npm run install:packages && npm run storybook`
- in the top left corner there should be a link to 'BBC Psammead'. This link should work and not error. 

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~Tests added for new features~ N/A
- [ ] Test engineer approval
