### PR TITLE
Add new typography method in Headings component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8284,20 +8284,20 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -8315,13 +8315,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -8338,32 +8338,32 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -8380,21 +8380,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -8404,14 +8404,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -8443,7 +8443,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -8460,7 +8460,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -8470,7 +8470,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -8481,20 +8481,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -8503,14 +8503,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -8519,7 +8519,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
@@ -8545,7 +8545,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -8554,7 +8554,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
@@ -8592,7 +8592,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -8621,7 +8621,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -8634,20 +8634,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -8656,21 +8656,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -8681,14 +8681,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -8708,7 +8708,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -8717,7 +8717,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -8749,14 +8749,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -8770,21 +8770,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -8795,7 +8795,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8805,7 +8805,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8814,7 +8814,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8837,7 +8837,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8854,7 +8854,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#421](https://github.com/bbc/psammead/pull/421) Add support for different scripts typographies |
 | 0.4.2   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.4.1   | [PR#381](https://github.com/bbc/psammead/pull/381) Make SubHeading padding-top 32px when viewport 400px and above |
 | 0.4.0   | [PR#381](https://github.com/bbc/psammead/pull/381) Make headline 40px for 600px and above |

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -12,17 +12,18 @@ The Headings are a set of two components, `Headline` and `SubHeading`. They use 
 
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
-| No props. |      |          |         |         |
+| Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 ## Usage
 
 ```jsx
 import { Headline, SubHeading } from '@bbc/psammead-headings';
+import { latin } from '@bbc/gel-foundations/scripts';
 
 const Wrapper = () => (
   <Fragment>
-    <Heading>Some headline</Heading>
-    <SubHeading>Some subheadline</SubHeading>
+    <Heading script={latin}>Some headline</Heading>
+    <SubHeading script={latin}>Some subheadline</SubHeading>
   </Fragment>
 );
 ```

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
-      "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
+      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
     },
     "@bbc/psammead-styles": {
       "version": "0.3.2",

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^0.3.0",
+    "@bbc/gel-foundations": "^1.0.0",
     "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`Headline component should render correctly with arabic script typograph
 <h1
   className="c0"
 >
-  This is my headline.
+  هذا هو العنوان الخاص بي
 </h1>
 `;
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -2,19 +2,13 @@
 
 exports[`Headline component should render correctly 1`] = `
 .c0 {
+  font-size: 1.75rem;
+  line-height: 2rem;
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 2rem 0;
   font-weight: 500;
-  font-size: 1.75rem;
-  line-height: 2rem;
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding: 2.5rem 0;
-  }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -31,6 +25,12 @@ exports[`Headline component should render correctly 1`] = `
   }
 }
 
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 2.5rem 0;
+  }
+}
+
 <h1
   className="c0"
 >
@@ -40,19 +40,13 @@ exports[`Headline component should render correctly 1`] = `
 
 exports[`SubHeading component attribute id should render without double quotes 1`] = `
 .c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 700;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -66,6 +60,12 @@ exports[`SubHeading component attribute id should render without double quotes 1
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 
@@ -80,19 +80,13 @@ exports[`SubHeading component attribute id should render without double quotes 1
 
 exports[`SubHeading component attribute id should render without exclamation marks 1`] = `
 .c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 700;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -106,6 +100,12 @@ exports[`SubHeading component attribute id should render without exclamation mar
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 
@@ -120,19 +120,13 @@ exports[`SubHeading component attribute id should render without exclamation mar
 
 exports[`SubHeading component attribute id should render without quotes 1`] = `
 .c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 700;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -146,6 +140,12 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 
@@ -160,19 +160,13 @@ exports[`SubHeading component attribute id should render without quotes 1`] = `
 
 exports[`SubHeading component should render correctly 1`] = `
 .c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   color: #3F3F42;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 1rem 0;
   font-weight: 700;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -186,6 +180,12 @@ exports[`SubHeading component should render correctly 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -38,6 +38,44 @@ exports[`Headline component should render correctly 1`] = `
 </h1>
 `;
 
+exports[`Headline component should render correctly with arabic script typography values 1`] = `
+.c0 {
+  font-size: 2rem;
+  line-height: 2.625rem;
+  color: #3F3F42;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 2rem 0;
+  font-weight: 500;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 2.25rem;
+    line-height: 2.875rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2.75rem;
+    line-height: 3.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 2.5rem 0;
+  }
+}
+
+<h1
+  className="c0"
+>
+  This is my headline.
+</h1>
+`;
+
 exports[`SubHeading component attribute id should render without double quotes 1`] = `
 .c0 {
   font-size: 1.25rem;
@@ -195,5 +233,45 @@ exports[`SubHeading component should render correctly 1`] = `
   tabIndex="-1"
 >
   This is a SubHeading
+</h2>
+`;
+
+exports[`SubHeading component should render correctly with arabic script typography values 1`] = `
+.c0 {
+  font-size: 1.5rem;
+  line-height: 2.125rem;
+  color: #3F3F42;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 1rem 0;
+  font-weight: 700;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.625rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2.375rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding-top: 2rem;
+  }
+}
+
+<h2
+  className="c0"
+  id="-"
+  tabIndex="-1"
+>
+  هذا عنوان فرعي
 </h2>
 `;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
+import { objectOf, object } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING_DBL,
   GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
 import {
-  GEL_CANON,
-  GEL_TRAFALGAR,
+  getCanon,
+  getTrafalgar,
   GEL_FF_REITH_SANS,
   GEL_FF_REITH_SERIF,
 } from '@bbc/gel-foundations/typography';
@@ -16,6 +17,7 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 
 export const Headline = styled.h1`
+  ${props => (props.script ? getCanon(props.script) : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
@@ -24,7 +26,6 @@ export const Headline = styled.h1`
     padding: 2.5rem 0;
   }
   font-weight: 500;
-  ${GEL_CANON};
 `;
 
 const regexPunctuationSymbols = /[^a-z0-9\s-]/gi;
@@ -34,6 +35,7 @@ export const SubHeading = styled.h2.attrs(({ text }) => ({
   id: text.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-'),
   tabIndex: '-1',
 }))`
+  ${props => (props.script ? getTrafalgar(props.script) : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SANS};
   margin: 0; /* Reset */
@@ -42,5 +44,12 @@ export const SubHeading = styled.h2.attrs(({ text }) => ({
     padding-top: ${GEL_SPACING_QUAD};
   }
   font-weight: 700;
-  ${GEL_TRAFALGAR};
 `;
+
+Headline.defaultProps = {
+  script: objectOf(object).required,
+};
+
+SubHeading.defaultProps = {
+  script: objectOf(object).required,
+};

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { latin } from '@bbc/gel-foundations/scripts';
 import notes from '../README.md';
 import { Headline, SubHeading } from './index';
 
 storiesOf('Headline', module).add(
   'default',
-  () => <Headline>This is my headline.</Headline>,
+  () => <Headline script={latin}>This is my headline.</Headline>,
   { notes },
 );
 
 storiesOf('SubHeading', module).add(
   'default',
   () => (
-    <SubHeading text="This is a SubHeading">This is a SubHeading</SubHeading>
+    <SubHeading text="This is a SubHeading" script={latin}>
+      This is a SubHeading
+    </SubHeading>
   ),
   { notes },
 );

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { latin } from '@bbc/gel-foundations/scripts';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
 import { Headline, SubHeading } from './index';
 
 describe('Headline component', () => {
   shouldMatchSnapshot(
     'should render correctly',
     <Headline script={latin}>This is my headline.</Headline>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with arabic script typography values',
+    <Headline script={arabic}>This is my headline.</Headline>,
   );
 });
 
@@ -36,6 +41,13 @@ describe('SubHeading component', () => {
     'attribute id should render without exclamation marks',
     <SubHeading text="This is! a SubHeading!" script={latin}>
       This is a SubHeading
+    </SubHeading>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with arabic script typography values',
+    <SubHeading text="هذا عنوان فرعي" script={arabic}>
+      هذا عنوان فرعي
     </SubHeading>,
   );
 });

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -11,7 +11,7 @@ describe('Headline component', () => {
 
   shouldMatchSnapshot(
     'should render correctly with arabic script typography values',
-    <Headline script={arabic}>This is my headline.</Headline>,
+    <Headline script={arabic}>هذا هو العنوان الخاص بي</Headline>,
   );
 });
 

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -1,32 +1,41 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { latin } from '@bbc/gel-foundations/scripts';
 import { Headline, SubHeading } from './index';
 
 describe('Headline component', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <Headline>This is my headline.</Headline>,
+    <Headline script={latin}>This is my headline.</Headline>,
   );
 });
 
 describe('SubHeading component', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <SubHeading text="This is a SubHeading">This is a SubHeading</SubHeading>,
+    <SubHeading text="This is a SubHeading" script={latin}>
+      This is a SubHeading
+    </SubHeading>,
   );
 
   shouldMatchSnapshot(
     'attribute id should render without quotes',
-    <SubHeading text="This 'is' a SubHeading">This is a SubHeading</SubHeading>,
+    <SubHeading text="This 'is' a SubHeading" script={latin}>
+      This is a SubHeading
+    </SubHeading>,
   );
 
   shouldMatchSnapshot(
     'attribute id should render without double quotes',
-    <SubHeading text='This "is" a SubHeading'>This is a SubHeading</SubHeading>,
+    <SubHeading text='This "is" a SubHeading' script={latin}>
+      This is a SubHeading
+    </SubHeading>,
   );
 
   shouldMatchSnapshot(
     'attribute id should render without exclamation marks',
-    <SubHeading text="This is! a SubHeading!">This is a SubHeading</SubHeading>,
+    <SubHeading text="This is! a SubHeading!" script={latin}>
+      This is a SubHeading
+    </SubHeading>,
   );
 });


### PR DESCRIPTION
Resolves #343

**Overall change:** 
Add support to allow the `Headings` component to use Typography Type Sizes for different scripts

**Code changes:**

- Allow the component to pass the script name a prop
- Add `propTypes` to require a `script` prop
- Remove previous `GEL_CANON` and `GEL_TRAFALGAR` imports
- Import new `getCanon` and `getTrafalgar` methods which make use of the new `getTypeSizes()` method to get the appropriate GEL Type Sizes for the component.
- Import `latin.js` script with the default typography GEL Types Sizes in the stories and unit test
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval