### PR TITLE
Increase padding bottom figure

### DIFF
--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.9   | [PR#xxx](https://github.com/BBC/psammead/pull/xxx) Increases the padding-bottom from 16px to 24px |
 | 0.1.8   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |
 | 0.1.7   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.9   | [PR#xxx](https://github.com/BBC/psammead/pull/xxx) Increases the padding-bottom from 16px to 24px |
+| 0.1.9   | [PR#386](https://github.com/BBC/psammead/pull/386) Increases the padding-bottom from 16px to 24px |
 | 0.1.8   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |
 | 0.1.7   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "dist/index.js",
   "description": "React styled component that generates a figure element",
   "repository": {

--- a/packages/components/psammead-figure/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-figure/src/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Figure should render correctly 1`] = `
 .c0 {
   margin: 0;
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
   width: 100%;
 }
 

--- a/packages/components/psammead-figure/src/index.jsx
+++ b/packages/components/psammead-figure/src/index.jsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
-import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 
 const Figure = styled.figure`
   margin: 0;
-  padding-bottom: ${GEL_SPACING_DBL};
+  padding-bottom: ${GEL_SPACING_TRPL};
   width: 100%;
 `;
 


### PR DESCRIPTION
Part of #379

**Overall change:** _Increases the padding-bottom of psammead-figure from 16px to 24px._

**Code changes:**

- _Changes psammead-figure's padding-bottom to use `GEL_SPACING_TRIPLE`_
- _Updates the snapshots_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval