### PR TITLE
Add custom propTypes shape to Caption and Paragraph components

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,22 +3,22 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.1   | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
-| 1.1.0   | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
-| 1.0.1   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
-| 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
-| 0.3.5   | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
-| 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
-| 0.3.3   | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
-| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
-| 0.3.1   | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
-| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
-| 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
-| 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
-| 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.1.5   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
-| 0.1.4   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
-| 0.1.3   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
-| 0.1.2   | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
-| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
-| 0.1.0   | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |
+| 1.1.1 | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
+| 1.1.0 | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
+| 1.0.1 | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
+| 1.0.0 | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
+| 0.3.5 | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
+| 0.3.4 | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
+| 0.3.3 | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
+| 0.3.2 | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.1 | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
+| 0.3.0 | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
+| 0.2.1 | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
+| 0.2.0 | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
+| 0.1.6 | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
+| 0.1.5 | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
+| 0.1.4 | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
+| 0.1.3 | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
+| 0.1.2 | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
+| 0.1.1 | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.0 | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-<<<<<<< HEAD
+| 1.0.2   | [PR#](https://github.com/bbc/psammead/pull/) Add custom propTypes shape |
 | 1.0.1   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
 | 0.3.5   | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,22 +3,22 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.1 | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
-| 1.1.0 | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
-| 1.0.1 | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
-| 1.0.0 | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
-| 0.3.5 | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
-| 0.3.4 | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
-| 0.3.3 | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
-| 0.3.2 | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
-| 0.3.1 | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
-| 0.3.0 | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
-| 0.2.1 | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
-| 0.2.0 | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
-| 0.1.6 | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.1.5 | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
-| 0.1.4 | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
-| 0.1.3 | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
-| 0.1.2 | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
-| 0.1.1 | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
-| 0.1.0 | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |
+| 1.1.1   | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
+| 1.1.0   | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
+| 1.0.1   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
+| 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
+| 0.3.5   | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
+| 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
+| 0.3.3   | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.1   | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
+| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
+| 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
+| 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
+| 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
+| 0.1.5   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
+| 0.1.4   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
+| 0.1.3   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
+| 0.1.2   | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.0   | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.2   | [PR#](https://github.com/bbc/psammead/pull/) Add custom propTypes shape |
+| 1.0.2   | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
 | 1.0.1   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
 | 0.3.5   | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
-      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.2.0.tgz",
+      "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ=="
     },
     "@bbc/psammead-inline-link": {
       "version": "0.3.4",

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^1.0.0",
+    "@bbc/gel-foundations": "^1.2.0",
     "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { objectOf, object } from 'prop-types';
+import { shape } from 'prop-types';
 import {
   GEL_SPACING,
   GEL_MARGIN_ABOVE_400PX,
@@ -16,6 +16,7 @@ import {
 } from '@bbc/gel-foundations/typography';
 
 import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
+import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
 // Defined separately since in future will need to apply
 // only when the script supports italic text
@@ -39,7 +40,7 @@ const Caption = styled.figcaption`
 `;
 
 Caption.propTypes = {
-  script: objectOf(object).required,
+  script: shape(scriptPropType).isRequired,
 };
 
 export default Caption;

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -14,7 +14,6 @@ import {
   getLongPrimer,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
-
 import { C_CLOUD_DARK } from '@bbc/psammead-styles/colours';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 

--- a/packages/components/psammead-caption/src/index.stories.jsx
+++ b/packages/components/psammead-caption/src/index.stories.jsx
@@ -22,7 +22,7 @@ storiesOf('Caption', module)
     inputProvider(
       ['visually hidden text', 'caption'],
       (hiddenText, captionText) => (
-        <Caption>
+        <Caption script={latin}>
           <VisuallyHiddenText>{hiddenText}</VisuallyHiddenText>
           {captionText}
         </Caption>

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.3   | [PR#](https://github.com/bbc/psammead/pull/) Add custom propTypes shape |
 | 1.0.2   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.1   | [PR#420](https://github.com/bbc/psammead/pull/420) Add language variants knob to Paragraph stories |
 | 1.0.0   | [PR#414](https://github.com/bbc/psammead/pull/414) Add support for different scripts typographies |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.3   | [PR#](https://github.com/bbc/psammead/pull/) Add custom propTypes shape |
+| 1.0.3   | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
 | 1.0.2   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 1.0.1   | [PR#420](https://github.com/bbc/psammead/pull/420) Add language variants knob to Paragraph stories |
 | 1.0.0   | [PR#414](https://github.com/bbc/psammead/pull/414) Add support for different scripts typographies |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.0.0.tgz",
-      "integrity": "sha512-u/tsowYXoMaiyt3pxKoqZpqepxyx9cNPqwRtV1GzuIvpaWt3fP5uWdS0+HNocRpSxhpSNrhYaSCEufWcS+Tt/A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.2.0.tgz",
+      "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "1.0.0",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^1.0.0",
+    "@bbc/gel-foundations": "^1.2.0",
     "@bbc/psammead-styles": "^0.3.2"
   },
   "devDependencies": {

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
-import { objectOf, object } from 'prop-types';
+import { shape } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import {
   getBodyCopy,
   GEL_FF_REITH_SANS,
 } from '@bbc/gel-foundations/typography';
+import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
 const Paragraph = styled.p`
   ${props => (props.script ? getBodyCopy(props.script) : '')};
@@ -16,7 +17,7 @@ const Paragraph = styled.p`
 `;
 
 Paragraph.propTypes = {
-  script: objectOf(object).isRequired,
+  script: shape(scriptPropType).isRequired,
 };
 
 export default Paragraph;


### PR DESCRIPTION
Resolves #425

**Overall change:** 
We should be more restrictive about what script 'object' we allow to pass to the component.
For this reason, we should add a custom propType shape matching the current scripts values.

**Code changes:**
- Replace `defaultProps` with `propTypes` in the `Caption` and `Paragraph` components
- Import script `propType` shape from `gel-foundations`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval