### PR TITLE
Update Component Dependencies

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#338](https://github.com/BBC/psammead/pull/338) Limit banner svg to group 5 |
 | 0.2.3   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 | ------- | ----------- |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#338](https://github.com/BBC/psammead/pull/338) Limit banner svg to group 5 |
 | 0.2.3   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -31,19 +31,19 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.4.tgz",
-      "integrity": "sha512-ZkVK23thUiHrvh/aiGp1U3ncn7Yu9i1QtcWrzUAGseTptX0g1XBm5w0tIPwj7MCq7fvq9EOLYLiv1J+ElHrmWA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-styles": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.1.6.tgz",
-      "integrity": "sha512-yZ6VstjEB35GdZ0JktArGY4YnuXRmlZaZbvBb4bWoBU7/SuhB8X72rBy1exI2DFPyBYwc2Q4bqAQGoeM3GnAIQ=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.3.2.tgz",
+      "integrity": "sha512-KRAcWam7ztRX0wLww+HIJa9Cif1m1kJ8hrHJn5/ftnwoya8ucSzL1PZQaG8w4OV2XkkyzN6Mv6v1guWhVJ/n/g=="
     },
     "@bbc/psammead-test-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.1.tgz",
-      "integrity": "sha512-W3O6n1AWrSYsPy1Q3Vr/3xbzimKGAMzTF+9RfY1uL1QIh6dmzsrPKt0bw3iiuDp9fnHYl2U/aJ6cAF8Y8nRuJQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.3.tgz",
+      "integrity": "sha512-w/ENAOLuXZ8f2l3IJ2wYKEuNVH69xn0p4YIV6qx6GpZBYdP12n5sBi1lvGZOKD9tRa3UOGN5WZzxrZLjcUCh+w==",
       "dev": true,
       "requires": {
         "jest-styled-components": "^6.3.1",
@@ -51,9 +51,9 @@
       }
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.7.tgz",
-      "integrity": "sha512-cKqB3ghBsYCiZakRvtx+dA7KYlHwbs/YkUGe3iGzXH7OtQZYPFMw2Um9bLaIug0baGHCK0zvX2xBLBlosW6KIA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.10.tgz",
+      "integrity": "sha512-QZ+/UWYjKeFus75L8p2/p8E876t9Vm57Gj2m0aqCrfNlCZm0K2UNmB4LDtRDyKXmtGLVAK+P9h2vK1oJvZh5mg==",
       "requires": {
         "styled-components": "^4.1.2"
       }
@@ -221,15 +221,33 @@
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
     },
     "react-test-renderer": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.3.tgz",
-      "integrity": "sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==",
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.5.tgz",
+      "integrity": "sha512-/pFpHYQH4f35OqOae/DgOCXJDxBqD3K3akVfDhLgR0qYHoHjnICI/XS9QDwIhbrOFHWL7okVW9kKMaHuKvt2ng==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.3",
-        "scheduler": "^0.13.3"
+        "react-is": "^16.8.5",
+        "scheduler": "^0.13.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.5",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+          "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.5.tgz",
+          "integrity": "sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "resolve-url": {

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/index.js",
   "description": "Provides the BBC News logo (as SVG), nested a hardcoded link to https://www.bbc.co.uk/news",
   "repository": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -17,14 +17,14 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.1.2",
-    "@bbc/psammead-styles": "^0.1.3",
-    "@bbc/psammead-visually-hidden-text": "^0.1.0",
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2",
+    "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "react": "^16.6.3",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0"
+    "@bbc/psammead-test-helpers": "^0.3.3"
   },
   "keywords": [
     "bbc",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "@bbc/psammead-styles": "^0.3.2",
     "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "react": "^16.6.3",

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`Brand should render correctly 1`] = `
 }
 
 .c1 {
-  max-width: 80em;
+  max-width: 80rem;
   margin: 0 auto;
 }
 
@@ -51,19 +51,19 @@ exports[`Brand should render correctly 1`] = `
   fill: #fff;
 }
 
-@media (max-width:25em) {
+@media (max-width:25rem) {
   .c0 {
     padding: 0 0.5rem;
   }
 }
 
-@media (min-width:25em) {
+@media (min-width:25rem) {
   .c0 {
     padding: 0 1rem;
   }
 }
 
-@media (min-width:62.9375em) {
+@media (min-width:62.9375rem) {
   .c0 {
     padding: 0 1rem;
   }

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.1   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
 | 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -36,9 +36,9 @@
       "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-inline-link": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-0.3.3.tgz",
-      "integrity": "sha512-VLEdAFOD51WjVL6lKa4BOXevv9VtJLU+uIaWFWG4oO6zDA1VWd45gTar3cS+CL7pOw90JwTCp4z6JllM6I1kJg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-0.3.4.tgz",
+      "integrity": "sha512-xOsaTFZkB6m2gEpRMJdG4VrerlLHAth4jn8jo7LanCBt7azXbkAJE3LmUUJBhM2E2NQLyv0FezRjCHA2rIBnUw==",
       "dev": true,
       "requires": {
         "@bbc/psammead-styles": "^0.2.1",

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -22,8 +22,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0",
-    "@bbc/psammead-inline-link": "^0.3.3",
+    "@bbc/psammead-test-helpers": "^0.3.3",
+    "@bbc/psammead-inline-link": "^0.3.4",
     "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "react": "^16.6.3"
   },

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.3   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.2   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-      "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.2",
-    "@bbc/psammead-styles": "^0.3.0"
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2"
   },
   "keywords": [
     "bbc",
@@ -28,6 +28,6 @@
     "figure"
   ],
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0"
+    "@bbc/psammead-test-helpers": "^0.3.3"
   }
 }

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "@bbc/psammead-styles": "^0.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.9   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.1.8   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |
 | 0.1.7   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-assets": {
       "version": "0.1.6",

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.1.4.tgz",
-      "integrity": "sha512-ZkVK23thUiHrvh/aiGp1U3ncn7Yu9i1QtcWrzUAGseTptX0g1XBm5w0tIPwj7MCq7fvq9EOLYLiv1J+ElHrmWA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-assets": {
       "version": "0.1.6",
@@ -42,28 +42,28 @@
       "dev": true
     },
     "@bbc/psammead-caption": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-caption/-/psammead-caption-0.2.0.tgz",
-      "integrity": "sha512-Khv0o9bFcQlD1J7kpI4tjNzaCbX3zs4RAc07PJl5M0C04n8pRdMGEiqQb4/QiBhb9fPIyxnWWFys61u8DMZYIg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-caption/-/psammead-caption-0.3.0.tgz",
+      "integrity": "sha512-UUeOoZBJNzXYEEVrV2FPFLZg8QVf7rh5wa3zuL4E0wqfBT0Z6RuA8z1qDd8sOrqEECGUD2ho1Hbgd/X1nJD8ug==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^0.2.2",
-        "@bbc/psammead-styles": "^0.3.0",
+        "@bbc/gel-foundations": "^0.2.5",
+        "@bbc/psammead-styles": "^0.3.2",
         "styled-components": "^4.1.2"
       },
       "dependencies": {
         "@bbc/gel-foundations": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-          "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg==",
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+          "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig==",
           "dev": true
         }
       }
     },
     "@bbc/psammead-copyright": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-copyright/-/psammead-copyright-0.3.0.tgz",
-      "integrity": "sha512-QkXivxVwmGZxk3Qtpk+Wl6L2ACTii6yPEt3DGcocsAO85EPVxewAnwMTiUXHzKp0DoLfn+MlirYo9lzSOANF+A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-copyright/-/psammead-copyright-0.3.2.tgz",
+      "integrity": "sha512-tjfMRolHaxkllk/+YBtKd5Ug5MYVe5DeKhDNn8c/ROTvnz5vsEVCnoXryDB2wb2wAPrUx4qBlJyV/4lpVxCy0w==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^0.2.2",
@@ -71,17 +71,17 @@
       },
       "dependencies": {
         "@bbc/gel-foundations": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-          "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg==",
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+          "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig==",
           "dev": true
         }
       }
     },
     "@bbc/psammead-image": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image/-/psammead-image-0.3.1.tgz",
-      "integrity": "sha512-z98MrFGbbaEQzqs0GMM1I3dtbZoXNqfbAryb6ZJSzR3WzdPM7WRJz+OwOg9E9mf7y7BhKs0jp4sCMqbe9xLjfg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image/-/psammead-image-0.3.3.tgz",
+      "integrity": "sha512-fJijzfrqEaNRO2tXRzyiAtRv2wKkCgAP+MNP8JGlknWyxklpvmA90mazbDWXGMc9EWy5eiPlLWkwa9NoP/eLmQ==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",
@@ -89,9 +89,9 @@
       }
     },
     "@bbc/psammead-image-placeholder": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-0.1.7.tgz",
-      "integrity": "sha512-P+Khrzib2dbe1UjgM/seJ94D5+sCqT0uZYcR0sy06pgKWGD6iFS+fAwaJkUaeqXXkfVgEVDp6AoedrcF+taKSg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-0.1.8.tgz",
+      "integrity": "sha512-WiwW9Ht7HNyImsdOjzvOG52aksk9UstIYWU3oRcQigqu4QV2ank56ObdM+1Zj3QGrborZJrIwlMWfI2J0qx42A==",
       "dev": true,
       "requires": {
         "@bbc/psammead-assets": "^0.1.2",
@@ -114,9 +114,9 @@
       "dev": true
     },
     "@bbc/psammead-test-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.1.tgz",
-      "integrity": "sha512-W3O6n1AWrSYsPy1Q3Vr/3xbzimKGAMzTF+9RfY1uL1QIh6dmzsrPKt0bw3iiuDp9fnHYl2U/aJ6cAF8Y8nRuJQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.3.tgz",
+      "integrity": "sha512-w/ENAOLuXZ8f2l3IJ2wYKEuNVH69xn0p4YIV6qx6GpZBYdP12n5sBi1lvGZOKD9tRa3UOGN5WZzxrZLjcUCh+w==",
       "dev": true,
       "requires": {
         "jest-styled-components": "^6.3.1",
@@ -124,9 +124,9 @@
       }
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.9.tgz",
-      "integrity": "sha512-9UVr1I4Db1KfaKXT7sd8ajL04UfPDCnA2lPQleYB1Uu27re+woiuj4AYtYplJdPjRNWdRaHKqB7CGcNXYwJOlA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.10.tgz",
+      "integrity": "sha512-QZ+/UWYjKeFus75L8p2/p8E876t9Vm57Gj2m0aqCrfNlCZm0K2UNmB4LDtRDyKXmtGLVAK+P9h2vK1oJvZh5mg==",
       "dev": true,
       "requires": {
         "styled-components": "^4.1.2"
@@ -296,15 +296,33 @@
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
     },
     "react-test-renderer": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.3.tgz",
-      "integrity": "sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==",
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.5.tgz",
+      "integrity": "sha512-/pFpHYQH4f35OqOae/DgOCXJDxBqD3K3akVfDhLgR0qYHoHjnICI/XS9QDwIhbrOFHWL7okVW9kKMaHuKvt2ng==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.3",
-        "scheduler": "^0.13.3"
+        "react-is": "^16.8.5",
+        "scheduler": "^0.13.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.5",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+          "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.5.tgz",
+          "integrity": "sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "resolve-url": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "dist/index.js",
   "description": "React styled component that generates a figure element",
   "repository": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-figure/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -17,16 +17,16 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-figure/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.1.4",
+    "@bbc/gel-foundations": "^0.2.5",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.1",
-    "@bbc/psammead-caption": "^0.2.0",
-    "@bbc/psammead-copyright": "^0.3.0",
-    "@bbc/psammead-image": "^0.3.0",
-    "@bbc/psammead-image-placeholder": "^0.1.7",
-    "@bbc/psammead-visually-hidden-text": "^0.1.9",
+    "@bbc/psammead-test-helpers": "^0.3.3",
+    "@bbc/psammead-caption": "^0.3.0",
+    "@bbc/psammead-copyright": "^0.3.2",
+    "@bbc/psammead-image": "^0.3.3",
+    "@bbc/psammead-image-placeholder": "^0.1.8",
+    "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "react": "^16.6.3"
   },
   "keywords": [

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-      "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.2",
-    "@bbc/psammead-styles": "^0.3.0",
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0"
+    "@bbc/psammead-test-helpers": "^0.3.3"
   },
   "keywords": [
     "bbc",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -11,14 +11,14 @@ exports[`Headline component should render correctly 1`] = `
   line-height: 2rem;
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 2.75rem;
     line-height: 3rem;
@@ -43,14 +43,14 @@ exports[`SubHeading component attribute id should render without double quotes 1
   line-height: 1.5rem;
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
@@ -77,14 +77,14 @@ exports[`SubHeading component attribute id should render without exclamation mar
   line-height: 1.5rem;
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
@@ -111,14 +111,14 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
   line-height: 1.5rem;
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
@@ -145,14 +145,14 @@ exports[`SubHeading component should render correctly 1`] = `
   line-height: 1.5rem;
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-      "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.2",
-    "@bbc/psammead-styles": "^0.3.0",
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0",
+    "@bbc/psammead-test-helpers": "^0.3.3",
     "react": "^16.6.3"
   }
 }

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`Paragraph should render a correctly 1`] = `
   line-height: 1.25rem;
 }
 
-@media (min-width:20em) {
+@media (min-width:20rem) {
   .c0 {
     font-size: 1rem;
     line-height: 1.375rem;

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.2   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.1   | [PR#347](https://github.com/BBC/psammead/pull/347) Constrain content width to Group 5 min width. |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.3   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.3   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.2   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.1   | [PR#347](https://github.com/BBC/psammead/pull/347) Constrain content width to Group 5 min width. |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.4.tgz",
-      "integrity": "sha512-vuVgD9FDDamPuLRVcGJjvDtuQ223YS5sRaBODsCbypQqr/fMpxVvVxqJIwvG/M0b2h2FBmMvy9JtR+QyeYcpTg=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
+      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
+      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "repository": {
@@ -23,14 +23,14 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.2",
-    "@bbc/psammead-styles": "^0.3.0",
+    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/psammead-styles": "^0.3.2",
     "nanoid": "^2.0.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0"
+    "@bbc/psammead-test-helpers": "^0.3.3"
   }
 }

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^0.3.0",
     "@bbc/psammead-styles": "^0.3.2",
     "nanoid": "^2.0.0",
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`List should render correctly 1`] = `
   min-width: 50%;
 }
 
-@media (max-width:37.4375em) {
+@media (max-width:37.4375rem) {
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
@@ -44,7 +44,7 @@ exports[`List should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
@@ -52,7 +52,7 @@ exports[`List should render correctly 1`] = `
   }
 }
 
-@media (min-width:63em) and (max-width:80em) {
+@media (min-width:63rem) and (max-width:80rem) {
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
@@ -60,7 +60,7 @@ exports[`List should render correctly 1`] = `
   }
 }
 
-@media (min-width:80em) {
+@media (min-width:80rem) {
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`SitewideLinks should render correctly 1`] = `
 }
 
 .c1 {
-  max-width: 80em;
+  max-width: 80rem;
   margin: 0 auto;
 }
 
@@ -63,7 +63,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   padding: 1rem 0;
 }
 
-@media (max-width:37.4375em) {
+@media (max-width:37.4375rem) {
   .c2 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
@@ -71,7 +71,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
@@ -79,7 +79,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   }
 }
 
-@media (min-width:63em) and (max-width:80em) {
+@media (min-width:63rem) and (max-width:80rem) {
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
@@ -87,7 +87,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   }
 }
 
-@media (min-width:80em) {
+@media (min-width:80rem) {
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
@@ -107,25 +107,25 @@ exports[`SitewideLinks should render correctly 1`] = `
   }
 }
 
-@media (max-width:25em) {
+@media (max-width:25rem) {
   .c0 {
     padding: 0 0.5rem;
   }
 }
 
-@media (min-width:25em) {
+@media (min-width:25rem) {
   .c0 {
     padding: 0 1rem;
   }
 }
 
-@media (min-width:20em) and (max-width:37.4375em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     line-height: 1.125rem;
   }
 }
 
-@media (min-width:37.5em) {
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 0.8125rem;
   }


### PR DESCRIPTION
**Overall change:** Update to use latest dependencies `psammead-styles@0.3.2` & `gel-foundations@0.3.0` 

Visually, there should be no changes.

`gel-foundations@0.3.0` changed the media query values to be `rem` instead of `em`. 

**Code changes:**

- `psammead-brand` & `psammead-figure` - updates `gel-foundations` from v`0.1.4` to `0.2.4` (Typography is changed from em to rem, but these components don't have visible text, so there are no visible changes)
- `psammead-brand` updates `psammead-styles` from `0.1.6` to `0.3.2` (This adds new colours and fonts, but these should not have any visual change.)
- `psammead-brand`, `psammead-copyright`, `psammead-paragraph`, `psammead-headings`, `psammead-sitewide-links` `psammead-figure` - updates `gel-foundations` from v`0.2.4` to `0.3.0` (This updates the media query values from `em` to `rem`. )

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval