### PR TITLE
Remove vertical spacing

### DIFF
--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.9   | [PR#xxx](https://github.com/BBC/psammead/pull/xxx) Vertical spacing should be defined outside of the component |
 | 0.1.8   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |
 | 0.1.7   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "dist/index.js",
   "description": "React styled component that generates a figure element",
   "repository": {

--- a/packages/components/psammead-figure/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-figure/src/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`Figure should render correctly 1`] = `
 .c0 {
   margin: 0;
-  padding-bottom: 1rem;
   width: 100%;
 }
 

--- a/packages/components/psammead-figure/src/index.jsx
+++ b/packages/components/psammead-figure/src/index.jsx
@@ -1,9 +1,7 @@
 import styled from 'styled-components';
-import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 
 const Figure = styled.figure`
-  margin: 0;
-  padding-bottom: ${GEL_SPACING_DBL};
+  margin: 0; /* Reset */
   width: 100%;
 `;
 

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.4.1   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Vertical spacing should be defined outside of the component |
+| 0.4.0   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`Headline component should render correctly 1`] = `
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 2rem 0 1rem 0;
   font-weight: 500;
   font-size: 1.75rem;
   line-height: 2rem;
@@ -37,7 +36,6 @@ exports[`SubHeading component attribute id should render without double quotes 1
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 1rem 0;
   font-weight: 700;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -71,7 +69,6 @@ exports[`SubHeading component attribute id should render without exclamation mar
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 1rem 0;
   font-weight: 700;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -105,7 +102,6 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 1rem 0;
   font-weight: 700;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -139,7 +135,6 @@ exports[`SubHeading component should render correctly 1`] = `
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
-  padding: 1rem 0;
   font-weight: 700;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,10 +1,6 @@
 import styled from 'styled-components';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
-  GEL_SPACING_DBL,
-  GEL_SPACING_QUAD,
-} from '@bbc/gel-foundations/spacings';
-import {
   GEL_CANON,
   GEL_TRAFALGAR,
   GEL_FF_REITH_SANS,
@@ -15,7 +11,6 @@ export const Headline = styled.h1`
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
-  padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_DBL} 0;
   font-weight: 500;
   ${GEL_CANON};
 `;
@@ -30,7 +25,6 @@ export const SubHeading = styled.h2.attrs(({ text }) => ({
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
   margin: 0; /* Reset */
-  padding: ${GEL_SPACING_DBL} 0;
   font-weight: 700;
   ${GEL_TRAFALGAR};
 `;

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.2   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Vertical spacing should be defined outside of the component |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
 | 0.3.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
 | 0.2.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,6 @@ exports[`Paragraph should render a correctly 1`] = `
 .c0 {
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
   margin: 0;
   font-size: 0.9375rem;
   line-height: 1.25rem;

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
-import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import {
   GEL_BODY_COPY,
   GEL_FF_REITH_SANS,
@@ -9,7 +8,6 @@ import {
 const Paragraph = styled.p`
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
-  padding-bottom: ${GEL_SPACING_DBL};
   margin: 0; /* Reset */
   ${GEL_BODY_COPY};
 `;


### PR DESCRIPTION
Resolves #399

**Overall change:** _Removes the vertical padding off of `psammead-headings`, `psammead-figure` and `psammead-paragraph`_

**Code changes:**

- _Removes the vertical spacings off of all top-level components_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval