### PR TITLE
Remove Timestamp padding from StoryPromo and StoryPromoList

### DIFF
--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.1.0-alpha.2 | [PR#534](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
+| 0.1.0-alpha.2 | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |
 | 0.1.0-alpha.1 | [PR#486](https://github.com/BBC-News/psammead/pull/486) Create initial package. |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.1.0-alpha.2 | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
+| 0.1.0-alpha.2 | [PR#534](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
 | 0.1.0-alpha.1 | [PR#486](https://github.com/BBC-News/psammead/pull/486) Create initial package. |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 0.1.0-alpha.2 | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
 | 0.1.0-alpha.1 | [PR#486](https://github.com/BBC-News/psammead/pull/486) Create initial package. |

--- a/packages/components/psammead-story-promo-list/README.md
+++ b/packages/components/psammead-story-promo-list/README.md
@@ -33,7 +33,9 @@ const Image = (
 
 const Info = (
   <Fragment>
-    <Headline script={latin}>The headline of the promo</Headline>
+    <Headline script={latin}>    
+      <Link href="https://www.bbc.co.uk/news">The headline of the promo</Link>
+   </Headline>
     <Summary script={latin}>The summary of the promo</Summary>
     <time>12 March 2019</time>
   </Fragment>

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -45,9 +45,9 @@
       "dev": true
     },
     "@bbc/psammead-story-promo": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-0.1.1.tgz",
-      "integrity": "sha512-h0e/xUKhZUK2XrU+b9HxrB5sN9cwI7VzmAc3H75aHK4vuSkS+f1IO8JMclGFlMuRSb+qZYiQqoNahKpYZomM2w==",
+      "version": "0.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-0.2.0-alpha.1.tgz",
+      "integrity": "sha512-7xpRU4vcNdD8C8U46NcXa+qudBrWVNwZYJro9gUCnDtSOpOXR0QY72BOf6+ApqGXilVAH6F88bZGkhMvzh0IDw==",
       "requires": {
         "@bbc/gel-foundations": "^1.2.0",
         "@bbc/psammead-styles": "^0.3.3"

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -75,12 +75,12 @@
       }
     },
     "@bbc/psammead-timestamp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.1.0.tgz",
-      "integrity": "sha512-FWOXj8oaA54djm46jQILd4kXOg/ILEM6nTs4ytxsuDpCYFTGnUxrBOkevrZztu43psSK/CwwTg2lYwH0D/xBTA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.3.2.tgz",
+      "integrity": "sha512-CayEqjUCBj7vciKf26eisSZZOV5KX+tp5rIGaEoOKpY51R/Zyb2h1OfW1lA7lVrVQFhAVA/kUUGRW4DI3bH40Q==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^1.0.0"
+        "@bbc/gel-foundations": "^1.2.0"
       }
     },
     "@emotion/is-prop-valid": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "main": "dist/index.js",
   "description": "List of story promos",
   "repository": {
@@ -25,7 +25,7 @@
     "@bbc/psammead-image": "^0.3.5",
     "@bbc/psammead-storybook-helpers": "^1.1.1",
     "@bbc/psammead-test-helpers": "^0.3.3",
-    "@bbc/psammead-timestamp": "^0.1.0",
+    "@bbc/psammead-timestamp": "^0.3.2",
     "react": "^16.6.3",
     "styled-components": "^4.1.3"
   },

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^1.2.0",
-    "@bbc/psammead-story-promo": "^0.1.1",
+    "@bbc/psammead-story-promo": "^0.2.0-alpha.1",
     "@bbc/psammead-styles": "^0.3.3"
   },
   "devDependencies": {

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -2,17 +2,20 @@
 
 exports[`StoryPromo should render correctly 1`] = `
 .c2 {
-  display: grid;
-  grid-template-columns: repeat(6,1fr);
-  grid-column-gap: 0.5rem;
+  position: relative;
 }
 
 .c3 {
-  grid-column: 1 / span 2;
+  display: inline-block;
+  vertical-align: top;
+  max-width: 33.33%;
 }
 
 .c4 {
-  grid-column: 3 / span 4;
+  display: inline-block;
+  vertical-align: top;
+  padding: 0 0.5rem;
+  max-width: 66.67%;
 }
 
 .c5 {
@@ -54,27 +57,46 @@ exports[`StoryPromo should render correctly 1`] = `
   padding: 0;
 }
 
-@media (min-width:37.5rem) {
+@supports (display:grid) {
   .c2 {
-    grid-column-gap: 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c2 {
-    grid-template-columns: repeat(12,1fr);
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c3 {
-    grid-column: 1 / span 4;
+    max-width: 33.33%;
+  }
+}
+
+@supports (display:grid) {
+  .c3 {
+    display: block;
+    max-width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
   .c4 {
-    grid-column: 5 / span 8;
+    max-width: 66.67%;
+  }
+}
+
+@supports (display:grid) {
+  .c4 {
+    display: block;
+    max-width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
   }
 }
 
@@ -103,6 +125,12 @@ exports[`StoryPromo should render correctly 1`] = `
   .c6 {
     font-size: 0.875rem;
     line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c6 {
+    display: none;
   }
 }
 

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`StoryPromo should render correctly 1`] = `
 
 .c1 {
   border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 1rem 0 0.5rem;
+  padding: 0.5rem 0 1rem;
 }
 
 .c1:first-child {

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -14,7 +14,7 @@ import {
 
 const StyledListItem = styled.li`
   border-bottom: 0.0625rem solid ${C_LUNAR};
-  padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};
+  padding: ${GEL_SPACING} 0 ${GEL_SPACING_DBL};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};

--- a/packages/components/psammead-story-promo-list/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.stories.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import Timestamp from '@bbc/psammead-timestamp';
 import Image from '@bbc/psammead-image';
 import { latin } from '@bbc/gel-foundations/scripts';
-import StoryPromo, { Headline, Summary } from '@bbc/psammead-story-promo';
+import StoryPromo, { Headline, Summary, Link } from '@bbc/psammead-story-promo';
 import { StoryPromoLi, StoryPromoUl } from './index';
 import storyPromoData from '../testHelpers/fixtureData';
 import notes from '../README.md';
@@ -16,7 +16,9 @@ const ImageComponent = ({ alt, src }) => (
 // eslint-disable-next-line react/prop-types
 const InfoComponent = ({ headlineText, summaryText, datetime, dateformat }) => (
   <Fragment>
-    <Headline script={latin}>{headlineText}</Headline>
+    <Headline script={latin}>
+      <Link href="https://www.bbc.co.uk/news">{headlineText}</Link>
+    </Headline>
     <Summary script={latin}>{summaryText}</Summary>
     <Timestamp datetime={datetime} script={latin} padding={false}>
       {dateformat}

--- a/packages/components/psammead-story-promo-list/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.stories.jsx
@@ -18,7 +18,7 @@ const InfoComponent = ({ headlineText, summaryText, datetime, dateformat }) => (
   <Fragment>
     <Headline script={latin}>{headlineText}</Headline>
     <Summary script={latin}>{summaryText}</Summary>
-    <Timestamp datetime={datetime} script={latin}>
+    <Timestamp datetime={datetime} script={latin} padding={false}>
       {dateformat}
     </Timestamp>
   </Fragment>

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.1.5   | [PR#534](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
+| 0.1.5   | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
 | 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 0.1.5   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
 | 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.1.5   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
+| 0.1.5   | [PR#534](https://github.com/BBC-News/psammead/pull/XXX) Remove Timestamp padding. |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
 | 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -70,12 +70,12 @@
       }
     },
     "@bbc/psammead-timestamp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.1.0.tgz",
-      "integrity": "sha512-FWOXj8oaA54djm46jQILd4kXOg/ILEM6nTs4ytxsuDpCYFTGnUxrBOkevrZztu43psSK/CwwTg2lYwH0D/xBTA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.3.2.tgz",
+      "integrity": "sha512-CayEqjUCBj7vciKf26eisSZZOV5KX+tp5rIGaEoOKpY51R/Zyb2h1OfW1lA7lVrVQFhAVA/kUUGRW4DI3bH40Q==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^1.0.0"
+        "@bbc/gel-foundations": "^1.2.0"
       }
     },
     "@emotion/is-prop-valid": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {
@@ -24,7 +24,7 @@
     "@bbc/psammead-image": "^0.3.5",
     "@bbc/psammead-storybook-helpers": "^2.0.0",
     "@bbc/psammead-test-helpers": "^0.3.3",
-    "@bbc/psammead-timestamp": "^0.1.0",
+    "@bbc/psammead-timestamp": "^0.3.2",
     "react": "^16.6.3",
     "styled-components": "^4.1.3"
   },

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -26,6 +26,7 @@ const InfoComponent = ({ headlineText, summaryText, script }) => (
     <Timestamp
       datetime={text('Timestamp datetime', '2019-03-01T14:00+00:00')}
       script={script}
+      padding={false}
     >
       {text('Timestamp', '12 March 2019')}
     </Timestamp>


### PR DESCRIPTION
Resolves #533

**Overall change:**
Remove the padding from the `Timestamp` used in the `StoryPromo` and `StoryPromoList` stories
and swap the Story Promo list item spacing values for (0-600px) breakpoint.

**Code changes:**
- Add `padding={false}` prop to the Timestamp used in the `StoryPromo` story.
- Add `padding={false}` prop to the Timestamp used in the`StoryPromoList` story
- Replace `StyledListItem` `padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};` with `  padding: ${GEL_SPACING} 0 ${GEL_SPACING_DBL};`



---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval