### PR TITLE
Fixes title of copyright changelog

### DIFF
--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Psammead Headings Changelog
+# Psammead Copyright Changelog
 
 <!-- prettier-ignore -->
 | Version | Description |


### PR DESCRIPTION
Changelog referenced Headings instead of Copyright.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval