### PR TITLE
update timestamp container to use latest timestamp; pass padding

### DIFF
--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Receive a padding; pass a padding |
 | 1.0.0 | [PR#532](https://github.com/bbc/psammead/pull/532) Initial creation of package |

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Receive a padding; pass a padding |
+| 1.1.0 | [PR#592](https://github.com/bbc/psammead/pull/592) Receive a padding; pass a padding |
 | 1.0.0 | [PR#532](https://github.com/bbc/psammead/pull/532) Initial creation of package |

--- a/packages/containers/psammead-timestamp-container/README.md
+++ b/packages/containers/psammead-timestamp-container/README.md
@@ -1,7 +1,7 @@
 # psammead-timestamp-container - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcontainers%2Fpsammead-timestamp-container%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcontainers%2Fpsammead-timestamp-container%2Fpackage.json) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-timestamp-container.svg)](https://www.npmjs.com/package/@bbc/psammead-timestamp-container) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/timestampcontainer--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description
-`psammead-timestamp-container` is a React container that offers relative and absolute times, with timezone support - using moment-timezone. Relative times are currently hard-coded to English (e.g. 3 minutes ago). `psammead-timestamp-container` returns a single time element. 
+`psammead-timestamp-container` is a React container that offers relative and absolute times, with timezone support - using moment-timezone. Relative times are currently hard-coded to English (e.g. 3 minutes ago). `psammead-timestamp-container` returns a single time element.
 
 ## When to use this component
 `psammead-timestamp-container` is intended to be used when a single time DOM element that has the possibility of having varying time formats and timezones is required.
@@ -18,6 +18,7 @@
 | isRelative | boolean | No | `false` | `true` |
 | format | string | No | `null` | `D MMMM YYYY, HH:mm z` |
 | timezone | string | No | `'Europe/London'` | `'Europe/London'` |
+| padding | boolean | No | `true` | `false` |
 | prefix | string | No | `null` | `Updated` |
 | suffix | string | No | `null` | `This is a suffix` |
 | script | object | Yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, } |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,13 +16,13 @@
       "dev": true,
       "requires": {
         "jest-styled-components": "^6.3.1",
-        "react-test-renderer": "^16.8.6"
+        "react-test-renderer": "^16.6.3"
       }
     },
     "@bbc/psammead-timestamp": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.3.2.tgz",
-      "integrity": "sha512-CayEqjUCBj7vciKf26eisSZZOV5KX+tp5rIGaEoOKpY51R/Zyb2h1OfW1lA7lVrVQFhAVA/kUUGRW4DI3bH40Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-0.3.3.tgz",
+      "integrity": "sha512-dCVji/Nq5D7M/3Pp68Tutzd/4tqQDvLPdm1MsOa1Foi+7OaozJmJp2qAvpupEuBk20s9xWjnFrBWZaOa1PBAiw==",
       "requires": {
         "@bbc/gel-foundations": "^1.2.0"
       },
@@ -116,6 +116,18 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
+      }
+    },
+    "react": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
       }
     },
     "react-is": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "description": "React Timestamp container for relative and absolute times, using moment-timezone",
   "repository": {
@@ -24,10 +24,14 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "^2.0.0",
-    "@bbc/psammead-timestamp": "^0.3.2",
+    "@bbc/psammead-timestamp": "^0.3.3",
     "moment-timezone": "^0.5.25"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^0.3.4"
+    "@bbc/psammead-test-helpers": "^0.3.4",
+    "react": "^16.8.6"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6"
   }
 }

--- a/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Timestamp should add prefix and suffix 1`] = `
 .c0 {
   font-size: 0.875rem;
   line-height: 1rem;
-  color: #757575;
+  color: #6E6E73;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding-bottom: 0.25rem;
@@ -44,7 +44,7 @@ exports[`Timestamp should render correctly 1`] = `
 .c0 {
   font-size: 0.875rem;
   line-height: 1rem;
-  color: #757575;
+  color: #6E6E73;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding-bottom: 0.25rem;
@@ -80,7 +80,7 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
 .c0 {
   font-size: 0.875rem;
   line-height: 1rem;
-  color: #757575;
+  color: #6E6E73;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   padding-bottom: 0.25rem;

--- a/packages/containers/psammead-timestamp-container/src/index.jsx
+++ b/packages/containers/psammead-timestamp-container/src/index.jsx
@@ -13,6 +13,7 @@ const TimestampContainer = ({
   dateTimeFormat,
   format,
   isRelative,
+  padding,
   prefix,
   suffix,
   timezone,
@@ -25,6 +26,7 @@ const TimestampContainer = ({
   return (
     <Timestamp
       datetime={formatUnixTimestamp(timestamp, dateTimeFormat, timezone)}
+      padding={padding}
       script={script}
     >
       {prefix ? `${prefix} ` : null}
@@ -40,6 +42,7 @@ TimestampContainer.propTypes = {
   isRelative: bool,
   format: string,
   timezone: string,
+  padding: bool,
   prefix: string,
   suffix: string,
   script: shape(scriptPropType).isRequired,
@@ -49,6 +52,7 @@ TimestampContainer.defaultProps = {
   isRelative: false,
   format: null,
   timezone: 'Europe/London',
+  padding: true,
   prefix: null,
   suffix: null,
 };


### PR DESCRIPTION
Resolves #590

**Overall change:** Updates the timestamp container to depend upon the latest version of the timestamp component, and passes through the `padding` prop.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval