### PR TITLE
Bump all packages below 1.0.0 to 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ NB: the `__snapshots__` directory is optional.
 
 The `package.json` is namespaced with `@bbc/psammead-*` e.g. `@bbc/psammead-headings`.
 
+Our packages start with version `1.0.0` to allow full use of [semver](https://semver.org/) major, minor and patch.
+
 Include the following authorship and repository information in your package. Replace the team name and email address if appropriate.
 
 ```
@@ -95,7 +97,7 @@ The changelog should follow the following convention:
 
 | Version | Description |
 |---------|-------------|
-| 0.1.0 | [PR#49](https://github.com/bbc/psammead/pull/49) Initial creation of package |
+| 1.0.0 | [PR#49](https://github.com/bbc/psammead/pull/49) Initial creation of package |
 ```
 
 **README**

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.7",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.7",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component that generates a figure element",
   "repository": {

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.10  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.9   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.1.8   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.10  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.9   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.1.8   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.10  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.9   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.1.8   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "0.1.10",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "0.1.10",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "Provides a 'BBC' image placeholder",
   "repository": {

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.3.5",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.3.5",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled components for an Image",
   "repository": {

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#419](https://github.com/bbc/psammead/pull/419) Add language variants knob to Inline Link stories |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#419](https://github.com/bbc/psammead/pull/419) Add language variants knob to Inline Link stories |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#419](https://github.com/bbc/psammead/pull/419) Add language variants knob to Inline Link stories |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.3.7",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "0.3.7",
+  "version": "1.0.0",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.0   | [PR#448](https://github.com/BBC-News/psammead/pull/448) Create initial package. |

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.0   | [PR#448](https://github.com/BBC-News/psammead/pull/448) Create initial package. |

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.0   | [PR#448](https://github.com/BBC-News/psammead/pull/448) Create initial package. |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "Provides a play icon and media duration for media page promos",
   "repository": {

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.6   | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.3.6   | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.6   | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |
 | 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |
 | 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |
 | 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.1   | [PR#493](https://github.com/bbc/psammead/pull/493) Add optional padding prop |
 | 0.3.0   | [PR#494](https://github.com/bbc/psammead/pull/494) Make script a required prop. |
 | 0.2.0   | [PR#461](https://github.com/bbc/psammead/pull/461) Make timestamp typography styling agnostic |

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.1   | [PR#493](https://github.com/bbc/psammead/pull/493) Add optional padding prop |
 | 0.3.0   | [PR#494](https://github.com/bbc/psammead/pull/494) Make script a required prop. |
 | 0.2.0   | [PR#461](https://github.com/bbc/psammead/pull/461) Make timestamp typography styling agnostic |

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.3.1   | [PR#493](https://github.com/bbc/psammead/pull/493) Add optional padding prop |
 | 0.3.0   | [PR#494](https://github.com/bbc/psammead/pull/494) Make script a required prop. |
 | 0.2.0   | [PR#461](https://github.com/bbc/psammead/pull/461) Make timestamp typography styling agnostic |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component for displaying a timestamp with a suitable semantic markup",
   "repository": {

--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 | --------------------- |
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 | --------------------- |
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 | --------------------- |
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.13  | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.1.12  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.1.11  | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-visually-hidden-text/package-lock.json
+++ b/packages/components/psammead-visually-hidden-text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-visually-hidden-text/package.json
+++ b/packages/components/psammead-visually-hidden-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component for visually hidden text (for screen readers)",
   "repository": {

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
 | 0.1.9   | [PR#490](https://github.com/bbc/psammead/pull/490) Update SVGs to consistent export, minify and add persian |
 | 0.1.8   | [PR#444](https://github.com/bbc/psammead/pull/444) Add service SVG's |
 | 0.1.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.1.9   | [PR#490](https://github.com/bbc/psammead/pull/490) Update SVGs to consistent export, minify and add persian |
 | 0.1.8   | [PR#444](https://github.com/bbc/psammead/pull/444) Add service SVG's |
 | 0.1.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0   | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.1.9   | [PR#490](https://github.com/bbc/psammead/pull/490) Update SVGs to consistent export, minify and add persian |
 | 0.1.8   | [PR#444](https://github.com/bbc/psammead/pull/444) Add service SVG's |
 | 0.1.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -1,17 +1,18 @@
 # @bbc/psammead-styles Changelog
 
 | Version | Description |
-|---------|-------------|
-| 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
-| 0.3.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.3.1   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
-| 0.3.0   |  [PR#304](https://github.com/BBC-News/psammead/pull/304) Move font fallback definitions to gel-foundations, add font-face constants. |
-| 0.2.1   |  [PR#300](https://github.com/BBC-News/psammead/pull/300) Adds colours for Consent Banner |
-| 0.2.0   |  [PR#283](https://github.com/BBC-News/psammead/pull/283) Adds colours and fonts necessary for Simorgh V1.0 :art: |
-| 0.1.6   | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada: |
-| 0.1.5   | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
-| 0.1.4   | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
-| 0.1.3 | [PR#74](https://github.com/BBC-News/psammead/pull/74) Move file contents into a src directory and babel transpile prepublish. |
-| 0.1.2 | [PR#72](https://github.com/BBC-News/psammead/pull/72) Update Readme's usage examples |
-| 0.1.1 | [PR#67](https://github.com/BBC-News/psammead/pull/67) Update psammead-styles' DOD |
-| 0.1.0 | [PR#44](https://github.com/BBC-News/psammead/pull/44) Initial creation of package |
+|--------|-------------|
+| 1.0.0  | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 0.3.3  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
+| 0.3.2  | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
+| 0.3.1  | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
+| 0.3.0  | [PR#304](https://github.com/BBC-News/psammead/pull/304) Move font fallback definitions to gel-foundations, add font-face constants. |
+| 0.2.1  | [PR#300](https://github.com/BBC-News/psammead/pull/300) Adds colours for Consent Banner |
+| 0.2.0  | [PR#283](https://github.com/BBC-News/psammead/pull/283) Adds colours and fonts necessary for Simorgh V1.0 :art: |
+| 0.1.6  | [PR#224](https://github.com/BBC-News/psammead/pull/224) Add tests for the exported values, coverage 100% :tada: |
+| 0.1.5  | [PR#212](https://github.com/BBC-News/psammead/pull/212) Update package description and README. |
+| 0.1.4  | [PR#173](https://github.com/BBC-News/psammead/pull/173) Update PRs welcome link |
+| 0.1.3  | [PR#74](https://github.com/BBC-News/psammead/pull/74) Move file contents into a src directory and babel transpile prepublish. |
+| 0.1.2  | [PR#72](https://github.com/BBC-News/psammead/pull/72) Update Readme's usage examples |
+| 0.1.1  | [PR#67](https://github.com/BBC-News/psammead/pull/67) Update psammead-styles' DOD |
+| 0.1.0  | [PR#44](https://github.com/BBC-News/psammead/pull/44) Initial creation of package |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |--------|-------------|
-| 1.0.0  | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Bump to major version |
+| 1.0.0  | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
 | 0.3.3  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2  | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
 | 0.3.1  | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |--------|-------------|
-| 1.0.0  | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version |
+| 1.0.0  | [PR#507](https://github.com/bbc/psammead/pull/507) Bump to major version, no other changes. |
 | 0.3.3  | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2  | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
 | 0.3.1  | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overall change:** Bump all packages below 1.0.0 to 1.0.0

We keep getting restricted by starting at `0.1.0` as you are unable to make a clear distinction between minor and patch version bumps

**Code changes:**

- Bump all packages below 1.0.0 to 1.0.0
- Update contributing docs to reflect this new rule

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- [ ] Test engineer approval