### PR TITLE
Fix broken story

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -4,6 +4,7 @@
 | Version | Description |
 | ------- | ----------- |
 | 0.2.0-alpha.2 | [PR#535](https://github.com/bbc/psammead/pull/535) Fix issues with knobs on storybook |
+| 0.2.0-alpha.1 | [PR#513](https://github.com/bbc/psammead/pull/513) Add Link with hover, focus and visited states |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
 | 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 0.1.5   | [PR#535](https://github.com/bbc/psammead/pull/535) Fix issues with knobs on storybook |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
 | 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -7,9 +7,9 @@ import Timestamp from '@bbc/psammead-timestamp';
 import notes from '../README.md';
 import StoryPromo, { Headline, Summary } from './index';
 
-const ImageComponent = (
+const buildImageComponent = () => (
   <Image
-    alt={text('Image alt text', '2019-03-01T14:00+00:00')}
+    alt={text('Image alt text', 'An example of image alt text')}
     src={text(
       'Image src',
       'https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg',
@@ -47,7 +47,7 @@ storiesOf('StoryPromo', module)
           />
         );
 
-        return <StoryPromo image={ImageComponent} info={Info} />;
+        return <StoryPromo image={buildImageComponent()} info={Info} />;
       },
     ),
     { notes, knobs: { escapeHTML: false } },

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -7,17 +7,6 @@ import Timestamp from '@bbc/psammead-timestamp';
 import notes from '../README.md';
 import StoryPromo, { Headline, Summary, Link } from './index';
 
-const buildImageComponent = () => (
-  <Image
-    alt={text('Image alt text', 'Robert Downey Junior in Iron Man')}
-    src={text(
-      'Image src',
-      'https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg',
-    )}
-    width="640"
-  />
-);
-
 // eslint-disable-next-line react/prop-types
 const InfoComponent = ({ headlineText, summaryText, script }) => (
   <Fragment>
@@ -49,7 +38,18 @@ storiesOf('StoryPromo', module)
           />
         );
 
-        return <StoryPromo image={buildImageComponent()} info={Info} />;
+        const Img = (
+          <Image
+            alt={text('Image alt text', 'Robert Downey Junior in Iron Man')}
+            src={text(
+              'Image src',
+              'https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg',
+            )}
+            width="640"
+          />
+        );
+
+        return <StoryPromo image={Img} info={Info} />;
       },
     ),
     { notes, knobs: { escapeHTML: false } },


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** When entering the psammead storybook for the first time, you are presented with two knobs, `Image alt text` and `Image src`, which do not exist on the viewed story. These are because knob functions on the **Story Promo** story are called too early. Instead, only call the knob functions when the story is being rendered.

![image](https://user-images.githubusercontent.com/10963046/57939534-74330500-78c2-11e9-91f5-9c4ad7795f47.png)
> These knobs don't affect this story!

Once this PR is merged, `Image alt text` and `Image src` knobs will be visible only on the Story Promo default story, and will control the image appearing on that story.

**Code changes:**

- Convert the static `ImageComponent` into a `buildImageComponent` function, which is called at the intended time.
- Use more representative example of alt text

---

- [x] I have assigned myself to this PR and the corresponding issues
- N/A Tests added for new features
- [ ] Test engineer approval