### PR TITLE
Add new typography method in Paragraph component

### DIFF
--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#414](https://github.com/bbc/psammead/pull/414) Add support for different scripts typographies |
 | 0.3.3   | [PR#392](https://github.com/bbc/psammead/pull/392) Increase padding-bottom from 16px to 24px |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -4,6 +4,7 @@
 | Version | Description |
 |---------|-------------|
 | 1.0.0   | [PR#414](https://github.com/bbc/psammead/pull/414) Add support for different scripts typographies |
+| 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#392](https://github.com/bbc/psammead/pull/392) Increase padding-bottom from 16px to 24px |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-paragraph/README.md
+++ b/packages/components/psammead-paragraph/README.md
@@ -14,14 +14,16 @@ It uses `@bbc/psammead-styles` for colours and font family and `@bbc/gel-foundat
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| No props. |      |          |         |         |
+| Script    | object | Yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+
 
 ## Usage
 
 ```jsx
 import Paragraph from '@bbc/psammead-paragraph';
+import { latin } from '@bbc/gel-foundations/scripts';
 
-const WrappingComponent = () => <Paragraph>Text here</Paragraph>;
+const WrappingComponent = () => <Paragraph script={latin}>Text here</Paragraph>;
 ```
 
 ### When to use this component

--- a/packages/components/psammead-paragraph/README.md
+++ b/packages/components/psammead-paragraph/README.md
@@ -14,7 +14,7 @@ It uses `@bbc/psammead-styles` for colours and font family and `@bbc/gel-foundat
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| Script    | object | Yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+| Script    | object | No | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 
 ## Usage

--- a/packages/components/psammead-paragraph/README.md
+++ b/packages/components/psammead-paragraph/README.md
@@ -14,7 +14,7 @@ It uses `@bbc/psammead-styles` for colours and font family and `@bbc/gel-foundat
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| Script    | object | No | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+| Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 
 ## Usage

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
-      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
+      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -23,8 +23,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^1.0.0",
-    "@bbc/psammead-styles": "^0.3.2",
-    "styled-components": "^4.1.2"
+    "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {
     "@bbc/psammead-test-helpers": "^0.3.3",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.3.0",
+    "@bbc/gel-foundations": "^1.0.0",
     "@bbc/psammead-styles": "^0.3.2",
     "styled-components": "^4.1.2"
   },

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -2,15 +2,22 @@
 
 exports[`Paragraph should render a correctly 1`] = `
 .c0 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding-bottom: 1.5rem;
   margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
 }
 
-@media (min-width:20rem) {
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
   .c0 {
     font-size: 1rem;
     line-height: 1.375rem;

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -30,3 +30,34 @@ exports[`Paragraph should render a correctly 1`] = `
   This is text in a paragraph.
 </p>
 `;
+
+exports[`Paragraph should render correctly with arabic script typography values 1`] = `
+.c0 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: #3F3F42;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  padding-bottom: 1.5rem;
+  margin: 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.25rem;
+    line-height: 1.875rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1.375rem;
+    line-height: 2.125rem;
+  }
+}
+
+<p
+  className="c0"
+>
+  بعض محتوى النص
+</p>
+`;

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,17 +1,35 @@
+import React from 'react';
 import styled from 'styled-components';
+import { node, objectOf, object } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import {
-  GEL_BODY_COPY,
+  getBodyCopy,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
+import { latin } from '@bbc/gel-foundations/scripts';
 
-const Paragraph = styled.p`
+const StyledElement = styled.p`
+  ${props => (props.typography ? props.typography : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
   padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
-  ${GEL_BODY_COPY};
 `;
+
+const Paragraph = ({ children, script }) => {
+  const GEL_BODY_COPY = getBodyCopy(script);
+
+  return <StyledElement typography={GEL_BODY_COPY}>{children}</StyledElement>;
+};
+
+Paragraph.propTypes = {
+  children: node.isRequired,
+  script: objectOf(object),
+};
+
+Paragraph.defaultProps = {
+  script: latin,
+};
 
 export default Paragraph;

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -9,7 +9,7 @@ import {
 } from '@bbc/gel-foundations/typography';
 import { latin } from '@bbc/gel-foundations/scripts';
 
-const StyledElement = styled.p`
+const StyledParagraph = styled.p`
   ${props => (props.typography ? props.typography : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
@@ -20,7 +20,9 @@ const StyledElement = styled.p`
 const Paragraph = ({ children, script }) => {
   const GEL_BODY_COPY = getBodyCopy(script);
 
-  return <StyledElement typography={GEL_BODY_COPY}>{children}</StyledElement>;
+  return (
+    <StyledParagraph typography={GEL_BODY_COPY}>{children}</StyledParagraph>
+  );
 };
 
 Paragraph.propTypes = {

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,37 +1,22 @@
-import React from 'react';
 import styled from 'styled-components';
-import { node, objectOf, object } from 'prop-types';
+import { objectOf, object } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import {
   getBodyCopy,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
-import { latin } from '@bbc/gel-foundations/scripts';
 
-const StyledParagraph = styled.p`
-  ${props => (props.typography ? props.typography : '')};
+const Paragraph = styled.p`
+  ${props => (props.script ? getBodyCopy(props.script) : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
   padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
 `;
 
-const Paragraph = ({ children, script }) => {
-  const GEL_BODY_COPY = getBodyCopy(script);
-
-  return (
-    <StyledParagraph typography={GEL_BODY_COPY}>{children}</StyledParagraph>
-  );
-};
-
 Paragraph.propTypes = {
-  children: node.isRequired,
-  script: objectOf(object),
-};
-
-Paragraph.defaultProps = {
-  script: latin,
+  script: objectOf(object).isRequired,
 };
 
 export default Paragraph;

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { latin } from '@bbc/gel-foundations/scripts';
 import notes from '../README.md';
 import Paragraph from './index';
 
 storiesOf('Paragraph', module).add(
   'default',
-  () => <Paragraph>This is text in a paragraph.</Paragraph>,
+  () => <Paragraph script={latin}>This is text in a paragraph.</Paragraph>,
   { notes },
 );

--- a/packages/components/psammead-paragraph/src/index.test.jsx
+++ b/packages/components/psammead-paragraph/src/index.test.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { latin } from '@bbc/gel-foundations/scripts';
 import Paragraph from './index';
 
 describe('Paragraph', () => {
   shouldMatchSnapshot(
     'should render a correctly',
-    <Paragraph>This is text in a paragraph.</Paragraph>,
+    <Paragraph script={latin}>This is text in a paragraph.</Paragraph>,
   );
 });

--- a/packages/components/psammead-paragraph/src/index.test.jsx
+++ b/packages/components/psammead-paragraph/src/index.test.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { latin } from '@bbc/gel-foundations/scripts';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
 import Paragraph from './index';
 
 describe('Paragraph', () => {
   shouldMatchSnapshot(
     'should render a correctly',
     <Paragraph script={latin}>This is text in a paragraph.</Paragraph>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with arabic script typography values',
+    <Paragraph script={arabic}>بعض محتوى النص</Paragraph>,
   );
 });


### PR DESCRIPTION
Resolves #351

**Overall change:** 
Add support to allow the `Paragraph` component to use Typography Type Sizes for different scripts

**Code changes:**

- Allow the component to pass the script name a prop
- Add `propTypes` to require a `script` prop
- Remove previous `GEL_BODY_COPY` import
- Import new `getBodyCopy` method which makes use of the new `getTypeSizes()` method to get the appropriate GEL Type Sizes for the component.
- Import `latin.js` script with the default typography GEL Types Sizes in the stories and unit test
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval