### PR TITLE
Update Headline & Subheading colour to Shadow

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -43,6 +43,13 @@ const GlobalStyle = createGlobalStyle`
     font-weight: 600;
     src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff') format('woff');
   }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSerifNewsBold;
+    font-style: normal;
+    font-weight: 700;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff') format('woff');
+  }
 `;
 
 addDecorator(story => (

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -45,10 +45,10 @@ const GlobalStyle = createGlobalStyle`
   }
   @font-face {
     font-display: optional;
-    font-family: ReithSerifNewsBold;
+    font-family: ReithSansNewsBold;
     font-style: normal;
     font-weight: 700;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff') format('woff');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff') format('woff');
   }
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,6 +993,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bbc/gel-foundations": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.4.tgz",
+      "integrity": "sha512-ZkVK23thUiHrvh/aiGp1U3ncn7Yu9i1QtcWrzUAGseTptX0g1XBm5w0tIPwj7MCq7fvq9EOLYLiv1J+ElHrmWA=="
+    },
     "@bbc/psammead-assets": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-0.1.3.tgz",

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.2.0   | [PR#305](https://github.com/BBC/psammead/pull/305) Updating colour of headline and subheading to Shadow. |
 | 0.1.7   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
 | 0.1.6   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
 | 0.1.5   | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.2.0   | [PR#305](https://github.com/BBC/psammead/pull/305) Updating colour of headline and subheading to Shadow. |
+| 0.2.0   | [PR#305](https://github.com/BBC/psammead/pull/305) Updating colour of headline and subheading to Shadow. Update Subheadings to use Reith Sans Bold. |
 | 0.1.7   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
 | 0.1.6   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
 | 0.1.5   | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,10 +31,14 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.3.tgz",
+      "integrity": "sha512-oeL+q31IVskqIXh/s7F2DAQTeG5yZtc9wDOnsOLZEJWGTcLqA5KQcLix8tz9j9RDZPZ8Ptw6qEa7Jh+wdG43MQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "0.1.5"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.2.1.tgz",
+      "integrity": "sha512-FYKtW0MrCBJqbcQ7lRJ3jJPL0O9u/D8WSAcb6GTw4gMuQ011FxA1aThwLJa4LjgIBDVj4pfAbDR0CC9XmzsuXA=="
     },
     "@bbc/psammead-test-helpers": {
       "version": "0.3.1",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^0.1.2",
-    "@bbc/psammead-styles": "^0.1.3",
+    "@bbc/psammead-styles": "^0.2.1",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`Headline component should render correctly 1`] = `
 exports[`SubHeading component attribute id should render without double quotes 1`] = `
 .c0 {
   color: #3F3F42;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  font-family: ReithSansNewsBold,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 400;
@@ -68,7 +68,7 @@ exports[`SubHeading component attribute id should render without double quotes 1
 exports[`SubHeading component attribute id should render without exclamation marks 1`] = `
 .c0 {
   color: #3F3F42;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  font-family: ReithSansNewsBold,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 400;
@@ -102,7 +102,7 @@ exports[`SubHeading component attribute id should render without exclamation mar
 exports[`SubHeading component attribute id should render without quotes 1`] = `
 .c0 {
   color: #3F3F42;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  font-family: ReithSansNewsBold,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 400;
@@ -136,7 +136,7 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
 exports[`SubHeading component should render correctly 1`] = `
 .c0 {
   color: #3F3F42;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  font-family: ReithSansNewsBold,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 400;

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Headline component should render correctly 1`] = `
 .c0 {
-  color: #222222;
+  color: #3F3F42;
   font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 2rem 0 1rem 0;
@@ -33,7 +33,7 @@ exports[`Headline component should render correctly 1`] = `
 
 exports[`SubHeading component attribute id should render without double quotes 1`] = `
 .c0 {
-  color: #404040;
+  color: #3F3F42;
   font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
@@ -67,7 +67,7 @@ exports[`SubHeading component attribute id should render without double quotes 1
 
 exports[`SubHeading component attribute id should render without exclamation marks 1`] = `
 .c0 {
-  color: #404040;
+  color: #3F3F42;
   font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
@@ -101,7 +101,7 @@ exports[`SubHeading component attribute id should render without exclamation mar
 
 exports[`SubHeading component attribute id should render without quotes 1`] = `
 .c0 {
-  color: #404040;
+  color: #3F3F42;
   font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
@@ -135,7 +135,7 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
 
 exports[`SubHeading component should render correctly 1`] = `
 .c0 {
-  color: #404040;
+  color: #3F3F42;
   font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
   FF_NEWS_SERIF_MDM,
-  FF_NEWS_SANS_REG,
+  FF_NEWS_SANS_BLD,
 } from '@bbc/psammead-styles/fonts';
 import {
   GEL_SPACING_DBL,
@@ -26,7 +26,7 @@ export const SubHeading = styled.h2.attrs(({ text }) => ({
   tabIndex: '-1',
 }))`
   color: ${C_SHADOW};
-  font-family: ${FF_NEWS_SANS_REG};
+  font-family: ${FF_NEWS_SANS_BLD};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_DBL} 0;
   font-weight: 400;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { C_EBON, C_STORM } from '@bbc/psammead-styles/colours';
+import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
   FF_NEWS_SERIF_MDM,
   FF_NEWS_SANS_REG,
@@ -11,7 +11,7 @@ import {
 import { GEL_CANON, GEL_TRAFALGAR } from '@bbc/gel-foundations/typography';
 
 export const Headline = styled.h1`
-  color: ${C_EBON};
+  color: ${C_SHADOW};
   font-family: ${FF_NEWS_SERIF_MDM};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_DBL} 0;
@@ -25,7 +25,7 @@ export const SubHeading = styled.h2.attrs(({ text }) => ({
   id: text.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-'),
   tabIndex: '-1',
 }))`
-  color: ${C_STORM};
+  color: ${C_SHADOW};
   font-family: ${FF_NEWS_SANS_REG};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_DBL} 0;


### PR DESCRIPTION
Resolves #279

**Overall change:** Update Headline & Subheading colour to Shadow `'#3F3F42'` & Subheading updated to use Reith Sans Bold font.

Screenshots of Storybook for Headline, with dev tools showing color is Shadow & font is unchanged:
<img width="633" alt="screen shot of heading" src="https://user-images.githubusercontent.com/3028997/53327303-7008d400-38df-11e9-9e18-a18058a615cb.png">

Subheading component shows color is Shadow and font updated to Reith Sans Bold:
<img width="764" alt="screen shot of subheading" src="https://user-images.githubusercontent.com/3028997/53330144-ab0e0600-38e5-11e9-9a35-62fead502e3b.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval