### PR TITLE
Update Story promo headline to use Great Primer

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 0.1.1   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.1.1   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Update Story promo headline to use Great Primer. |
+| 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -16,8 +16,8 @@ exports[`StoryPromo should render correctly 1`] = `
 }
 
 .c3 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
@@ -60,15 +60,15 @@ exports[`StoryPromo should render correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c3 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c3 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -11,7 +11,7 @@ import {
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import {
-  getPica,
+  getGreatPrimer,
   getLongPrimer,
   GEL_FF_REITH_SERIF,
   GEL_FF_REITH_SANS,
@@ -49,7 +49,7 @@ const TextGridItem = styled.div`
 `;
 
 export const Headline = styled.h3`
-  ${props => (props.script ? getPica(props.script) : '')};
+  ${props => (props.script ? getGreatPrimer(props.script) : '')};
   color: ${C_SHADOW};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */


### PR DESCRIPTION
Resolves #473

**Overall change:** 
Update the story promo headline component to use Great Primer instead of Pica

**Code changes:**

- Replace `getPica` with `getGreatPrimer`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval