### PR TITLE
Add custom scripts propTypes in gel-foundations

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.2.0   | [PR#431](https://github.com/bbc/psammead/pull/431) Add custom scripts propTypes |
 | 1.1.0   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.0   | [PR#353](https://github.com/BBC/psammead/pull/353) Add support for different scripts typographies |
 | 0.3.0   | [PR#360](https://github.com/BBC/psammead/pull/360) Move to using rems for breakpoints |

--- a/packages/utilities/gel-foundations/index.test.jsx
+++ b/packages/utilities/gel-foundations/index.test.jsx
@@ -1,10 +1,12 @@
 import { testUtilityPackages } from '@bbc/psammead-test-helpers';
 import * as spacings from './spacings';
 import * as breakpoints from './breakpoints';
+import * as propTypes from './prop-types';
 import * as typography from './typography';
 import * as scripts from './scripts';
 import * as spacingsFromSrc from './src/spacings';
 import * as breakpointsFromSrc from './src/breakpoints';
+import * as propTypesFromSrc from './src/prop-types';
 import * as typographyFromSrc from './src/typography';
 import * as scriptsFromSrc from './src/scripts';
 
@@ -37,6 +39,11 @@ const breakpointsExpectedExports = {
   GEL_GROUP_4_SCREEN_WIDTH_MAX: 'string',
   GEL_GROUP_5_SCREEN_WIDTH_MIN: 'string',
   MEDIA_QUERY_TYPOGRAPHY: 'object',
+};
+
+const propTypesExpectedExports = {
+  scriptPropType: 'object',
+  default: 'object',
 };
 
 const typographyExpectedExports = {
@@ -97,6 +104,7 @@ const scriptsExpectedExports = {
 const expectedExports = {
   spacings: spacingsExpectedExports,
   breakpoints: breakpointsExpectedExports,
+  propTypes: propTypesExpectedExports,
   typography: typographyExpectedExports,
   scripts: scriptsExpectedExports,
 };
@@ -104,6 +112,7 @@ const expectedExports = {
 const actualExports = {
   spacings,
   breakpoints,
+  propTypes,
   typography,
   scripts,
 };
@@ -111,6 +120,7 @@ const actualExports = {
 const actualExportsFromSrc = {
   spacings: spacingsFromSrc,
   breakpoints: breakpointsFromSrc,
+  propTypes: propTypesFromSrc,
   typography: typographyFromSrc,
   scripts: scriptsFromSrc,
 };

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {
     "type": "git",

--- a/packages/utilities/gel-foundations/prop-types.js
+++ b/packages/utilities/gel-foundations/prop-types.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/prop-types'); // eslint-disable-line import/no-unresolved

--- a/packages/utilities/gel-foundations/src/prop-types.js
+++ b/packages/utilities/gel-foundations/src/prop-types.js
@@ -1,0 +1,4 @@
+/* eslint-disable global-require */
+module.exports = {
+  scriptPropType: require('../dist/propTypes/scripts').default,
+};

--- a/packages/utilities/gel-foundations/src/propTypes/scripts/groups.js
+++ b/packages/utilities/gel-foundations/src/propTypes/scripts/groups.js
@@ -1,0 +1,10 @@
+import { shape } from 'prop-types';
+import sizesPropTypes from './sizes';
+
+const groupPropTypes = {
+  groupA: shape(sizesPropTypes).isRequired,
+  groupB: shape(sizesPropTypes).isRequired,
+  groupD: shape(sizesPropTypes).isRequired,
+};
+
+export default groupPropTypes;

--- a/packages/utilities/gel-foundations/src/propTypes/scripts/index.js
+++ b/packages/utilities/gel-foundations/src/propTypes/scripts/index.js
@@ -1,0 +1,22 @@
+import { shape } from 'prop-types';
+import groupPropTypes from './groups';
+
+const scriptPropTypes = {
+  canon: shape(groupPropTypes).isRequired,
+  trafalgar: shape(groupPropTypes).isRequired,
+  paragon: shape(groupPropTypes).isRequired,
+  doublePica: shape(groupPropTypes).isRequired,
+  greatPrimer: shape(groupPropTypes).isRequired,
+  bodyCopy: shape(groupPropTypes).isRequired,
+  pica: shape(groupPropTypes).isRequired,
+  longPrimer: shape(groupPropTypes).isRequired,
+  brevier: shape(groupPropTypes).isRequired,
+  minion: shape(groupPropTypes).isRequired,
+  atlas: shape(groupPropTypes),
+  elephant: shape(groupPropTypes),
+  imperial: shape(groupPropTypes),
+  royal: shape(groupPropTypes),
+  foolscap: shape(groupPropTypes),
+};
+
+export default scriptPropTypes;

--- a/packages/utilities/gel-foundations/src/propTypes/scripts/sizes.js
+++ b/packages/utilities/gel-foundations/src/propTypes/scripts/sizes.js
@@ -1,0 +1,8 @@
+import { string } from 'prop-types';
+
+const sizesPropTypes = {
+  fontSize: string.isRequired,
+  lineHeight: string.isRequired,
+};
+
+export default sizesPropTypes;


### PR DESCRIPTION
Resolves #425

**Overall change:** 
Following the discussion in this [PR](https://github.com/bbc/psammead/pull/428) we decided to add the custom `propTypes` definition for the scripts inside the `gel-foundations` package.

**Code changes:**
- Add `index`, `groups` and `sizes` files containing the current shape of the `scripts`
- Load `propTypes` dynamically using threesaking

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Tests added for new features
- [ ] Test engineer approval