### PR TITLE
Timestamp container datetime bug

### DIFF
--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.1 | [PR#TBC](https://github.com/bbc/psammead/pull/TBC) Do not localise `datetime` |
 | 1.2.0 | [PR#643](https://github.com/bbc/psammead/pull/643) Add support for passing locales as prop |
 | 1.1.0 | [PR#592](https://github.com/bbc/psammead/pull/592) Receive a padding; pass a padding |
 | 1.0.0 | [PR#532](https://github.com/bbc/psammead/pull/532) Initial creation of package |

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.2.1 | [PR#TBC](https://github.com/bbc/psammead/pull/TBC) Do not localise `datetime` |
+| 1.2.1 | [PR#666](https://github.com/bbc/psammead/pull/666) Do not localise `datetime` |
 | 1.2.0 | [PR#643](https://github.com/bbc/psammead/pull/643) Add support for passing locales as prop |
 | 1.1.0 | [PR#592](https://github.com/bbc/psammead/pull/592) Receive a padding; pass a padding |
 | 1.0.0 | [PR#532](https://github.com/bbc/psammead/pull/532) Initial creation of package |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "description": "React Timestamp container for relative and absolute times, using moment-timezone",
   "repository": {

--- a/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`Timestamp should add prefix and suffix 1`] = `
 
 <time
   className="c0"
-  dateTime="۲۰۱۸-۱۰-۱۹"
+  dateTime="2018-10-19"
 >
   Prefix here  
   ۱۹ اکتبر ۲۰۱۸
@@ -70,7 +70,7 @@ exports[`Timestamp should render correctly 1`] = `
 
 <time
   className="c0"
-  dateTime="۲۰۱۸-۱۰-۱۹"
+  dateTime="2018-10-19"
 >
   ۱۹ اکتبر ۲۰۱۸
 </time>
@@ -106,7 +106,7 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
 
 <time
   className="c0"
-  dateTime="۲۰۱۸-۰۷-۰۷"
+  dateTime="2018-07-07"
 >
   ۷ ژوئیه ۲۰۱۸
 </time>

--- a/packages/containers/psammead-timestamp-container/src/index.jsx
+++ b/packages/containers/psammead-timestamp-container/src/index.jsx
@@ -36,7 +36,7 @@ const TimestampContainer = ({
       script={script}
     >
       {prefix ? `${prefix} ` : null}
-      {showRelativeTime(timestamp, isRelative, format, timezone)}
+      {showRelativeTime(timestamp, isRelative, format, timezone, locale)}
       {suffix ? ` ${suffix}` : null}
     </Timestamp>
   );

--- a/packages/containers/psammead-timestamp-container/src/timestampUtilities.js
+++ b/packages/containers/psammead-timestamp-container/src/timestampUtilities.js
@@ -13,17 +13,29 @@ export const isValidDateTime = dateTime => {
 };
 
 // when using this function, we recommend using webpack configuration to only load in the relevant timezone, rather than all of moment-timezone
-export const formatUnixTimestamp = (timestamp, momentString, timezone) =>
+export const formatUnixTimestamp = (
+  timestamp,
+  momentString,
+  timezone,
+  locale = 'en',
+) =>
   moment(timestamp)
+    .locale(locale)
     .tz(timezone)
     .format(momentString);
 
-export const showRelativeTime = (timestamp, isRelative, format, timezone) => {
+export const showRelativeTime = (
+  timestamp,
+  isRelative,
+  format,
+  timezone,
+  locale,
+) => {
   if (isRelative) {
     return relativeTime(timestamp);
   }
   if (format) {
-    return formatUnixTimestamp(timestamp, format, timezone);
+    return formatUnixTimestamp(timestamp, format, timezone, locale);
   }
   return formatUnixTimestamp(timestamp, defaultFormat, timezone);
 };


### PR DESCRIPTION
Resolves #651 

**Overall change:** 
Updated Timestamp Container to not localise the value of `datetime`.

**Code changes:**
- Updated the `formatUnixTimestamp` in `timestampUtilities` to set the locale to default to 'en' unless other value specified
- add `locale` to `showRelativeTime` function to localise the timestamp visible on the page
- updated snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval