### PR TITLE
Bump psammead-image to 0.4.0

### DIFF
--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "description": "React styled components for an Image",
   "repository": {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** #618 didn't update the `package.json` with a new version. This does it. 

**Code changes:**

- Change version in `package-lock.json`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval