### PR TITLE
Add language variants knob to Inline Link stories

### DIFF
--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.6   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Inline Link stories |
+| 0.3.6   | [PR#419](https://github.com/bbc/psammead/pull/419) Add language variants knob to Inline Link stories |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.4   | [PR#371](https://github.com/bbc/psammead/pull/371) Update colour from Shadow to Ebon |
 | 0.3.3   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.6   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Inline Link stories |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.4   | [PR#371](https://github.com/bbc/psammead/pull/371) Update colour from Shadow to Ebon |
 | 0.3.3   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,6 +32,12 @@
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bbc/psammead-storybook-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-1.0.0.tgz",
+      "integrity": "sha512-2JSrr/zA3HBbR/kOuOkONir8e/iePeN1InNEHKnjsriyOqcUnIUhJ7sdCjdAI0m/7cD/HwB0DAvipW/4+kHCNQ==",
+      "dev": true
     },
     "@bbc/psammead-styles": {
       "version": "0.2.1",

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "repository": {
@@ -26,6 +26,7 @@
     "@bbc/psammead-styles": "^0.2.1"
   },
   "devDependencies": {
+    "@bbc/psammead-storybook-helpers": "^1.0.0",
     "@bbc/psammead-test-helpers": "^0.3.0",
     "react": "^16.6.3",
     "styled-components": "^4.1.3"

--- a/packages/components/psammead-inline-link/src/index.stories.jsx
+++ b/packages/components/psammead-inline-link/src/index.stories.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { inputProvider } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import InlineLink from './index';
 
-storiesOf('InlineLink', module).add(
-  'default',
-  () => <InlineLink href="https://www.bbc.com/news">BBC News</InlineLink>,
-  { notes },
-);
+storiesOf('InlineLink', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    inputProvider(['link text'], linkText => (
+      <InlineLink href="https://www.bbc.com/news">{linkText}</InlineLink>
+    )),
+    { notes, knobs: { escapeHTML: false } },
+  );


### PR DESCRIPTION
Relates to #331, #370 

**Overall change:** Adds the support for examining Psammead components' behaviour
in the different language services

**Code changes:**

-  Updates stories for the psammead-inline-link component to use the psammead-storybook-helpers utility `inputProvider`


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval