### PR TITLE
Caption styles update

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. |
 | 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. |
+| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
 | 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-caption/README.md
+++ b/packages/components/psammead-caption/README.md
@@ -46,7 +46,9 @@ Since this is just a `<figcaption>` tag with associated styles, when you use thi
 
 The font and background-color choices meet WCAG AA colour contrast guidelines.
 
-<!-- ## Roadmap -->
+## Roadmap
+
+When this caption is used for scripts that do not support italic text, we can consider creating a prop that toggles the `font-style: italic`.
 
 ## Contributing
 

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -31,24 +31,24 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-      "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-inline-link": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-0.1.3.tgz",
-      "integrity": "sha512-vB4rz8wohCh8P4NG0LuG4LKIlIoTQvG/toL6jfL/KPz0HB1qR+tXQh4NdLDkf/ThWHsDHiJUhkLhm/g9t/rR7A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-0.3.3.tgz",
+      "integrity": "sha512-VLEdAFOD51WjVL6lKa4BOXevv9VtJLU+uIaWFWG4oO6zDA1VWd45gTar3cS+CL7pOw90JwTCp4z6JllM6I1kJg==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-styles": "^0.1.3",
+        "@bbc/psammead-styles": "^0.2.1",
         "styled-components": "^4.1.2"
       },
       "dependencies": {
         "@bbc/psammead-styles": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.1.6.tgz",
-          "integrity": "sha512-yZ6VstjEB35GdZ0JktArGY4YnuXRmlZaZbvBb4bWoBU7/SuhB8X72rBy1exI2DFPyBYwc2Q4bqAQGoeM3GnAIQ==",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.2.1.tgz",
+          "integrity": "sha512-FYKtW0MrCBJqbcQ7lRJ3jJPL0O9u/D8WSAcb6GTw4gMuQ011FxA1aThwLJa4LjgIBDVj4pfAbDR0CC9XmzsuXA==",
           "dev": true
         }
       }
@@ -69,9 +69,9 @@
       }
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.9.tgz",
-      "integrity": "sha512-9UVr1I4Db1KfaKXT7sd8ajL04UfPDCnA2lPQleYB1Uu27re+woiuj4AYtYplJdPjRNWdRaHKqB7CGcNXYwJOlA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.10.tgz",
+      "integrity": "sha512-QZ+/UWYjKeFus75L8p2/p8E876t9Vm57Gj2m0aqCrfNlCZm0K2UNmB4LDtRDyKXmtGLVAK+P9h2vK1oJvZh5mg==",
       "dev": true,
       "requires": {
         "styled-components": "^4.1.2"

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -17,14 +17,14 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.2",
-    "@bbc/psammead-styles": "^0.3.0",
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
     "@bbc/psammead-test-helpers": "^0.3.0",
-    "@bbc/psammead-inline-link": "^0.1.0",
-    "@bbc/psammead-visually-hidden-text": "^0.1.3",
+    "@bbc/psammead-inline-link": "^0.3.3",
+    "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "react": "^16.6.3"
   },
   "keywords": [

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`should render Caption with some offscreen text 1`] = `
   line-height: 1.125rem;
   color: #757575;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-style: italic;
   padding: 0.5rem;
   width: 100%;
 }

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -15,8 +15,7 @@ exports[`should render Caption with some offscreen text 1`] = `
 .c0 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
-  background-color: #D5D0CD;
-  color: #404040;
+  color: #757575;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding: 0.5rem;
   width: 100%;

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
 import {
@@ -8,10 +8,17 @@ import {
 
 import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
 
+// Defined separately since in future will need to apply
+// only when the script supports italic text
+const FS_ITALIC = css`
+  font-style: italic;
+`;
+
 const Caption = styled.figcaption`
   ${GEL_LONG_PRIMER};
   color: ${C_CLOUD_DARK};
   font-family: ${GEL_FF_REITH_SANS};
+  ${FS_ITALIC};
   padding: ${GEL_SPACING};
   width: 100%;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -5,12 +5,12 @@ import {
   GEL_LONG_PRIMER,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
-import { C_STONE, C_STORM } from '@bbc/psammead-styles/colours';
+
+import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
 
 const Caption = styled.figcaption`
   ${GEL_LONG_PRIMER};
-  background-color: ${C_STONE};
-  color: ${C_STORM};
+  color: ${C_CLOUD_DARK};
   font-family: ${GEL_FF_REITH_SANS};
   padding: ${GEL_SPACING};
   width: 100%;


### PR DESCRIPTION
Part of #270

**Overall change:** Removes background colour & updates text colour to be Cloud Dark. Text has font-style italic. 

**Code changes:**

- Updates dependencies to use latest Psammead packages
- Changes text colour and removes background colour
- Text font-style italic

Caption:
<img width="686" alt="Screen Shot caption in storybook" src="https://user-images.githubusercontent.com/3028997/54543278-43535400-4995-11e9-970d-ef71cefec635.png">

Caption with link:
<img width="764" alt="Screen Shot caption with link in storybook" src="https://user-images.githubusercontent.com/3028997/54543275-43535400-4995-11e9-9677-0ae72ee08abe.png">




---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval