### PR TITLE
Add new typography method in Caption component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8284,20 +8284,20 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -8315,13 +8315,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -8338,32 +8338,32 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -8380,21 +8380,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -8404,14 +8404,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -8443,7 +8443,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -8460,7 +8460,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -8470,7 +8470,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -8481,20 +8481,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -8503,14 +8503,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -8519,7 +8519,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
@@ -8545,7 +8545,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -8554,7 +8554,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
@@ -8592,7 +8592,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -8621,7 +8621,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -8634,20 +8634,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -8656,21 +8656,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -8681,14 +8681,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -8708,7 +8708,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -8717,7 +8717,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -8749,14 +8749,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -8770,21 +8770,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -8795,7 +8795,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8805,7 +8805,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8814,7 +8814,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8837,7 +8837,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8854,7 +8854,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -4,6 +4,7 @@
 | Version | Description |
 |---------|-------------|
 | 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
+| 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.1   | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
 | 0.3.3   | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.1   | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |

--- a/packages/components/psammead-caption/README.md
+++ b/packages/components/psammead-caption/README.md
@@ -12,7 +12,7 @@ The `psammead-caption` component is a styled `figcaption` element.
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| No props. |      |          |         |         |
+| Script    | object | No | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 ## Usage
 
@@ -22,11 +22,12 @@ The `psammead-caption` component is a styled `figcaption` element.
 import Caption from '@bbc/psammead-caption';
 import Figure from '@bbc/psammead-figure';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
+import { arabic } from '@bbc/gel-foundations/scripts';
 
 const Wrapper = captionText => (
   <Figure>
     ...
-    <Caption>
+    <Caption script={arabic}>
       <VisuallyHiddenText>Image caption, </VisuallyHiddenText>
       {captionText}
     </Caption>

--- a/packages/components/psammead-caption/README.md
+++ b/packages/components/psammead-caption/README.md
@@ -12,7 +12,7 @@ The `psammead-caption` component is a styled `figcaption` element.
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| Script    | object | No | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+| Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 ## Usage
 

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.2.5.tgz",
-      "integrity": "sha512-vEpe9CcDyDoIUAPSrDwtGqnNvJdZedL7h/sKu0hQBctuIjbeZifoq7R7NES5SuI8oNUmUTbhJtl9aO05ceRFig=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
+      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
     },
     "@bbc/psammead-inline-link": {
       "version": "0.3.4",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -18,8 +18,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^1.0.0",
-    "@bbc/psammead-styles": "^0.3.2",
-    "styled-components": "^4.1.2"
+    "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {
     "@bbc/psammead-test-helpers": "^0.3.3",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.2.5",
+    "@bbc/gel-foundations": "^1.0.0",
     "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render Caption with some offscreen text 1`] = `
+exports[`Caption should render with some offscreen text 1`] = `
 .c1 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -52,6 +52,66 @@ exports[`should render Caption with some offscreen text 1`] = `
   className="c0"
 >
   This is some Caption text
+  <span
+    className="c1"
+  >
+    Some offscreen text
+  </span>
+</figcaption>
+`;
+
+exports[`Caption should render with some offscreen text and arabic script typography values 1`] = `
+.c1 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+.c0 {
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  color: #757575;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-style: italic;
+  padding: 0.5rem 0.5rem;
+  width: 100%;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 0.5rem 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    padding: 0.5rem 0;
+  }
+}
+
+<figcaption
+  className="c0"
+>
+  هذا هو بعض النص التسمية التوضيحي
   <span
     className="c1"
   >

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -22,19 +22,27 @@ exports[`should render Caption with some offscreen text 1`] = `
   width: 100%;
 }
 
-@media (min-width:37.5em) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
-    font-size: 0.875rem;
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
   }
 }
 
-@media (min-width:25em) and (max-width:62.9375em) {
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
   .c0 {
     padding: 0.5rem 1rem;
   }
 }
 
-@media (min-width:63em) {
+@media (min-width:63rem) {
   .c0 {
     padding: 0.5rem 0;
   }

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
+import { node, objectOf, object } from 'prop-types';
 import {
   GEL_SPACING,
   GEL_MARGIN_ABOVE_400PX,
@@ -10,11 +12,12 @@ import {
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import {
-  GEL_LONG_PRIMER,
+  getLongPrimer,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
 
 import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
+import { latin } from '@bbc/gel-foundations/scripts';
 
 // Defined separately since in future will need to apply
 // only when the script supports italic text
@@ -22,8 +25,8 @@ const FS_ITALIC = css`
   font-style: italic;
 `;
 
-const Caption = styled.figcaption`
-  ${GEL_LONG_PRIMER};
+const StyledElement = styled.figcaption`
+  ${props => (props.typography ? props.typography : '')};
   color: ${C_CLOUD_DARK};
   font-family: ${GEL_FF_REITH_SANS};
   ${FS_ITALIC};
@@ -38,4 +41,20 @@ const Caption = styled.figcaption`
   }
 `;
 
+const Caption = ({ children, script }) => {
+  const GEL_LONG_PRIMER = getLongPrimer(script);
+
+  return <StyledElement typography={GEL_LONG_PRIMER}>{children}</StyledElement>;
+};
+
+Caption.propTypes = {
+  children: node.isRequired,
+  script: objectOf(object),
+};
+
+Caption.defaultProps = {
+  script: latin,
+};
+
 export default Caption;
+

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 import { node, objectOf, object } from 'prop-types';
 import {
@@ -17,7 +16,6 @@ import {
 } from '@bbc/gel-foundations/typography';
 
 import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
-import { latin } from '@bbc/gel-foundations/scripts';
 
 // Defined separately since in future will need to apply
 // only when the script supports italic text
@@ -25,14 +23,13 @@ const FS_ITALIC = css`
   font-style: italic;
 `;
 
-const StyledCaption = styled.figcaption`
-  ${props => (props.typography ? props.typography : '')};
+const Caption = styled.figcaption`
+  ${props => (props.script ? getLongPrimer(props.script) : '')};
   color: ${C_CLOUD_DARK};
   font-family: ${GEL_FF_REITH_SANS};
   ${FS_ITALIC};
   padding: ${GEL_SPACING} ${GEL_MARGIN_BELOW_400PX};
   width: 100%;
-
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     padding: ${GEL_SPACING} ${GEL_MARGIN_ABOVE_400PX};
   }
@@ -41,19 +38,9 @@ const StyledCaption = styled.figcaption`
   }
 `;
 
-const Caption = ({ children, script }) => {
-  const GEL_LONG_PRIMER = getLongPrimer(script);
-
-  return <StyledCaption typography={GEL_LONG_PRIMER}>{children}</StyledCaption>;
-};
-
 Caption.propTypes = {
   children: node.isRequired,
-  script: objectOf(object),
-};
-
-Caption.defaultProps = {
-  script: latin,
+  script: objectOf(object).required,
 };
 
 export default Caption;

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -57,4 +57,3 @@ Caption.defaultProps = {
 };
 
 export default Caption;
-

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { node, objectOf, object } from 'prop-types';
+import { objectOf, object } from 'prop-types';
 import {
   GEL_SPACING,
   GEL_MARGIN_ABOVE_400PX,
@@ -39,7 +39,6 @@ const Caption = styled.figcaption`
 `;
 
 Caption.propTypes = {
-  children: node.isRequired,
   script: objectOf(object).required,
 };
 

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -25,7 +25,7 @@ const FS_ITALIC = css`
   font-style: italic;
 `;
 
-const StyledElement = styled.figcaption`
+const StyledCaption = styled.figcaption`
   ${props => (props.typography ? props.typography : '')};
   color: ${C_CLOUD_DARK};
   font-family: ${GEL_FF_REITH_SANS};
@@ -44,7 +44,7 @@ const StyledElement = styled.figcaption`
 const Caption = ({ children, script }) => {
   const GEL_LONG_PRIMER = getLongPrimer(script);
 
-  return <StyledElement typography={GEL_LONG_PRIMER}>{children}</StyledElement>;
+  return <StyledCaption typography={GEL_LONG_PRIMER}>{children}</StyledCaption>;
 };
 
 Caption.propTypes = {

--- a/packages/components/psammead-caption/src/index.stories.jsx
+++ b/packages/components/psammead-caption/src/index.stories.jsx
@@ -2,17 +2,18 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InlineLink from '@bbc/psammead-inline-link';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
+import { latin } from '@bbc/gel-foundations/scripts';
 import notes from '../README.md';
 import Caption from '.';
 
 storiesOf('Caption', module)
-  .add('default', () => <Caption>This is a caption.</Caption>, {
+  .add('default', () => <Caption script={latin}>This is a caption.</Caption>, {
     notes,
   })
   .add(
     'with offscreen text',
     () => (
-      <Caption>
+      <Caption script={latin}>
         <VisuallyHiddenText>Image caption, </VisuallyHiddenText>
         This is a caption with preceding offscreen text.
       </Caption>
@@ -22,7 +23,7 @@ storiesOf('Caption', module)
   .add(
     'containing an inline link',
     () => (
-      <Caption>
+      <Caption script={latin}>
         {'This is a caption '}
         <InlineLink href="https://www.bbc.com">
           containing an inline link

--- a/packages/components/psammead-caption/src/index.test.jsx
+++ b/packages/components/psammead-caption/src/index.test.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { latin } from '@bbc/gel-foundations/scripts';
 import Caption from '.';
 
 shouldMatchSnapshot(
   'should render Caption with some offscreen text',
-  <Caption>
+  <Caption script={latin}>
     This is some Caption text
     <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
   </Caption>,

--- a/packages/components/psammead-caption/src/index.test.jsx
+++ b/packages/components/psammead-caption/src/index.test.jsx
@@ -1,13 +1,23 @@
 import React from 'react';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { latin } from '@bbc/gel-foundations/scripts';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
 import Caption from '.';
 
-shouldMatchSnapshot(
-  'should render Caption with some offscreen text',
-  <Caption script={latin}>
-    This is some Caption text
-    <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
-  </Caption>,
-);
+describe('Caption', () => {
+  shouldMatchSnapshot(
+    'should render with some offscreen text',
+    <Caption script={latin}>
+      This is some Caption text
+      <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
+    </Caption>,
+  );
+
+  shouldMatchSnapshot(
+    'should render with some offscreen text and arabic script typography values',
+    <Caption script={arabic}>
+      هذا هو بعض النص التسمية التوضيحي
+      <VisuallyHiddenText>Some offscreen text</VisuallyHiddenText>
+    </Caption>,
+  );
+});


### PR DESCRIPTION
Resolves #345

**Overall change:** 
Add support to allow the `Caption` component to use Typography Type Sizes for different scripts

**Code changes:**

- Allow the component to pass the script name a prop
- Add `propTypes` to require a `script` prop
- Remove previous `GEL_LONG_PRIMER` import
- Import new `getLongPrimer` method which makes use of the new `getTypeSizes()` method to get the appropriate GEL Type Sizes for the component.
- Import `latin.js` script with the default typography GEL Types Sizes in the stories and unit test
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval