### PR TITLE
Fixed broken npm command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ N.B. When merging branches, the `npm run install:packages` command should be fav
 Run the following command to link all psammead packages up regardless of dependancy version:
 
 ```
-npm install:packages:link
+npm run install:packages:link
 ```
 
 ### :runner: Run tests


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _There was a missing word in a command._

**Code changes:**

- _Updated README to read `npm run install:packages:link`_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval