### PR TITLE
Bump reith font version from 2.302 to 2.511

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ You can do this in pure CSS:
     font-family: "ReithSans";
     font-style: normal;
     font-weight: 400;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff2')
-        format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff')
+    src: url('https://gel.files.bbci.co.uk/r2.511/BBCReithSans_W_Rg.woff2')
+        format('woff2'), url('https://gel.files.bbci.co.uk/r2.511/BBCReithSans_W_Rg.woff')
         format('woff');
   }
   @font-face {
@@ -116,8 +116,8 @@ You can do this in pure CSS:
     font-family: "ReithSerif";
     font-style: normal;
     font-weight: 600;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2')
-        format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff')
+    src: url('https://gel.files.bbci.co.uk/r2.511/BBCReithSerif_W_Md.woff2')
+        format('woff2'), url('https://gel.files.bbci.co.uk/r2.511/BBCReithSerif_W_Md.woff')
         format('woff');
   }
 </style>

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.4.0   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump the reith font version from 2.302 to 2.511 |
 | 0.3.5   | [PR#537](https://github.com/bbc/psammead/pull/537) Create story for colours |
 | 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.4.0   | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump the reith font version from 2.302 to 2.511 |
+| 0.4.0   | [PR#548](https://github.com/bbc/psammead/pull/548) Bump the reith font version from 2.302 to 2.511 |
 | 0.3.5   | [PR#537](https://github.com/bbc/psammead/pull/537) Create story for colours |
 | 0.3.4   | [PR#505](https://github.com/bbc/psammead/pull/505) Add Metal; update Pebble |
 | 0.3.3   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/fonts.js
+++ b/packages/utilities/psammead-styles/src/fonts.js
@@ -1,4 +1,4 @@
-const baseFontUrl = 'https://gel.files.bbci.co.uk/r2.302/';
+const baseFontUrl = 'https://gel.files.bbci.co.uk/r2.511/';
 
 // Serif
 export const F_REITH_SERIF_REGULAR = `


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/1710

**Overall change:** _Changes the Reith font version from 2.302 to 2.511. Updates read me's and change logs_

**Testing notes:**
Visual regression storybook and the Reith font being used. The main chunk of the manual testing will be performed in the simorgh integration PR

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval