### PR TITLE
Display Psammead-styles colours in Storybook

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.5   | [PR#537](https://github.com/bbc/psammead/pull/537) Create story for Colours|
+| 0.3.5   | [PR#537](https://github.com/bbc/psammead/pull/537) Create story for colours |
 | 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.3.5   | [PR#](https://github.com/bbc/psammead/pull/) Create story for Colours|
+| 0.3.5   | [PR#537](https://github.com/bbc/psammead/pull/537) Create story for Colours|
 | 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.3.5   | [PR#](https://github.com/bbc/psammead/pull/) Create story for Colours|
 | 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.2   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -7,7 +7,8 @@
     "@bbc/gel-foundations": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.2.0.tgz",
-      "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ=="
+      "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ==",
+      "dev": true
     },
     "@bbc/psammead-test-helpers": {
       "version": "0.3.1",

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@bbc/gel-foundations": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.2.0.tgz",
+      "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ=="
+    },
     "@bbc/psammead-test-helpers": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.1.tgz",

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -15,9 +15,6 @@
     "url": "https://github.com/bbc/psammead/issues"
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/utilities/psammead-styles/README.md",
-  "dependencies": {
-    "@bbc/gel-foundations": "^1.2.0"
-  },
   "keywords": [
     "bbc",
     "utilities",
@@ -27,6 +24,7 @@
     "fonts"
   ],
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.0"
+    "@bbc/psammead-test-helpers": "^0.3.0",
+    "@bbc/gel-foundations": "^1.2.0"
   }
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/bbc/psammead/issues"
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/utilities/psammead-styles/README.md",
+  "dependencies": {
+    "@bbc/gel-foundations": "^1.2.0"
+  },
   "keywords": [
     "bbc",
     "utilities",

--- a/packages/utilities/psammead-styles/src/index.stories.jsx
+++ b/packages/utilities/psammead-styles/src/index.stories.jsx
@@ -19,7 +19,6 @@ const ColourRow = styled.div`
 const ColourBox = styled.div`
   background: ${props => props.colour};
   color: #000;
-  mix-blend-mode: difference;
   padding: 10px 5px;
   border-radius: 5px;
   display: inline-block;

--- a/packages/utilities/psammead-styles/src/index.stories.jsx
+++ b/packages/utilities/psammead-styles/src/index.stories.jsx
@@ -1,32 +1,39 @@
 import React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
+import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import {
+  getBodyCopy,
+  GEL_FF_REITH_SANS,
+} from '@bbc/gel-foundations/typography';
+import { latin } from '@bbc/gel-foundations/scripts';
 import notes from '../README.md';
 import * as colours from './colours';
 
 const ColourContainer = styled.div`
-  padding: 10px;
-  font-size: 14px;
-  font-family: 'Nunito Sans', -apple-system, Helvetica, Arial, sans-serif;
+  padding: ${GEL_SPACING_DBL};
+  font-family: ${GEL_FF_REITH_SANS};
 `;
 
 const ColourRow = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 10px;
+  margin-bottom: ${GEL_SPACING_DBL};
 `;
 
 const ColourBox = styled.div`
   background: ${props => props.colour};
   color: #000;
-  padding: 10px 5px;
-  border-radius: 5px;
+  padding: ${GEL_SPACING_DBL} ${GEL_SPACING};
+  border-radius: 0.3125rem;
   display: inline-block;
+  ${getBodyCopy(latin)};
 `;
 
 const ColourValue = styled.div`
-  padding-left: 10px;
+  padding-left: ${GEL_SPACING};
   display: inline-block;
+  ${getBodyCopy(latin)};
 `;
 
 storiesOf('Psammead Styles', module).add(

--- a/packages/utilities/psammead-styles/src/index.stories.jsx
+++ b/packages/utilities/psammead-styles/src/index.stories.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+import { storiesOf } from '@storybook/react';
+import notes from '../README.md';
+import * as colours from './colours';
+
+const ColourContainer = styled.div`
+  padding: 10px;
+  font-size: 14px;
+  font-family: 'Nunito Sans', -apple-system, Helvetica, Arial, sans-serif;
+`;
+
+const ColourRow = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+
+const ColourBox = styled.div`
+  background: ${props => props.colour};
+  color: #000;
+  mix-blend-mode: difference;
+  padding: 10px 5px;
+  border-radius: 5px;
+  display: inline-block;
+`;
+
+const ColourValue = styled.div`
+  padding-left: 10px;
+  display: inline-block;
+`;
+
+storiesOf('Psammead Styles', module).add(
+  'colours',
+  () => (
+    <ColourContainer>
+      {Object.keys(colours).map(colour => (
+        <ColourRow key={colours[colour]}>
+          <ColourBox colour={colours[colour]}>{colours[colour]}</ColourBox>
+          <ColourValue>{colour}</ColourValue>
+        </ColourRow>
+      ))}
+    </ColourContainer>
+  ),
+  {
+    notes,
+  },
+);


### PR DESCRIPTION
Resolves #362

**Overall change:** 
Adding the colours to Storybook.

**Code changes:**
- Add a story to the `psammead-styles` package that shows our colours as a palette. 
<img width="937" alt="Screenshot 2019-05-21 at 08 51 33" src="https://user-images.githubusercontent.com/46446236/58078021-adf75a80-7ba5-11e9-9c7d-005da963cc72.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval