### PR TITLE
Psammead Styles - Add colours for consent banner

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.2.1   |  [PR#300](https://github.com/BBC-News/psammead/pull/300) Adds colours for Consent Banner |
 | 0.2.0   |  [PR#283](https://github.com/BBC-News/psammead/pull/283) Adds colours and fonts necessary for Simorgh V1.0 :art: |
 | 0.1.6   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada: |
 | 0.1.5   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |

--- a/packages/utilities/psammead-styles/index.test.jsx
+++ b/packages/utilities/psammead-styles/index.test.jsx
@@ -35,6 +35,9 @@ const coloursExpectedExports = {
   C_CLOUD_LIGHT: 'string',
   C_LUNAR: 'string',
   C_GHOST: 'string',
+  C_CONSENT_BACKGROUND: 'string',
+  C_CONSENT_ACTION: 'string',
+  C_CONSENT_CONTENT: 'string',
 };
 
 const expectedExports = {

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/colours.js
+++ b/packages/utilities/psammead-styles/src/colours.js
@@ -17,4 +17,7 @@ export const C_LUNAR = '#F2F2F2';
 export const C_GHOST = '#FDFDFD';
 
 // Colours from other BBC services
+export const C_CONSENT_BACKGROUND = '#323232';
+export const C_CONSENT_ACTION = '#F6A21D';
+export const C_CONSENT_CONTENT = '#BEBEBE';
 export const C_ORBIT_GREY = '#4C4C4C';


### PR DESCRIPTION
Resolves #299

**Overall change:** Adds three colours to Psammead Styles. These will be needed for the consent banner work. 

**Code changes:**

- Adds styles & updates unit test. Naming of variables was discussed in the issue #299 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval