### PR TITLE
Copyright Lang attribute

### DIFF
--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.3.8   | [PR#623](https://github.com/bbc/psammead/pull/424) Add copyright lang attribute |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.8   | [PR#623](https://github.com/bbc/psammead/pull/424) Add copyright lang attribute |
+| 0.3.8   | [PR#623](https://github.com/bbc/psammead/pull/623) Add copyright lang attribute |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`Copyright should render correctly 1`] = `
 
 <p
   className="c0"
+  lang="en-gb"
   role="text"
 >
   Getty Images

--- a/packages/components/psammead-copyright/src/index.jsx
+++ b/packages/components/psammead-copyright/src/index.jsx
@@ -5,6 +5,7 @@ import { GEL_MINION, GEL_FF_REITH_SANS } from '@bbc/gel-foundations/typography';
 
 const Copyright = styled.p.attrs({
   role: 'text',
+  lang: 'en-gb',
 })`
   ${GEL_MINION};
   background-color: rgba(34, 34, 34, 0.75);


### PR DESCRIPTION
Resolves [#623](https://github.com/bbc/simorgh/issues/623)

**Overall change:** _Add default "en-gb" lang attribute to copyright_

**Code changes:**

- _Add default lang attribute to copyright regardless of the page's service._


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval