### PR TITLE
Pass an optional prop of 'id' to SubHeading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8638,7 +8638,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.0   | [PR#504](https://github.com/bbc/psammead/pull/504) Remove required text prop |
 | 1.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 1.1.2   | [PR#428](https://github.com/bbc/psammead/pull/428) Add custom propTypes shape |
 | 1.1.1   | [PR#412](https://github.com/bbc/psammead/pull/412) Make SubHeading padding-bottom 24px instead of 16px |

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 # psammead-headings - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-headings%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-headings%2Fpackage.json) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/headline--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-headings.svg)](https://www.npmjs.com/package/@bbc/psammead-headings) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description
@@ -10,9 +11,9 @@ The Headings are a set of two components, `Headline` and `SubHeading`. They use 
 
 ## Props
 
-| Argument | Type   | Required | Default | Example                                                                                                                                                                                                                                                                                                                  |
-| -------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Script   | object | yes      | latin   | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, } |
+| Argument  | Type | Required | Default | Example |
+| --------- | ---- | -------- | ------- | ------- |
+| Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 
 ## Usage
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -10,9 +10,9 @@ The Headings are a set of two components, `Headline` and `SubHeading`. They use 
 
 ## Props
 
-| Argument  | Type | Required | Default | Example |
-| --------- | ---- | -------- | ------- | ------- |
-| Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+| Argument | Type   | Required | Default | Example                                                                                                                                                                                                                                                                                                                  |
+| -------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Script   | object | yes      | latin   | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, } |
 
 ## Usage
 
@@ -28,17 +28,17 @@ const Wrapper = () => (
 );
 ```
 
-All `SubHeading` components can be used as page anchors, with their ID being generated from their text, with any whitespace replaced with hyphens. To take the above usage as an example:
+`SubHeading` components can be used as page anchors when passed an `id` prop. To take the above usage as an example:
 
-```
-<SubHeading>Some subheadline</SubHeading>
+```jsx
+<SubHeading id="some-subheadline">Some subheadline</SubHeading>
 ```
 
-This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#Some-subheadline`
+This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#some-subheadline`
 
 ### When to use this component
 
-These components can be used at any point on the page, however the `Headline` is designed to be used once at the top of the page. The `SubHeading` adds an `id` value to the `h2` which can be used as an anchor when referencing content.
+These components can be used at any point on the page, however the `Headline` is designed to be used once at the top of the page. The `SubHeading` takes an optional `id` value and passes it to the `h2` which can be used as an anchor when referencing content.
 
 <!-- ### When not to use this component -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -32,7 +32,7 @@ const Wrapper = () => (
 `SubHeading` components can be used as page anchors when passed an `id` prop. To take the above usage as an example:
 
 ```jsx
-<SubHeading id="some-subheadline">Some subheadline</SubHeading>
+<SubHeading id="some-subheadline" script={latin}>Some subheadline</SubHeading>
 ```
 
 This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#some-subheadline`

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "description": "React styled components for a Headline and SubHeading",
   "repository": {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -109,7 +109,6 @@ exports[`SubHeading component should render correctly 1`] = `
 
 <h2
   className="c0"
-  id={null}
   tabIndex="-1"
 >
   This is a SubHeading
@@ -189,7 +188,6 @@ exports[`SubHeading component should render correctly with arabic script typogra
 
 <h2
   className="c0"
-  id={null}
   tabIndex="-1"
 >
   هذا عنوان فرعي

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -76,127 +76,47 @@ exports[`Headline component should render correctly with arabic script typograph
 </h1>
 `;
 
-exports[`SubHeading component attribute id should render without double quotes 1`] = `
-.c0 {
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-  color: #3F3F42;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  margin: 0;
-  padding: 1.5rem 0;
-  font-weight: 700;
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c0 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    font-size: 2rem;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
-}
-
-<h2
-  className="c0"
-  id="This-is-a-SubHeading"
-  tabIndex="-1"
->
-  This is a SubHeading
-</h2>
-`;
-
-exports[`SubHeading component attribute id should render without exclamation marks 1`] = `
-.c0 {
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-  color: #3F3F42;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  margin: 0;
-  padding: 1.5rem 0;
-  font-weight: 700;
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c0 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    font-size: 2rem;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
-}
-
-<h2
-  className="c0"
-  id="This-is-a-SubHeading"
-  tabIndex="-1"
->
-  This is a SubHeading
-</h2>
-`;
-
-exports[`SubHeading component attribute id should render without quotes 1`] = `
-.c0 {
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-  color: #3F3F42;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  margin: 0;
-  padding: 1.5rem 0;
-  font-weight: 700;
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c0 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    font-size: 2rem;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
-  }
-}
-
-<h2
-  className="c0"
-  id="This-is-a-SubHeading"
-  tabIndex="-1"
->
-  This is a SubHeading
-</h2>
-`;
-
 exports[`SubHeading component should render correctly 1`] = `
+.c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  color: #3F3F42;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 1.5rem 0;
+  font-weight: 700;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding-top: 2rem;
+  }
+}
+
+<h2
+  className="c0"
+  id={null}
+  tabIndex="-1"
+>
+  This is a SubHeading
+</h2>
+`;
+
+exports[`SubHeading component should render correctly with an ID 1`] = `
 .c0 {
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -269,7 +189,7 @@ exports[`SubHeading component should render correctly with arabic script typogra
 
 <h2
   className="c0"
-  id="-"
+  id={null}
   tabIndex="-1"
 >
   هذا عنوان فرعي

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { shape } from 'prop-types';
+import { shape, string } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING_TRPL,
@@ -29,8 +29,10 @@ export const Headline = styled.h1`
 const regexPunctuationSymbols = /[^a-z0-9\s-]/gi;
 const regexSpaces = /\s+/g;
 
-export const SubHeading = styled.h2.attrs(({ text }) => ({
-  id: text.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-'),
+export const SubHeading = styled.h2.attrs(({ id }) => ({
+  id: id
+    ? id.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-')
+    : null,
   tabIndex: '-1',
 }))`
   ${props => (props.script ? getTrafalgar(props.script) : '')};
@@ -49,5 +51,10 @@ Headline.propTypes = {
 };
 
 SubHeading.propTypes = {
+  id: string,
   script: shape(scriptPropType).isRequired,
+};
+
+SubHeading.defaultProps = {
+  id: null
 };

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -26,13 +26,7 @@ export const Headline = styled.h1`
   font-weight: 500;
 `;
 
-const regexPunctuationSymbols = /[^a-z0-9\s-]/gi;
-const regexSpaces = /\s+/g;
-
-export const SubHeading = styled.h2.attrs(({ id }) => ({
-  id: id
-    ? id.replace(regexPunctuationSymbols, '').replace(regexSpaces, '-')
-    : null,
+export const SubHeading = styled.h2.attrs(() => ({
   tabIndex: '-1',
 }))`
   ${props => (props.script ? getTrafalgar(props.script) : '')};

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -56,5 +56,5 @@ SubHeading.propTypes = {
 };
 
 SubHeading.defaultProps = {
-  id: null
+  id: null,
 };

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { shape, string } from 'prop-types';
+import { shape } from 'prop-types';
 import { C_SHADOW } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING_TRPL,
@@ -45,10 +45,5 @@ Headline.propTypes = {
 };
 
 SubHeading.propTypes = {
-  id: string,
   script: shape(scriptPropType).isRequired,
-};
-
-SubHeading.defaultProps = {
-  id: null,
 };

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -20,20 +20,19 @@ storiesOf('SubHeading', module)
   .add(
     'default',
     inputProvider([{ name: 'SubHeading' }], ([subheader], script) => (
-      <SubHeading script={script}>
-        {subheader}
-      </SubHeading>
+      <SubHeading script={script}>{subheader}</SubHeading>
     )),
     { notes, knobs: { escapeHTML: false } },
   )
   .add(
     'with optional ID',
     inputProvider([{ name: 'SubHeading' }], ([subheader], script) => {
-      const id = text('ID', 'foo', 'subheading');
+      const id = text('ID', 'foo', 'Other');
       return (
         <SubHeading id={id} script={script}>
           {subheader}
         </SubHeading>
-    )}),
+      );
+    }),
     { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -25,7 +25,7 @@ storiesOf('SubHeading', module)
       </SubHeading>
     )),
     { notes, knobs: { escapeHTML: false } },
-   )
+  )
   .add(
     'with optional ID',
     inputProvider([{ name: 'SubHeading' }], ([subheader], script) => {

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { text, withKnobs } from '@storybook/addon-knobs';
 import { inputProvider } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import { Headline, SubHeading } from './index';
@@ -20,9 +20,20 @@ storiesOf('SubHeading', module)
   .add(
     'default',
     inputProvider([{ name: 'SubHeading' }], ([subheader], script) => (
-      <SubHeading text={subheader} script={script}>
+      <SubHeading script={script}>
         {subheader}
       </SubHeading>
     )),
+    { notes, knobs: { escapeHTML: false } },
+   )
+  .add(
+    'with optional ID',
+    inputProvider([{ name: 'SubHeading' }], ([subheader], script) => {
+      const id = text('ID', 'foo', 'subheading');
+      return (
+        <SubHeading id={id} script={script}>
+          {subheader}
+        </SubHeading>
+    )}),
     { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -18,36 +18,18 @@ describe('Headline component', () => {
 describe('SubHeading component', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <SubHeading text="This is a SubHeading" script={latin}>
-      This is a SubHeading
-    </SubHeading>,
-  );
-
-  shouldMatchSnapshot(
-    'attribute id should render without quotes',
-    <SubHeading text="This 'is' a SubHeading" script={latin}>
-      This is a SubHeading
-    </SubHeading>,
-  );
-
-  shouldMatchSnapshot(
-    'attribute id should render without double quotes',
-    <SubHeading text='This "is" a SubHeading' script={latin}>
-      This is a SubHeading
-    </SubHeading>,
-  );
-
-  shouldMatchSnapshot(
-    'attribute id should render without exclamation marks',
-    <SubHeading text="This is! a SubHeading!" script={latin}>
-      This is a SubHeading
-    </SubHeading>,
+    <SubHeading script={latin}>This is a SubHeading</SubHeading>,
   );
 
   shouldMatchSnapshot(
     'should render correctly with arabic script typography values',
-    <SubHeading text="هذا عنوان فرعي" script={arabic}>
-      هذا عنوان فرعي
+    <SubHeading script={arabic}>هذا عنوان فرعي</SubHeading>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with an ID',
+    <SubHeading id="This-is-a-SubHeading" script={latin}>
+      This is a SubHeading
     </SubHeading>,
   );
 });


### PR DESCRIPTION
Resolves #88 

**Overall change:** 
Removes required `text` prop and subsequent regex logic from `SubHeading` in `psammead-headings` package. An optional `id` can be passed to the SubHeading to act as an anchor.

**Code changes:**

- Removed `text` prop, therefore this is a breaking change
- Remove regex logic to strip strings for them to be valid IDs. This should be handled by the container
- Snapshots updated
- Storybook updated

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [x] Test engineer approval