### PR TITLE
Set the correct slack channel name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def dockerRegistry = "329802642264.dkr.ecr.eu-west-1.amazonaws.com"
 def nodeImageVersion = "0.0.8"
 def nodeImage = "${dockerRegistry}/bbc-news/node-8-lts:${nodeImageVersion}"
 def nodeName
-def slackChannel = "#psammead"
+def slackChannel = "#si_repo-psammead"
 def stageName = "Unknown"
 def gitCommitAuthor = "Unknown"
 def gitCommitMessage = "Unknown"


### PR DESCRIPTION
Resolves Doesn't need a number 🗡 

**Overall change:** 

This PR sets the correct slack channel in the Jenkins file.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [ ] Test engineer approval