### PR TITLE
Alphabetise text variants

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.1.1   | [PR#???](https://github.com/bbc/psammead/pull/???) Alphabetise text variants by language |
 | 1.1.0   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.0   | [PR#378](https://github.com/bbc/psammead/pull/378) Create initial package, pulled in from [psammead](https://github.com/BBC-News/psammead/blob/latest/CONTRIBUTING.md). |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.1.1   | [PR#???](https://github.com/bbc/psammead/pull/???) Alphabetise text variants by language |
+| 1.1.1   | [PR#432](https://github.com/bbc/psammead/pull/432) Alphabetise text variants by language |
 | 1.1.0   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.0   | [PR#378](https://github.com/bbc/psammead/pull/378) Create initial package, pulled in from [psammead](https://github.com/BBC-News/psammead/blob/latest/CONTRIBUTING.md). |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "description": "A collection of common values that are used in storybook by the Psammead components.",
   "repository": {

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -4,68 +4,68 @@ const LANGUAGE_VARIANTS = {
   Afrique:
     'La police surveille le cimetière de Christchurch où sont enterrées les premières victimes de la tuerie.',
   Amharic: 'አቶ ባትሪ ለማ እና አቶ ደቻሳ ጉተማ',
-  English: 'Kepler telescope discovers 100 Earth-sized planets',
-  Gahuza:
-    'Abashika 100.000 ntawuzi irengero ryabo, abandi ibihumbi nabo ntibagira aho bakika umusaya',
-  Hausa: 'Bayanin Ganduje kan ayyukan Gama',
-  Igbo:
-    "Trade Fair: Ọ bụrụgodi na gọọmenti etiti chọrọ ire ọdọ ahịa a, ndị Igbo ga-egonwu ya'",
-  Pidgin:
-    'Di Nigeria Army don set up 9 man Committee to chook eye inside how dia men conduct demsef during di 2019 General Elections.',
-  Somali: 'Qaar ka mid ah dadkii laga soo badbaadiyay Hotel Dusit2 ee Nairobi',
-  Swahili:
-    'Kimbunga Idai: ‘Watu milioni 1.7 wapo katika njia kuu’ ya kimbunga Msumbiji, Zimbabwe',
-  Tigrinya: 'ዓብዱራሕማን ኣቡሃሽም',
-  Yoruba: 'Wo àwọn òrílẹ̀ èdè Mẹ́wàá tó láyọ̀ jùlọ Lágbàyé',
-  Kyrgyz: 'Казакстан Назарбаевден башка президентти көрө элек',
-  Uzbek:
-    'Дариға Назарбоева Қозоғистон президентининг Британияга охирги сафарида отасига ҳамроҳлик қилган',
+  Arabic:
+    'المحكمة العليا الأمريكية ذات الأغلبية المحافظة وافقت على احتجاز غير المواطنين لأجل غير مسمى حتى بعد سنوات من خروجهم من السجن',
+  Azeri:
+    'Qazaxıstan prezidenti vəzifələrini icra edəcək Kasım-Comərt Tokayev and içib',
+  Bengali: 'পাসওয়ার্ড হতে হবে খুব শক্ত যাতে কেউ সেটা ভাঙতে না পারে',
+  Brasil:
+    'Medidas anunciadas no encontro entre Bolsonaro e Trump celebram aproximação com o governo americano - mas elas agora precisam passar pelo teste da concretização',
   Burmese: 'အောက်စဖို့ဒ် ဆရာတော် ပါမောက္ခ ဒေါက်တာအရှင်ဓမ္မသာမိ',
   ChineseSimp: '家长们在学校门口维权。',
   ChineseTrad: '家長們在學校門口維權。',
+  English: 'Kepler telescope discovers 100 Earth-sized planets',
+  Gahuza:
+    'Abashika 100.000 ntawuzi irengero ryabo, abandi ibihumbi nabo ntibagira aho bakika umusaya',
+  Gujarati: 'જીતેન્દ્રસિંહ મૂળ ઉત્તર પ્રદેશના ફિરોઝાબાદના',
+  Hausa: 'Bayanin Ganduje kan ayyukan Gama',
+  Hindi: 'जय शाह',
+  Igbo:
+    "Trade Fair: Ọ bụrụgodi na gọọmenti etiti chọrọ ire ọdọ ahịa a, ndị Igbo ga-egonwu ya'",
   Indonesian:
     '"Apa yang terjadi di Selandia Baru adalah kekerasan yang dibawa oleh seseorang yang tumbuh dan belajar ideologinya di tempat lain,\' kata Jacinda Ardern.',
   Japanese: '度目の採決認めなかった理由は？ 英下院議長に取材',
   Korean: '마이크 폼페이오 미국 국무장관',
+  Kyrgyz: 'Казакстан Назарбаевден башка президентти көрө элек',
+  Marathi: 'नीरव मोदी',
+  Mundo:
+    'La caída en los precios de la vivienda ha hecho que algunas personas puedan comprar en zonas acomodadas de la ciudad.',
+  Nepali: 'हेमन्तप्रकाश मल्ल',
+  Pashto:
+    'د ملګرو ملتونو د ماشومانو ادارې یونیسف افغان کرېکټ لوبغاړی راشد خان په افغانستان کې د ښه نیست ملي سفیر وټاکه.',
+  Persian:
+    'در این جشنواره برای نخستین بار از کارگران افغانستان در شهر تهران تقدیر شد',
+  Pidgin:
+    'Di Nigeria Army don set up 9 man Committee to chook eye inside how dia men conduct demsef during di 2019 General Elections.',
+  Punjabi:
+    'ਪਾਕਿਸਤਾਨੀ ਮਹਿਲਾ ਰਾਹਿਲਾ ਨੇ ਭਾਰਤੀ ਵਕੀਲ ਜ਼ਰੀਏ ਅਦਾਲਤ ਵਿੱਚ ਦਿੱਤੀ ਅਰਜ਼ੀ ਵਿੱਚ ਕਿਹਾ ਕਿ ਮਾਮਲੇ ਨਾਲ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ',
+  Russian:
+    'Мнение Назарбаева будет иметь приоритетное значение при принятии важных для страны решений, сказал Токаев',
+  SerbianCyr: 'Караџић се годинама крио пре него што је ухапшен 2008. године',
+  SerbianLat: 'Karadžić se godinama krio pre nego što je uhapšen 2008. godine',
+  Sinhala: 'සිවිල් යුද ගැටුම් හමුවේ කොටු වී සිටි සිවිල් වැසියන්',
+  Somali: 'Qaar ka mid ah dadkii laga soo badbaadiyay Hotel Dusit2 ee Nairobi',
+  Swahili:
+    'Kimbunga Idai: ‘Watu milioni 1.7 wapo katika njia kuu’ ya kimbunga Msumbiji, Zimbabwe',
+  Tamil: 'நீரவ் மோதி',
+  Telugu:
+    'నల్లగొండ ఫ్లోరైడ్ సమస్య గురించి నాటి ప్రధాని అటల్ బిహారీ వాజపేయికి దుశ్చర్ల సత్యనారాయణ వివరించారు',
   Thai: 'ภาพวาดของตำรวจจากใบหน้าผู้เสียชีวิต',
+  Tigrinya: 'ዓብዱራሕማን ኣቡሃሽም',
+  Turkish:
+    'Kassım Jomart Tokayev, parlamentoda yemin ederek devlet başkanlığı görevini resmen devraldı.',
   UKChinaSimp:
     '该计划的批评者说，这个政策不能解决住房短缺的问题（Credit: Alamy）',
   UKChinaTrad:
     '該計劃的批評者說，這個政策不能解決住房短缺的問題（Credit: Alamy）',
-  Vietnamese: 'Ông Nazarbayev bất ngờ tuyên bố từ chức hôm 19/3/2019',
-  Bengali: 'পাসওয়ার্ড হতে হবে খুব শক্ত যাতে কেউ সেটা ভাঙতে না পারে',
-  Gujarati: 'જીતેન્દ્રસિંહ મૂળ ઉત્તર પ્રદેશના ફિરોઝાબાદના',
-  Hindi: 'जय शाह',
-  Marathi: 'नीरव मोदी',
-  Nepali: 'हेमन्तप्रकाश मल्ल',
-  Pashto:
-    'د ملګرو ملتونو د ماشومانو ادارې یونیسف افغان کرېکټ لوبغاړی راشد خان په افغانستان کې د ښه نیست ملي سفیر وټاکه.',
-  Punjabi:
-    'ਪਾਕਿਸਤਾਨੀ ਮਹਿਲਾ ਰਾਹਿਲਾ ਨੇ ਭਾਰਤੀ ਵਕੀਲ ਜ਼ਰੀਏ ਅਦਾਲਤ ਵਿੱਚ ਦਿੱਤੀ ਅਰਜ਼ੀ ਵਿੱਚ ਕਿਹਾ ਕਿ ਮਾਮਲੇ ਨਾਲ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ',
-  Sinhala: 'සිවිල් යුද ගැටුම් හමුවේ කොටු වී සිටි සිවිල් වැසියන්',
-  Tamil: 'நீரவ் மோதி',
-  Telugu:
-    'నల్లగొండ ఫ్లోరైడ్ సమస్య గురించి నాటి ప్రధాని అటల్ బిహారీ వాజపేయికి దుశ్చర్ల సత్యనారాయణ వివరించారు',
-  Urdu:
-    'وزیر اعظم جاسنڈا آرڈرن کا کہنا ہے کہ حملہ آور کا نام کسی واچ لسٹ پر نہیں تھا، نہ آسٹریلیا میں اور نہ ہی کہیں اور',
-  Azeri:
-    'Qazaxıstan prezidenti vəzifələrini icra edəcək Kasım-Comərt Tokayev and içib',
-  Russian:
-    'Мнение Назарбаева будет иметь приоритетное значение при принятии важных для страны решений, сказал Токаев',
-  SerbianLat: 'Karadžić se godinama krio pre nego što je uhapšen 2008. godine',
-  SerbianCyr: 'Караџић се годинама крио пре него што је ухапшен 2008. године',
-  Turkish:
-    'Kassım Jomart Tokayev, parlamentoda yemin ederek devlet başkanlığı görevini resmen devraldı.',
   Ukrainian:
     "Олег Ляшко був традиційно емоційним, говорив на підвищених тонах. Прем'єр спочатку нервував, проте швидко опанував ситуацію.",
-  Brasil:
-    'Medidas anunciadas no encontro entre Bolsonaro e Trump celebram aproximação com o governo americano - mas elas agora precisam passar pelo teste da concretização',
-  Mundo:
-    'La caída en los precios de la vivienda ha hecho que algunas personas puedan comprar en zonas acomodadas de la ciudad.',
-  Arabic:
-    'المحكمة العليا الأمريكية ذات الأغلبية المحافظة وافقت على احتجاز غير المواطنين لأجل غير مسمى حتى بعد سنوات من خروجهم من السجن',
-  Persian:
-    'در این جشنواره برای نخستین بار از کارگران افغانستان در شهر تهران تقدیر شد',
+  Urdu:
+    'وزیر اعظم جاسنڈا آرڈرن کا کہنا ہے کہ حملہ آور کا نام کسی واچ لسٹ پر نہیں تھا، نہ آسٹریلیا میں اور نہ ہی کہیں اور',
+  Uzbek:
+    'Дариға Назарбоева Қозоғистон президентининг Британияга охирги сафарида отасига ҳамроҳлик қилган',
+  Vietnamese: 'Ông Nazarbayev bất ngờ tuyên bố từ chức hôm 19/3/2019',
+  Yoruba: 'Wo àwọn òrílẹ̀ èdè Mẹ́wàá tó láyọ̀ jùlọ Lágbàyé',
 };
 
 export default LANGUAGE_VARIANTS;


### PR DESCRIPTION
Resolves #426

**Overall change:** Updates the list of text variants in `psammead-storybook-helpers` to be sorted in alphabetical order by language name.

**Code changes:**

- Sorted the list of text variants.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval