### PR TITLE
Update getVersionScript to return array of published package versions

### DIFF
--- a/scripts/publish/src/getRegistryVersion.js
+++ b/scripts/publish/src/getRegistryVersion.js
@@ -2,6 +2,15 @@ const { exec } = require('shelljs');
 
 // Get version of package in NPM regsitry. Returns 0.0.0 if doesn't exist.
 module.exports = name => {
-  const npmVersion = exec(`npm show ${name} version`, { silent: true }).stdout;
-  return npmVersion ? npmVersion.split('\n')[0] : '0.0.0';
+  let packageVersions = [];
+  const npmVersion = exec(`npm view ${name} versions -json`, { silent: true })
+    .stdout;
+
+  if (typeof npmVersion === 'string' && JSON.parse(npmVersion)) {
+    const jsonResponse = JSON.parse(npmVersion);
+    packageVersions = Array.isArray(jsonResponse) ? jsonResponse : [];
+  }
+
+  const latestPublishedVersion = packageVersions.pop(); // removes the last element from the array and returns it i.e. the latest published version
+  return latestPublishedVersion || '0.0.0';
 };

--- a/scripts/publish/test/getRegistryVersion.test.js
+++ b/scripts/publish/test/getRegistryVersion.test.js
@@ -4,10 +4,22 @@ describe(`Publish Script - getRegistry`, () => {
     jest.resetModules();
   });
 
-  it('returns registry version with newline in response', () => {
+  it('returns latest registry version from array', () => {
     jest.mock('shelljs', () => ({
       exec: () => ({
-        stdout: '1.3.2\n ',
+        stdout: JSON.stringify(['1.0.0', '1.1.0', '1.1.1']),
+      }),
+    }));
+
+    const getRegistry = require('../src/getRegistryVersion');
+
+    expect(getRegistry('foobar')).toEqual('1.1.1');
+  });
+
+  it('returns single registry version ', () => {
+    jest.mock('shelljs', () => ({
+      exec: () => ({
+        stdout: JSON.stringify(['1.3.2']),
       }),
     }));
 
@@ -16,19 +28,7 @@ describe(`Publish Script - getRegistry`, () => {
     expect(getRegistry('foobar')).toEqual('1.3.2');
   });
 
-  it('returns registry version without newline in response', () => {
-    jest.mock('shelljs', () => ({
-      exec: () => ({
-        stdout: '3.2.1',
-      }),
-    }));
-
-    const getRegistry = require('../src/getRegistryVersion');
-
-    expect(getRegistry('foobar')).toEqual('3.2.1');
-  });
-
-  it('returns default version when there is no output', () => {
+  it('returns default version when an array of versions is not returned', () => {
     jest.mock('shelljs', () => ({
       exec: () => ({}),
     }));


### PR DESCRIPTION
Resolves #518 

**Overall change:** 
Returns an array of published versions of components form the NPM registry and checks the latest version against our local version.

Previously returning a single version would not show the latest published alpha version and would prevent us from publishing updated alphas.

**Code changes:**

- Uses the NPM `versions` endpoint to return an array of package versions
- requests JSON from the endpoint
- Parse's the JSON making sure it is an array and gets the latest version

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Tests added for new features
- [ ] Test engineer approval