### PR TITLE
Dynamic sitewide link rows

### DIFF
--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.3.8   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Make row count dynamic on number of columns and items |
 | 0.3.7   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.3.6   | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.3.8   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Make row count dynamic on number of columns and items |
+| 0.3.8   | [PR#585](https://github.com/bbc/psammead/pull/585) Make row count dynamic on number of columns and items |
 | 0.3.7   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.3.6   | [PR#430](https://github.com/bbc/psammead/pull/430) Add text knobs to story |
 | 0.3.5   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`List should render correctly 1`] = `
+exports[`List should render correctly with 7 items 1`] = `
 .c3 {
   padding: 0.5rem 0 0.5rem;
   color: #FFFFFF;
@@ -84,6 +84,303 @@ exports[`List should render correctly 1`] = `
   className="c0"
   role="list"
 >
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`List should render correctly with 8 items 1`] = `
+.c3 {
+  padding: 0.5rem 0 0.5rem;
+  color: #FFFFFF;
+  font-weight: 700;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+}
+
+.c2:hover .c4,
+.c2:focus .c4 {
+  padding-bottom: 2px;
+  border-bottom: 2px solid #FFFFFF;
+}
+
+.c0 {
+  border-bottom: 1px solid #3F3F42;
+  display: grid;
+  grid-auto-flow: column;
+  list-style-type: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+}
+
+.c0 > li:first-child {
+  border-bottom: 1px solid #3F3F42;
+  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
+  grid-column: 1/-1;
+}
+
+.c1 {
+  min-width: 50%;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+    grid-template-columns: repeat(2,1fr);
+    grid-template-rows: repeat(5,auto);
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+    grid-template-columns: repeat(3,1fr);
+    grid-template-rows: repeat(4,auto);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+    grid-template-columns: repeat(4,1fr);
+    grid-template-rows: repeat(3,auto);
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+    grid-template-columns: repeat(5,1fr);
+    grid-template-rows: repeat(3,auto);
+  }
+}
+
+@supports not (display:grid) {
+  .c0 > li:first-child {
+    width: 100%;
+  }
+}
+
+@supports not (display:grid) {
+  .c1 {
+    display: inline-block;
+  }
+}
+
+<ul
+  className="c0"
+  role="list"
+>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
+  <li
+    className="c1"
+    role="listitem"
+  >
+    <a
+      className="c2 c3"
+      href="https://www.bbc.co.uk/news"
+    >
+      <span
+        className="c4"
+      >
+        Link
+      </span>
+    </a>
+  </li>
   <li
     className="c1"
     role="listitem"

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -234,7 +234,13 @@ exports[`List should render correctly with 8 items 1`] = `
   min-width: 50%;
 }
 
-@media (max-width:37.4375rem) {
+@media (max-width:14.9375rem) {
+  .c0 {
+    grid-auto-flow: row;
+  }
+}
+
+@media (min-width:15rem) and (max-width:37.4375rem) {
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`List should render correctly with 7 items 1`] = `
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(4,auto);
+    grid-template-rows: repeat( 4,auto );
   }
 }
 
@@ -48,7 +48,7 @@ exports[`List should render correctly with 7 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -56,7 +56,7 @@ exports[`List should render correctly with 7 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -64,7 +64,7 @@ exports[`List should render correctly with 7 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -232,7 +232,7 @@ exports[`List should render correctly with 8 items 1`] = `
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(5,auto);
+    grid-template-rows: repeat( 5,auto );
   }
 }
 
@@ -240,7 +240,7 @@ exports[`List should render correctly with 8 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(4,auto);
+    grid-template-rows: repeat( 4,auto );
   }
 }
 
@@ -248,7 +248,7 @@ exports[`List should render correctly with 8 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -256,7 +256,7 @@ exports[`List should render correctly with 8 items 1`] = `
   .c0 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -15,6 +15,8 @@ import {
 
 import Link from '../Link';
 
+const getRowCount = (children, columns) => Math.ceil((children.length - 1) /columns) + 1;
+
 const StyledList = styled.ul`
   border-bottom: 1px solid ${C_SHADOW};
   display: grid;
@@ -25,22 +27,22 @@ const StyledList = styled.ul`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING};
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(4, auto);
+    grid-template-rows: repeat(${({children}) => getRowCount(children, 2)}, auto);
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(3, auto);
+    grid-template-rows: repeat(${({children}) => getRowCount(children, 3)}, auto);
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: repeat(3, auto);
+    grid-template-rows: repeat(${({children}) => getRowCount(children, 4)}, auto);
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(3, auto);
+    grid-template-rows: repeat(${({children}) => getRowCount(children, 5)}, auto);
   }
   > li:first-child {
     border-bottom: 1px solid ${C_SHADOW};

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -18,7 +18,7 @@ import Link from '../Link';
 // Gets the number of grid rows, taking into account the
 // first-child in the grid being separate, on its own row.
 const getRowCount = (children, columns) =>
-  Math.ceil((children.length - 1) / columns) + 1;
+  Math.ceil((React.Children.count(children) - 1) / columns) + 1;
 
 const StyledList = styled.ul`
   border-bottom: 1px solid ${C_SHADOW};

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -16,7 +16,8 @@ import {
 import Link from '../Link';
 
 // Get number of rows using children length minus 1 (to account for first-child being seperate)
-// and devide by number of columns, adding 1 extra row (to account for first-child being seperate)
+// and divide by number of columns, adding 1 extra row (to account for first-child being seperate)
+
 const getRowCount = (children, columns) => Math.ceil((children.length - 1) / columns) + 1;
 
 const StyledList = styled.ul`

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -15,9 +15,8 @@ import {
 
 import Link from '../Link';
 
-// Get number of rows using children length minus 1 (to account for first-child being seperate)
-// and divide by number of columns, adding 1 extra row (to account for first-child being seperate)
-
+// Gets the number of grid rows, taking into account the
+// first-child in the grid being seperate, on its own row.
 const getRowCount = (children, columns) => Math.ceil((children.length - 1) / columns) + 1;
 
 const StyledList = styled.ul`

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -16,7 +16,7 @@ import {
 import Link from '../Link';
 
 // Gets the number of grid rows, taking into account the
-// first-child in the grid being seperate, on its own row.
+// first-child in the grid being separate, on its own row.
 const getRowCount = (children, columns) =>
   Math.ceil((children.length - 1) / columns) + 1;
 

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -15,7 +15,9 @@ import {
 
 import Link from '../Link';
 
-const getRowCount = (children, columns) => Math.ceil((children.length - 1) /columns) + 1;
+// Get number of rows using children length minus 1 (to account for first-child being seperate)
+// and devide by number of columns, adding 1 extra row (to account for first-child being seperate)
+const getRowCount = (children, columns) => Math.ceil((children.length - 1) / columns) + 1;
 
 const StyledList = styled.ul`
   border-bottom: 1px solid ${C_SHADOW};

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -17,7 +17,8 @@ import Link from '../Link';
 
 // Gets the number of grid rows, taking into account the
 // first-child in the grid being seperate, on its own row.
-const getRowCount = (children, columns) => Math.ceil((children.length - 1) / columns) + 1;
+const getRowCount = (children, columns) =>
+  Math.ceil((children.length - 1) / columns) + 1;
 
 const StyledList = styled.ul`
   border-bottom: 1px solid ${C_SHADOW};
@@ -29,22 +30,34 @@ const StyledList = styled.ul`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING};
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(${({children}) => getRowCount(children, 2)}, auto);
+    grid-template-rows: repeat(
+      ${({ children }) => getRowCount(children, 2)},
+      auto
+    );
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(${({children}) => getRowCount(children, 3)}, auto);
+    grid-template-rows: repeat(
+      ${({ children }) => getRowCount(children, 3)},
+      auto
+    );
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: repeat(${({children}) => getRowCount(children, 4)}, auto);
+    grid-template-rows: repeat(
+      ${({ children }) => getRowCount(children, 4)},
+      auto
+    );
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(${({children}) => getRowCount(children, 5)}, auto);
+    grid-template-rows: repeat(
+      ${({ children }) => getRowCount(children, 5)},
+      auto
+    );
   }
   > li:first-child {
     border-bottom: 1px solid ${C_SHADOW};

--- a/packages/components/psammead-sitewide-links/src/List/index.test.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.test.jsx
@@ -8,19 +8,15 @@ describe(`List`, () => {
     text: 'Link',
   };
 
-  const getLinks = count => (new Array(count)).fill(link);
+  const getLinks = count => new Array(count).fill(link);
 
   shouldMatchSnapshot(
     'should render correctly with 7 items',
-    <List
-      links={getLinks(7)}
-    />,
+    <List links={getLinks(7)} />,
   );
 
   shouldMatchSnapshot(
     'should render correctly with 8 items',
-    <List
-      links={getLinks(8)}
-    />,
+    <List links={getLinks(8)} />,
   );
 });

--- a/packages/components/psammead-sitewide-links/src/List/index.test.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.test.jsx
@@ -8,7 +8,19 @@ describe(`List`, () => {
     text: 'Link',
   };
 
-  const links = [link];
+  const getLinks = count => (new Array(count)).fill(link);
 
-  shouldMatchSnapshot('should render correctly', <List links={links} />);
+  shouldMatchSnapshot(
+    'should render correctly with 7 items',
+    <List
+      links={getLinks(7)}
+    />,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with 8 items',
+    <List
+      links={getLinks(8)}
+    />,
+  );
 });

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(4,auto);
+    grid-template-rows: repeat(1,auto);
   }
 }
 
@@ -75,7 +75,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat(1,auto);
   }
 }
 
@@ -83,7 +83,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat(1,auto);
   }
 }
 
@@ -91,7 +91,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat(1,auto);
   }
 }
 

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(4,auto);
+    grid-template-rows: repeat( 4,auto );
   }
 }
 
@@ -75,7 +75,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -83,7 +83,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 
@@ -91,7 +91,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,auto);
+    grid-template-rows: repeat( 3,auto );
   }
 }
 

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(1,auto);
+    grid-template-rows: repeat(4,auto);
   }
 }
 
@@ -75,7 +75,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(1,auto);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
@@ -83,7 +83,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(1,auto);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
@@ -91,7 +91,7 @@ exports[`SitewideLinks should render correctly 1`] = `
   .c2 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(1,auto);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
@@ -141,6 +141,96 @@ exports[`SitewideLinks should render correctly 1`] = `
       className="c2"
       role="list"
     >
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
+      <li
+        className="c3"
+        role="listitem"
+      >
+        <a
+          className="c4 c5"
+          href="https://www.bbc.co.uk/news"
+        >
+          <span
+            className="c6"
+          >
+            Link
+          </span>
+        </a>
+      </li>
       <li
         className="c3"
         role="listitem"

--- a/packages/components/psammead-sitewide-links/src/index.test.jsx
+++ b/packages/components/psammead-sitewide-links/src/index.test.jsx
@@ -8,7 +8,7 @@ describe(`SitewideLinks`, () => {
     text: 'Link',
   };
 
-  const links = [link];
+  const links = new Array(7).fill(link);
 
   shouldMatchSnapshot(
     'should render correctly',


### PR DESCRIPTION
Resolves #567

**Overall change:** Make sitewide link component rows dynamic

**Code changes:**

- Makes the number of rows used in sitewide links dynamic based on the number of children and desired number of columns at that break point. This is due to the desire to order the list like

| one | three | five | seven |
| two | four | six | eight |

not

| one | two | three | four |
| five | six | seven | eight |


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval