### PR TITLE
Boosts Headline padding to 40px (32px on mobile)

### DIFF
--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Psammead Headings Changelog
 
+<!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 44px for 600px and above |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.2   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 44px for 600px and above |
+| 0.3.2   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.2   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
+| 0.4.0   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`Headline component should render correctly 1`] = `
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 2rem 0 2rem 0;
+  padding: 2rem 0;
   font-weight: 500;
   font-size: 1.75rem;
   line-height: 2rem;

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`Headline component should render correctly 1`] = `
   line-height: 2rem;
 }
 
-@media (min-width:20em) {
+@media (min-width:37.5em) {
   .c0 {
     padding: 2.5rem 0 2.5rem 0;
   }

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`Headline component should render correctly 1`] = `
 
 @media (min-width:37.5em) {
   .c0 {
-    padding: 2.5rem 0 2.5rem 0;
+    padding: 2.5rem 0;
   }
 }
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -5,10 +5,16 @@ exports[`Headline component should render correctly 1`] = `
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 2rem 0 1rem 0;
+  padding: 2rem 0 2rem 0;
   font-weight: 500;
   font-size: 1.75rem;
   line-height: 2rem;
+}
+
+@media (min-width:20em) {
+  .c0 {
+    padding: 2.5rem 0 2.5rem 0;
+  }
 }
 
 @media (min-width:20em) and (max-width:37.4375em) {

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -16,7 +16,7 @@ export const Headline = styled.h1`
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
-  padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_QUAD} 0;
+  padding: ${GEL_SPACING_QUAD} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
     padding: 2.5rem 0;
   }

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -17,7 +17,7 @@ export const Headline = styled.h1`
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_QUAD} 0;
-  ${MEDIA_QUERY_TYPOGRAPHY.SMART_PHONE_AND_LARGER} {
+  ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
     padding: 2.5rem 0 2.5rem 0;
   }
   font-weight: 500;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -10,12 +10,16 @@ import {
   GEL_FF_REITH_SANS,
   GEL_FF_REITH_SERIF,
 } from '@bbc/gel-foundations/typography';
+import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
 
 export const Headline = styled.h1`
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
-  padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_DBL} 0;
+  padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_QUAD} 0;
+  ${MEDIA_QUERY_TYPOGRAPHY.SMART_PHONE_AND_LARGER} {
+    padding: 2.5rem 0 2.5rem 0;
+  }
   font-weight: 500;
   ${GEL_CANON};
 `;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -18,7 +18,7 @@ export const Headline = styled.h1`
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_QUAD} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
-    padding: 2.5rem 0 2.5rem 0;
+    padding: 2.5rem 0;
   }
   font-weight: 500;
   ${GEL_CANON};


### PR DESCRIPTION
Resolves #375

**Overall change:** Changes Headline padding according to the designs.

**Code changes:**

- Increases padding to 40px for Smartphone and up. 32px for smaller.
- Updates snapshot tests
- Adds changelog and bumps version number

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval