### PR TITLE
colours: update pebble; add metal

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
 | 0.3.1   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |

--- a/packages/utilities/psammead-styles/index.test.jsx
+++ b/packages/utilities/psammead-styles/index.test.jsx
@@ -47,6 +47,7 @@ const coloursExpectedExports = {
   C_CLOUD_LIGHT: 'string',
   C_LUNAR: 'string',
   C_GHOST: 'string',
+  C_METAL: 'string',
   C_CONSENT_BACKGROUND: 'string',
   C_CONSENT_ACTION: 'string',
   C_CONSENT_CONTENT: 'string',

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/colours.js
+++ b/packages/utilities/psammead-styles/src/colours.js
@@ -6,7 +6,7 @@ export const C_WHITE = '#FFFFFF';
 export const C_BLUEJAY = '#0F556C';
 export const C_BLUEJAY_LHT = '#C3DEE7';
 export const C_OAT_LHT = '#F5F3F1';
-export const C_PEBBLE = '#5C5752';
+export const C_PEBBLE = '#AEAEB5';
 export const C_RHINO = '#5A5A5A';
 export const C_STONE = '#D5D0CD';
 export const C_CHALK = '#ECEAE7';
@@ -15,6 +15,7 @@ export const C_CLOUD_DARK = '#757575';
 export const C_CLOUD_LIGHT = '#BABABA';
 export const C_LUNAR = '#F2F2F2';
 export const C_GHOST = '#FDFDFD';
+export const C_METAL = '#6E6E73';
 
 // Colours from other BBC services
 export const C_CONSENT_BACKGROUND = '#323232';


### PR DESCRIPTION
Resolves #501 

**Overall change:** Updates Pebble to current UX definition and adds Metal.

<img width="349" alt="image" src="https://user-images.githubusercontent.com/10963046/57313087-bef49600-70e6-11e9-8429-e0a190dfc786.png">

**Code changes:**

There already was a `C_PEBBLE`; it doesn't seem to be used elsewhere in psammead and UX have redefined its value so I updated it to the current value.
Added `C_METAL`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval