### PR TITLE
Add language variants knob to Headline and SubHeading

### DIFF
--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.4.2   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Headings |
 | 0.4.1   | [PR#381](https://github.com/bbc/psammead/pull/381) Make SubHeading padding-top 32px when viewport 400px and above |
 | 0.4.0   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.4.2   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Headings |
+| 0.4.2   | [PR#418](https://github.com/bbc/psammead/pull/418) Add language variants knob to Headings |
 | 0.4.1   | [PR#381](https://github.com/bbc/psammead/pull/381) Make SubHeading padding-top 32px when viewport 400px and above |
 | 0.4.0   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,6 +34,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
       "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
+    },
+    "@bbc/psammead-storybook-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-1.0.0.tgz",
+      "integrity": "sha512-2JSrr/zA3HBbR/kOuOkONir8e/iePeN1InNEHKnjsriyOqcUnIUhJ7sdCjdAI0m/7cD/HwB0DAvipW/4+kHCNQ==",
+      "dev": true
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {
@@ -22,6 +22,7 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
+    "@bbc/psammead-storybook-helpers": "^1.0.0",
     "@bbc/psammead-test-helpers": "^0.3.3"
   },
   "keywords": [

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { inputProvider } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import { Headline, SubHeading } from './index';
 
-storiesOf('Headline', module).add(
-  'default',
-  () => <Headline>This is my headline.</Headline>,
-  { notes },
-);
+storiesOf('Headline', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    inputProvider(['headline'], headline => <Headline>{headline}</Headline>),
+    { notes, knobs: { escapeHTML: false } },
+  );
 
-storiesOf('SubHeading', module).add(
-  'default',
-  () => (
-    <SubHeading text="This is a SubHeading">This is a SubHeading</SubHeading>
-  ),
-  { notes },
-);
+storiesOf('SubHeading', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    inputProvider(['subheading'], subheader => (
+      <SubHeading text={subheader}>{subheader}</SubHeading>
+    )),
+    { notes, knobs: { escapeHTML: false } },
+  );


### PR DESCRIPTION
Relates to #331, #370 

**Overall change:** Adds the support for examining Psammead components' behaviour
in the different language services

**Code changes:**

-  Updates stories for the psammead-headings (Headline and SubHeading) components to use the psammead-storybook-helpers utility `inputProvider`


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval