### PR TITLE
Story Promo headline - Apply Pica under 600px

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.2.0-alpha.6 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Story promo headline to use Pica under 600px. |
+| 0.2.0-alpha.6 | [PR#588](https://github.com/bbc/psammead/pull/588) Update Story promo headline to use Pica under 600px. |
 | 0.2.0-alpha.5 | [PR#522](https://github.com/bbc/psammead/pull/522) Add MediaIndicator. |
 | 0.2.0-alpha.4 | [PR#546](https://github.com/bbc/psammead/pull/546) Replace colours and hide summary under 600px width screen. |
 | 0.2.0-alpha.3 | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,13 +3,14 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 0.2.0-alpha.5 | [PR#522](https://github.com/bbc/psammead/pull/522) Add MediaIndicator |
-| 0.2.0-alpha.4 | [PR#546](https://github.com/bbc/psammead/pull/546) Replace colours and hide summary under 600px width screen |
+| 0.2.0-alpha.6 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Story promo headline to use Pica under 600px. |
+| 0.2.0-alpha.5 | [PR#522](https://github.com/bbc/psammead/pull/522) Add MediaIndicator. |
+| 0.2.0-alpha.4 | [PR#546](https://github.com/bbc/psammead/pull/546) Replace colours and hide summary under 600px width screen. |
 | 0.2.0-alpha.3 | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |
-| 0.2.0-alpha.2 | [PR#535](https://github.com/bbc/psammead/pull/535) Fix issues with knobs on storybook |
-| 0.2.0-alpha.1 | [PR#513](https://github.com/bbc/psammead/pull/513) Add Link with hover, focus and visited states |
+| 0.2.0-alpha.2 | [PR#535](https://github.com/bbc/psammead/pull/535) Fix issues with knobs on storybook. |
+| 0.2.0-alpha.1 | [PR#513](https://github.com/bbc/psammead/pull/513) Add Link with hover, focus and visited states. |
 | 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
-| 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
+| 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider. |
 | 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |
 | 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
 | 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -16,8 +16,8 @@ exports[`StoryPromo should render correctly 1`] = `
 }
 
 .c3 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   color: #222222;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
@@ -114,15 +114,22 @@ exports[`StoryPromo should render correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c3 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c3 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -242,8 +249,8 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 }
 
 .c9 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   color: #222222;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
@@ -347,15 +354,22 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c9 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c9 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -14,6 +14,7 @@ import {
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import {
+  getPica,
   getGreatPrimer,
   getLongPrimer,
   GEL_FF_REITH_SERIF,
@@ -108,12 +109,15 @@ const InlineMediaIndicator = styled.div`
 `;
 
 export const Headline = styled.h3`
-  ${props => (props.script ? getGreatPrimer(props.script) : '')};
+  ${props => (props.script ? getPica(props.script) : '')};
   color: ${C_EBON};
   font-family: ${GEL_FF_REITH_SERIF};
   margin: 0; /* Reset */
   padding-bottom: ${GEL_SPACING};
   font-weight: 700;
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    ${props => (props.script ? getGreatPrimer(props.script) : '')};
+  }
 `;
 
 export const Summary = styled.p`


### PR DESCRIPTION
Resolves #568

**Overall change:**
Apply Pica to Story Promo headline under 600px.

**Code changes:**
- Import `getPica` and apply it by default to the Story Promo headline.
- Apply `getGreatPrimer` > 600px.
---
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval