### PR TITLE
Allow dynamic placement of copyright component

### DIFF
--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.4.0   | [PR#617](https://github.com/bbc/psammead/pull/617) Add optional `position` prop, and default position to left of its parent container |
+| 1.0.0   | [PR#617](https://github.com/bbc/psammead/pull/617) Add optional `position` prop, and default position to left of its parent container |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.4.0   | [PR#617](https://github.com/bbc/psammead/pull/617) Add optional `position` prop, and default position to left of its parent container |
 | 0.3.7   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
 | 0.3.6   | [PR#417](https://github.com/bbc/psammead/pull/417) Add text input knob to Copyright |
 | 0.3.5   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "description": "React styled component for overlaid copyright or source attribution.",
   "repository": {

--- a/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
@@ -22,3 +22,26 @@ exports[`Copyright should render correctly 1`] = `
   Getty Images
 </p>
 `;
+
+exports[`Copyright should render correctly when passed prop position with value "right" 1`] = `
+.c0 {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  background-color: rgba(34,34,34,0.75);
+  text-transform: uppercase;
+  color: #FFFFFF;
+  padding: 0.25rem 0.5rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  position: absolute;
+  bottom: 0;
+  margin: 0;
+  right: 0;
+}
+
+<p
+  className="c0"
+  role="text"
+>
+  Getty Images
+</p>
+`;

--- a/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-copyright/src/__snapshots__/index.test.jsx.snap
@@ -11,8 +11,8 @@ exports[`Copyright should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   position: absolute;
   bottom: 0;
-  right: 0;
   margin: 0;
+  left: 0;
 }
 
 <p

--- a/packages/components/psammead-copyright/src/index.jsx
+++ b/packages/components/psammead-copyright/src/index.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { oneOf } from 'prop-types';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING, GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
 import { GEL_MINION, GEL_FF_REITH_SANS } from '@bbc/gel-foundations/typography';
@@ -14,8 +15,16 @@ const Copyright = styled.p.attrs({
   font-family: ${GEL_FF_REITH_SANS};
   position: absolute;
   bottom: 0;
-  right: 0;
   margin: 0;
+  ${props => props.position}: 0;
 `;
+
+Copyright.propTypes = {
+  position: oneOf(['left', 'right']),
+};
+
+Copyright.defaultProps = {
+  position: 'left',
+};
 
 export default Copyright;

--- a/packages/components/psammead-copyright/src/index.stories.jsx
+++ b/packages/components/psammead-copyright/src/index.stories.jsx
@@ -1,26 +1,38 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, select, text } from '@storybook/addon-knobs';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import notes from '../README.md';
 import Copyright from './index';
-
+// inputProvider([{ name: 'Caption' }], ([captionText], script) => (
+//   <Caption script={script}>{captionText}</Caption>
+// )),
 storiesOf('Components|Copyright', module)
   .addDecorator(withKnobs)
   .add(
     'default',
-    () => <Copyright>{text('copyright', 'Getty Images')}</Copyright>,
+    () => {
+      const position = select('Position', ['left', 'right'], 'left');
+      return (
+        <Copyright position={position}>
+          {text('copyright', 'Getty Images')}
+        </Copyright>
+      );
+    },
     { notes, knobs: { escapeHTML: false } },
   )
   .add(
     'with visually hidden text',
-    () => (
-      <Copyright>
-        <VisuallyHiddenText>
-          {text('visually hidden text', 'Image source, ')}
-        </VisuallyHiddenText>
-        {text('copyright', 'Getty Images')}
-      </Copyright>
-    ),
+    () => {
+      const position = select('Position', ['left', 'right'], 'left');
+      return (
+        <Copyright position={position}>
+          <VisuallyHiddenText>
+            {text('visually hidden text', 'Image source, ')}
+          </VisuallyHiddenText>
+          {text('copyright', 'Getty Images')}
+        </Copyright>
+      );
+    },
     { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-copyright/src/index.stories.jsx
+++ b/packages/components/psammead-copyright/src/index.stories.jsx
@@ -4,9 +4,7 @@ import { withKnobs, select, text } from '@storybook/addon-knobs';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import notes from '../README.md';
 import Copyright from './index';
-// inputProvider([{ name: 'Caption' }], ([captionText], script) => (
-//   <Caption script={script}>{captionText}</Caption>
-// )),
+
 storiesOf('Components|Copyright', module)
   .addDecorator(withKnobs)
   .add(

--- a/packages/components/psammead-copyright/src/index.test.jsx
+++ b/packages/components/psammead-copyright/src/index.test.jsx
@@ -7,4 +7,9 @@ describe('Copyright', () => {
     'should render correctly',
     <Copyright>Getty Images</Copyright>,
   );
+
+  shouldMatchSnapshot(
+    'should render correctly when passed prop position with value "right"',
+    <Copyright position="right">Getty Images</Copyright>,
+  );
 });


### PR DESCRIPTION
Resolves #552 

**Overall change:** Change the default absolute position of `psammead-copyright` from right, to left. Allow it to be overridden to `right` with a prop named `position`.

**Code changes:**

- Snapshots updated
- Pass optional prop `position` to `psammead-copyright`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval