### PR TITLE
Add GEL Group A breakpoint

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Gel Foundations Changelog
 
-| Version | Description |
-|---------|-------------|
-| 0.2.4   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.2.3   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
-| 0.2.2   | [PR#304](https://github.com/BBC-News/psammead/pull/304) Add font family definitions, which include GEL-defined font fallbacks. |
-| 0.2.1   | [PR#303](https://github.com/BBC-News/psammead/pull/303) Bump to ensure correct build is published |
-| 0.2.0   | [PR#290](https://github.com/BBC-News/psammead/pull/290) Move typography font-sizes to use rem instead of em |
-| 0.1.4   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada: |
-| 0.1.1   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
+| Version | Description                                                                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 0.2.5   | [PR#349](https://github.com/BBC/psammead/pull/349) Add GEL Group A breakpoint                                                                                |
+| 0.2.4   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge                                                                             |
+| 0.2.3   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues.                                                                            |
+| 0.2.2   | [PR#304](https://github.com/BBC-News/psammead/pull/304) Add font family definitions, which include GEL-defined font fallbacks.                               |
+| 0.2.1   | [PR#303](https://github.com/BBC-News/psammead/pull/303) Bump to ensure correct build is published                                                            |
+| 0.2.0   | [PR#290](https://github.com/BBC-News/psammead/pull/290) Move typography font-sizes to use rem instead of em                                                  |
+| 0.1.4   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada:                                              |
+| 0.1.1   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README.                                                               |
 | 0.1.0   | [PR#221](https://github.com/BBC-News/psammead/pull/221) Create initial package, pulled in from gel-constants and gel-foundations-styled-components packages. |
-

--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Gel Foundations Changelog
 
-| Version | Description                                                                                                                                                  |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 0.2.5   | [PR#349](https://github.com/BBC/psammead/pull/349) Add GEL Group A breakpoint                                                                                |
-| 0.2.4   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge                                                                             |
-| 0.2.3   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues.                                                                            |
-| 0.2.2   | [PR#304](https://github.com/BBC-News/psammead/pull/304) Add font family definitions, which include GEL-defined font fallbacks.                               |
-| 0.2.1   | [PR#303](https://github.com/BBC-News/psammead/pull/303) Bump to ensure correct build is published                                                            |
-| 0.2.0   | [PR#290](https://github.com/BBC-News/psammead/pull/290) Move typography font-sizes to use rem instead of em                                                  |
-| 0.1.4   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada:                                              |
-| 0.1.1   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README.                                                               |
+| Version | Description |
+|---------|-------------|
+| 0.2.5   | [PR#349](https://github.com/BBC/psammead/pull/349) Add GEL Group A breakpoint |
+| 0.2.4   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
+| 0.2.3   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
+| 0.2.2   | [PR#304](https://github.com/BBC-News/psammead/pull/304) Add font family definitions, which include GEL-defined font fallbacks. |
+| 0.2.1   | [PR#303](https://github.com/BBC-News/psammead/pull/303) Bump to ensure correct build is published |
+| 0.2.0   | [PR#290](https://github.com/BBC-News/psammead/pull/290) Move typography font-sizes to use rem instead of em |
+| 0.1.4   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada: |
+| 0.1.1   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
 | 0.1.0   | [PR#221](https://github.com/BBC-News/psammead/pull/221) Create initial package, pulled in from gel-constants and gel-foundations-styled-components packages. |
+

--- a/packages/utilities/gel-foundations/index.test.jsx
+++ b/packages/utilities/gel-foundations/index.test.jsx
@@ -19,6 +19,7 @@ const spacingsExpectedExports = {
 };
 
 const breakpointsExpectedExports = {
+  GEL_GROUP_A_MAX_WIDTH: 'number',
   GEL_GROUP_B_MIN_WIDTH: 'number',
   GEL_GROUP_B_MAX_WIDTH: 'number',
   GEL_GROUP_CD_MIN_WIDTH: 'number',

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {
     "type": "git",

--- a/packages/utilities/gel-foundations/src/breakpoints.js
+++ b/packages/utilities/gel-foundations/src/breakpoints.js
@@ -1,6 +1,6 @@
 /* 
    Screen sizes for GEL Typography
-   These namings are based on the GEL description. They are also known as group B and group D
+   These namings are based on the GEL description. They are also known as group A, group B and group D
    Link to relevant GEL docs: http://www.bbc.co.uk/gel/guidelines/typography#type-sizes
 */
 export const GEL_GROUP_A_MAX_WIDTH = 19.9375; // 319px

--- a/packages/utilities/gel-foundations/src/breakpoints.js
+++ b/packages/utilities/gel-foundations/src/breakpoints.js
@@ -3,6 +3,7 @@
    These namings are based on the GEL description. They are also known as group B and group D
    Link to relevant GEL docs: http://www.bbc.co.uk/gel/guidelines/typography#type-sizes
 */
+export const GEL_GROUP_A_MAX_WIDTH = 19.9375; // 319px
 export const GEL_GROUP_B_MIN_WIDTH = 20; // 320px
 export const GEL_GROUP_B_MAX_WIDTH = 37.4375; // 599px
 export const GEL_GROUP_CD_MIN_WIDTH = 37.5; // 600px
@@ -30,6 +31,7 @@ export const GEL_GROUP_4_SCREEN_WIDTH_MAX = `80em`; // 1279px
 export const GEL_GROUP_5_SCREEN_WIDTH_MIN = `80em`; // 1280px
 
 export const MEDIA_QUERY_TYPOGRAPHY = {
+  FEATURE_PHONE_ONLY: `@media (max-width: ${GEL_GROUP_A_MAX_WIDTH}em)`,
   SMART_PHONE_ONLY: `@media (min-width: ${GEL_GROUP_B_MIN_WIDTH}em) and (max-width: ${GEL_GROUP_B_MAX_WIDTH}em)`,
   SMART_PHONE_AND_LARGER: `@media (min-width: ${GEL_GROUP_B_MIN_WIDTH}em)`,
   LAPTOP_AND_LARGER: `@media (min-width: ${GEL_GROUP_CD_MIN_WIDTH}em)`,


### PR DESCRIPTION
Resolves #348

**Overall change:** Added breakpoint for missing GEL Group A

**Code changes:**

- Added new `GEL_GROUP_A_MAX_WIDTH` constant
- Added new `FEATURE_PHONE_ONLY` breakpoint for 0 - 319 pixels
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval