### PR TITLE
Package version bumps lost in conflicts

### DIFF
--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "dist/index.js",
   "description": "React styled component that generates a figure element",
   "repository": {

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
Follows up #392 

**Overall change:** _Conflicts on https://github.com/bbc/psammead/pull/392 caused the `package.json` and `package-lock.json` version bumps to be removed from the PR. This bumps them so npm will publish the new versions._

**Code changes:**

- bumps the package versions of psammead-figure and psammead-paragraph

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~