### PR TITLE
Add new typography method in Copyright component

### DIFF
--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#415](https://github.com/bbc/psammead/pull/415) Add support for different scripts typographies |
 | 0.3.4   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
 | 0.3.3   | [PR#329](https://github.com/BBC/psammead/pull/329) Adding Visually Hidden Text to copyright component story. |
 | 0.3.2   | [PR#334](https://github.com/BBC/psammead/pull/334) Improve examples of using Figure and Copyright |

--- a/packages/components/psammead-copyright/README.md
+++ b/packages/components/psammead-copyright/README.md
@@ -12,18 +12,20 @@ Displays a source attribution in block capitals in the bottom-right of the paren
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| No props. |      |          |         |         |
+| Script    | object | No | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 ## Usage
 
 Commonly used alongside [`psammead-figure`](https://github.com/BBC-News/psammead/tree/latest/packages/components/psammead-figure), [`psammead-image`](https://github.com/BBC-News/psammead/tree/latest/packages/components/psammead-image) and [`psammead-image-placeholder`](https://github.com/BBC-News/psammead/tree/latest/packages/components/psammead-image-placeholder). Can also pass in [`psammead-visually-hidden-text`](https://github.com/BBC-News/psammead/tree/latest/packages/components/psammead-visually-hidden-text) in order to announce the component.
 
 ```jsx
+import { latin } from '@bbc/gel-foundations/scripts';
+
 const WrapperComponent = ({ alt, ratio, src, width }) => (
   <Figure>
     <ImagePlaceholder ratio={ratio}>
       <Image alt={alt} src={src} width={width} />
-      <Copyright>
+      <Copyright script={latin}>
         <VisuallyHiddenText>Image source, </VisuallyHiddenText>
         Getty Images
       </Copyright>

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
-      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
+      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.3.0",
+    "@bbc/gel-foundations": "^1.0.0",
     "@bbc/psammead-styles": "^0.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
@@ -15,6 +15,20 @@ exports[`Copyright should render correctly 1`] = `
   margin: 0;
 }
 
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
 <p
   className="c0"
   role="text"

--- a/packages/components/psammead-copyright/src/index.jsx
+++ b/packages/components/psammead-copyright/src/index.jsx
@@ -1,12 +1,15 @@
+import React from 'react';
 import styled from 'styled-components';
+import { node, objectOf, object } from 'prop-types';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING, GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
-import { GEL_MINION, GEL_FF_REITH_SANS } from '@bbc/gel-foundations/typography';
+import { getMinion, GEL_FF_REITH_SANS } from '@bbc/gel-foundations/typography';
+import { latin } from '@bbc/gel-foundations/scripts';
 
-const Copyright = styled.p.attrs({
+const StyledCopyright = styled.p.attrs({
   role: 'text',
 })`
-  ${GEL_MINION};
+  ${props => (props.typography ? props.typography : '')};
   background-color: rgba(34, 34, 34, 0.75);
   text-transform: uppercase;
   color: ${C_WHITE};
@@ -17,5 +20,20 @@ const Copyright = styled.p.attrs({
   right: 0;
   margin: 0;
 `;
+
+const Copyright = ({ children, script }) => {
+  const GEL_MINION = getMinion(script);
+
+  return <StyledCopyright typography={GEL_MINION}>{children}</StyledCopyright>;
+};
+
+Copyright.propTypes = {
+  children: node.isRequired,
+  script: objectOf(object),
+};
+
+Copyright.defaultProps = {
+  script: latin,
+};
 
 export default Copyright;


### PR DESCRIPTION
Resolves #358

**Overall change:** 
Add support to allow the `Copyright` component to use Typography Type Sizes for different scripts

**Code changes:**

- Allow the component to pass the script name a prop
- Add `propTypes` to require a `script` prop
- Remove previous `GEL_MINION` import
- Import new `getMinion` method which makes use of the new `getTypeSizes()` method to get the appropriate GEL Type Sizes for the component.
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval