### PR TITLE
RTL testing

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.0   | [PR#335](https://github.com/BBC/psammead/pull/335) Add `direction` CSS property for RTL scripts |
 | 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
 | 0.1.5   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`should render Caption with some offscreen text 1`] = `
   line-height: 1.125rem;
   background-color: #D5D0CD;
   color: #404040;
+  direction: ltr;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding: 0.5rem;
   width: 100%;

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -11,6 +11,7 @@ const Caption = styled.figcaption`
   ${GEL_LONG_PRIMER};
   background-color: ${C_STONE};
   color: ${C_STORM};
+  direction: ${props => props.textDirection || 'ltr'};
   font-family: ${GEL_FF_REITH_SANS};
   padding: ${GEL_SPACING};
   width: 100%;

--- a/packages/components/psammead-caption/src/index.stories.jsx
+++ b/packages/components/psammead-caption/src/index.stories.jsx
@@ -23,4 +23,10 @@ storiesOf('Caption', module)
       </InlineLink>
       .
     </Caption>
+  ))
+  .add('with right-to-left text', () => (
+    <Caption textDirection="rtl">
+      چارلز وسلر،‌ تهیه کننده فیلم کتاب سبز در کنار پیتر فرلی و سایر عوامل فیلم
+      در حال دریافت جایزه اسکار بهترین فیلم
+    </Caption>
   ));


### PR DESCRIPTION
Resolves #328

**Overall change:**
We (the WS team) need to make sure that the current components will work with RTL left scripts. This is the beginning of such work.

**Code changes:**

- Added the `direction` CSS property to the component. The value of "RTL" can be passed via a prop, or if not, it will default to "LTR".
- A new story was added to reflect this change and to show an example of a RTL script. The caption was taken from an existing article on BBC Persian.
- Updated snapshots accordingly

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval