### PR TITLE
Add language variants knob to Paragraph stories

### DIFF
--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.3.5   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Paragraph stories |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#392](https://github.com/bbc/psammead/pull/392) Increase padding-bottom from 16px to 24px |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.5   | [PR#???](https://github.com/bbc/psammead/pull/???) Add language variants knob to Paragraph stories |
+| 0.3.5   | [PR#420](https://github.com/bbc/psammead/pull/420) Add language variants knob to Paragraph stories |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#392](https://github.com/bbc/psammead/pull/392) Increase padding-bottom from 16px to 24px |
 | 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -37,6 +37,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
       "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
+    },
+    "@bbc/psammead-storybook-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-1.0.0.tgz",
+      "integrity": "sha512-2JSrr/zA3HBbR/kOuOkONir8e/iePeN1InNEHKnjsriyOqcUnIUhJ7sdCjdAI0m/7cD/HwB0DAvipW/4+kHCNQ==",
+      "dev": true
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {
@@ -26,6 +26,7 @@
     "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {
+    "@bbc/psammead-storybook-helpers": "^1.0.0",
     "@bbc/psammead-test-helpers": "^0.3.3",
     "react": "^16.6.3",
     "styled-components": "^4.1.3"

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -12,5 +12,5 @@ storiesOf('Paragraph', module)
     inputProvider(['paragraph'], paragraph => (
       <Paragraph>{paragraph}</Paragraph>
     )),
-    { notes },
+    { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { inputProvider } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import Paragraph from './index';
 
-storiesOf('Paragraph', module).add(
-  'default',
-  () => <Paragraph>This is text in a paragraph.</Paragraph>,
-  { notes },
-);
+storiesOf('Paragraph', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    inputProvider(['paragraph'], paragraph => (
+      <Paragraph>{paragraph}</Paragraph>
+    )),
+    { notes },
+  );


### PR DESCRIPTION
Relates to #331, #370 

**Overall change:** Adds the support for examining Psammead components' behaviour
in the different language services

**Code changes:**

-  Updates stories for the psammead-paragraph component to use the psammead-storybook-helpers utility `inputProvider`


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval