### PR TITLE
Update InlineLink styling

### DIFF
--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.0   |  |
+| 0.3.0   | [PR#309](https://github.com/bbc/psammead/pull/309) Update colours to reflect new UX designs. |
 | 0.2.0   | [PR#248](https://github.com/BBC-News/psammead/pull/248) Remove top and buttom padding |
 | 0.1.3   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
 | 0.1.2   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.0   |  |
 | 0.2.0   | [PR#248](https://github.com/BBC-News/psammead/pull/248) Remove top and buttom padding |
 | 0.1.3   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
 | 0.1.2   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |

--- a/packages/components/psammead-inline-link/README.md
+++ b/packages/components/psammead-inline-link/README.md
@@ -81,10 +81,6 @@ Since this is just a `<a>` tag with associated styles, when you use this compone
 
 The font and background-color choices for each hover/focused/visited/default states meet WCAG AA colour contrast guidelines.
 
-## Roadmap
-
-Our UX team are considering updating the colours for the hover and focus states of this component. When we implement this change, we will ensure it is a major version increase, since for downstream teams this will be a breaking change.
-
 ## Contributing
 
 Psammead is completely open source. We are grateful for any contributions, whether they be new components, bug fixes or general improvements. Please see our primary contributing guide which can be found at [the root of the Psammead respository](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md).

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,7 +31,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "0.1.5"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.2.1.tgz",
+      "integrity": "sha512-FYKtW0MrCBJqbcQ7lRJ3jJPL0O9u/D8WSAcb6GTw4gMuQ011FxA1aThwLJa4LjgIBDVj4pfAbDR0CC9XmzsuXA=="
     },
     "@bbc/psammead-test-helpers": {
       "version": "0.3.1",

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "^0.1.3",
+    "@bbc/psammead-styles": "^0.2.1",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`InlineLink should render correctly 1`] = `
 .c0 {
   color: #3F3F42;
-  padding: 0 2px;
   border-bottom: 1px solid #B80000;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
@@ -2,28 +2,26 @@
 
 exports[`InlineLink should render correctly 1`] = `
 .c0 {
-  color: #0F556C;
+  color: #3F3F42;
   padding: 0 2px;
-  border-bottom: 1px solid #0F556C;
+  border-bottom: 1px solid #B80000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c0:visited {
-  color: #5C5752;
-  border-bottom: 1px solid #5C5752;
+  color: #757575;
+  border-bottom: 1px solid #757575;
 }
 
 .c0:focus {
-  background-color: #0F556C;
-  border-bottom: 1px solid #F5F3F1;
-  color: #F5F3F1;
+  color: #B80000;
+  border-bottom: 2px solid #B80000;
 }
 
 .c0:hover {
-  color: #0F556C;
-  background-color: #C3DEE7;
-  border-bottom: 1px solid #0F556C;
+  color: #B80000;
+  border-bottom: 2px solid #B80000;
 }
 
 <a

--- a/packages/components/psammead-inline-link/src/index.jsx
+++ b/packages/components/psammead-inline-link/src/index.jsx
@@ -7,7 +7,6 @@ import {
 
 const InlineLink = styled.a`
   color: ${C_SHADOW};
-  padding: 0 2px;
   border-bottom: 1px solid ${C_POSTBOX};
   text-decoration: none;
 

--- a/packages/components/psammead-inline-link/src/index.jsx
+++ b/packages/components/psammead-inline-link/src/index.jsx
@@ -1,29 +1,29 @@
 import styled from 'styled-components';
 import {
-  C_BLUEJAY,
-  C_BLUEJAY_LHT,
-  C_OAT_LHT,
-  C_PEBBLE,
+  C_SHADOW,
+  C_POSTBOX,
+  C_CLOUD_DARK,
 } from '@bbc/psammead-styles/colours';
 
 const InlineLink = styled.a`
-  color: ${C_BLUEJAY};
+  color: ${C_SHADOW};
   padding: 0 2px;
-  border-bottom: 1px solid ${C_BLUEJAY};
+  border-bottom: 1px solid ${C_POSTBOX};
   text-decoration: none;
+
   &:visited {
-    color: ${C_PEBBLE};
-    border-bottom: 1px solid ${C_PEBBLE};
+    color: ${C_CLOUD_DARK};
+    border-bottom: 1px solid ${C_CLOUD_DARK};
   }
+
   &:focus {
-    background-color: ${C_BLUEJAY};
-    border-bottom: 1px solid ${C_OAT_LHT};
-    color: ${C_OAT_LHT};
+    color: ${C_POSTBOX};
+    border-bottom: 2px solid ${C_POSTBOX};
   }
+
   &:hover {
-    color: ${C_BLUEJAY};
-    background-color: ${C_BLUEJAY_LHT};
-    border-bottom: 1px solid ${C_BLUEJAY};
+    color: ${C_POSTBOX};
+    border-bottom: 2px solid ${C_POSTBOX};
   }
 `;
 


### PR DESCRIPTION
Resolves #286 

**Overall change:** Changes the InlineLink appearance to match the updated Simorgh designs.

(Screenshots npm linked into psammead-caption to help display it better)

Default
![screenshot 2019-02-26 at 09 07 26](https://user-images.githubusercontent.com/11646957/53401903-a2cacf00-39a8-11e9-9fab-2a0d49de14ec.png)

Hover/Focus
![screenshot 2019-02-26 at 09 07 37](https://user-images.githubusercontent.com/11646957/53401973-c1c96100-39a8-11e9-9e14-9161b0b9bd4d.png)

Visited
![screenshot 2019-02-26 at 09 07 46](https://user-images.githubusercontent.com/11646957/53402006-d0b01380-39a8-11e9-8edb-48e4627ba044.png)

**Code changes:**

- Updates InlineLink colours, bumping psammead-styles dependency.
- I removed the padding from the component, as I believe this was part of the previous design, with the background?
- Currently doesn't alter underline implementation -- I think we wanted to avoid using `border-bottom` due to issues with Reith overlapping, but UX have specified specific pixel stylings depending on hover/visited state. 🤔 This overlapping seemed to still occur slightly when I experimented with `box-shadow` as an alternative implementation.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests ~added~ updated for new features
- [ ] Test engineer approval