### PR TITLE
Increase padding bottom paragraph

### DIFF
--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.2   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Increase padding-bottom from 16px to 24px |
+| 0.3.2   | [PR#387](https://github.com/bbc/psammead/pull/387) Increase padding-bottom from 16px to 24px |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Increase padding-bottom from 16px to 24px |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Paragraph should render a correctly 1`] = `
 .c0 {
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
   margin: 0;
   font-size: 0.9375rem;
   line-height: 1.25rem;

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
-import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import {
   GEL_BODY_COPY,
   GEL_FF_REITH_SANS,
@@ -9,7 +9,7 @@ import {
 const Paragraph = styled.p`
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
-  padding-bottom: ${GEL_SPACING_DBL};
+  padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
   ${GEL_BODY_COPY};
 `;


### PR DESCRIPTION
Part of #379

**Overall change:** Increases the padding-bottom of psammead-paragraph from 16px to 24px.

**Code changes:**

- _Changes psammead-paragraph's padding-bottom to use GEL_SPACING_TRIPLE_
- _Updates the snapshots_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval