### PR TITLE
Media Indicator and Link position bugs

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.0-alpha.1 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Fix floating media indicator and promo link bugs  |
 | 1.0.0-alpha.0 | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.2.0-alpha.9 | [PR#663](https://github.com/bbc/psammead/pull/663) Add assertion tests |
 | 0.2.0-alpha.8 | [PR#578](https://github.com/bbc/psammead/pull/578) Add Top Story promo design |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0-alpha.1 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Fix floating media indicator and promo link bugs  |
+| 1.0.0-alpha.1 | [PR#694](https://github.com/bbc/psammead/pull/694) Fix floating media indicator and promo link bugs  |
 | 1.0.0-alpha.0 | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.2.0-alpha.9 | [PR#663](https://github.com/bbc/psammead/pull/663) Add assertion tests |
 | 0.2.0-alpha.8 | [PR#578](https://github.com/bbc/psammead/pull/578) Add Top Story promo design |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 }
 
 .c2 {
-  display: relative;
+  position: relative;
 }
 
 .c4 {
@@ -272,7 +272,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 }
 
 .c2 {
-  display: relative;
+  position: relative;
 }
 
 .c3 {
@@ -532,7 +532,7 @@ exports[`StoryPromo should render correctly 1`] = `
 }
 
 .c2 {
-  display: relative;
+  position: relative;
 }
 
 .c4 {
@@ -787,7 +787,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 }
 
 .c2 {
-  display: relative;
+  position: relative;
 }
 
 .c10 {

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StoryPromo - Top Story should render correctly 1`] = `
+.c0 {
+  position: relative;
+}
+
 .c1 {
   display: inline-block;
   vertical-align: top;
@@ -8,7 +12,11 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   margin-bottom: 0.5rem;
 }
 
-.c3 {
+.c2 {
+  display: relative;
+}
+
+.c4 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-size: 1.25rem;
@@ -20,7 +28,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   font-weight: 700;
 }
 
-.c5 {
+.c6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #3F3F42;
@@ -29,19 +37,19 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c2 {
+.c3 {
   display: inline-block;
   vertical-align: top;
 }
 
-.c4 {
+.c5 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c4:before {
+.c5:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -53,20 +61,14 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   z-index: 1;
 }
 
-.c4:hover,
-.c4:focus {
+.c5:hover,
+.c5:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c4:visited {
+.c5:visited {
   color: #6E6E73;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    position: relative;
-  }
 }
 
 @supports (display:grid) {
@@ -99,74 +101,74 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c4 {
     font-size: 1.375rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1.75rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
+  .c6 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 {
+  .c6 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     max-width: 66.67%;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c3 {
     max-width: 66.67%;
   }
 }
 
 @supports (display:grid) {
-  .c2 {
+  .c3 {
     display: block;
     max-width: initial;
     padding: initial;
@@ -180,26 +182,30 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   <div
     className="c1"
   >
-    <img
-      alt="Alt text"
-      src="https://foobar.com/image.png"
-    />
+    <div
+      className="c2"
+    >
+      <img
+        alt="Alt text"
+        src="https://foobar.com/image.png"
+      />
+    </div>
   </div>
   <div
-    className="c2"
+    className="c3"
   >
     <h3
-      className="c3"
+      className="c4"
     >
       <a
-        className="c4"
+        className="c5"
         href="https://www.bbc.co.uk/news"
       >
         The headline of the promo
       </a>
     </h3>
     <p
-      className="c5"
+      className="c6"
     >
       The summary of the promo
     </p>
@@ -211,7 +217,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 `;
 
 exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`] = `
-.c7 {
+.c8 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -222,7 +228,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   width: 1px;
 }
 
-.c3 {
+.c4 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
   display: inline-block;
@@ -232,7 +238,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   color: #222222;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -243,15 +249,19 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   align-items: center;
 }
 
-.c5 {
+.c6 {
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
 }
 
-.c6 {
+.c7 {
   vertical-align: middle;
   margin: 0 0.25rem;
+}
+
+.c0 {
+  position: relative;
 }
 
 .c1 {
@@ -262,11 +272,15 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 }
 
 .c2 {
+  display: relative;
+}
+
+.c3 {
   position: absolute;
   bottom: 0;
 }
 
-.c9 {
+.c10 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-size: 1.25rem;
@@ -278,7 +292,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   font-weight: 700;
 }
 
-.c11 {
+.c12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #3F3F42;
@@ -287,19 +301,19 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   padding-bottom: 0.5rem;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   vertical-align: top;
 }
 
-.c10 {
+.c11 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c10:before {
+.c11:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -311,20 +325,14 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   z-index: 1;
 }
 
-.c10:hover,
-.c10:focus {
+.c11:hover,
+.c11:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c10:visited {
+.c11:visited {
   color: #6E6E73;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    position: relative;
-  }
 }
 
 @supports (display:grid) {
@@ -357,74 +365,74 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c10 {
     font-size: 1.375rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1.75rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c11 {
+  .c12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c11 {
+  .c12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     max-width: 66.67%;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c8 {
+  .c9 {
     max-width: 66.67%;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c9 {
     display: block;
     max-width: initial;
     padding: initial;
@@ -438,65 +446,69 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   <div
     className="c1"
   >
-    <img
-      alt="Alt text"
-      src="https://foobar.com/image.png"
-    />
     <div
       className="c2"
     >
+      <img
+        alt="Alt text"
+        src="https://foobar.com/image.png"
+      />
       <div
         className="c3"
       >
         <div
           className="c4"
         >
-          <svg
-            aria-hidden="true"
+          <div
             className="c5"
-            focusable="false"
-            height="12px"
-            viewBox="0 0 32 32"
-            width="12px"
           >
-            <polygon
-              points="3,32 29,16 3,0"
-            />
-          </svg>
-          <time
-            className="c6"
-            dateTime="PT2M15S"
-          >
-            <span
-              className="c7"
-            >
-              Video 2 minutes 15 seconds
-            </span>
-            <span
+            <svg
               aria-hidden="true"
+              className="c6"
+              focusable="false"
+              height="12px"
+              viewBox="0 0 32 32"
+              width="12px"
             >
-              2:15
-            </span>
-          </time>
+              <polygon
+                points="3,32 29,16 3,0"
+              />
+            </svg>
+            <time
+              className="c7"
+              dateTime="PT2M15S"
+            >
+              <span
+                className="c8"
+              >
+                Video 2 minutes 15 seconds
+              </span>
+              <span
+                aria-hidden="true"
+              >
+                2:15
+              </span>
+            </time>
+          </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="c8"
+    className="c9"
   >
     <h3
-      className="c9"
+      className="c10"
     >
       <a
-        className="c10"
+        className="c11"
         href="https://www.bbc.co.uk/news"
       >
         The headline of the promo
       </a>
     </h3>
     <p
-      className="c11"
+      className="c12"
     >
       The summary of the promo
     </p>
@@ -508,6 +520,10 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 `;
 
 exports[`StoryPromo should render correctly 1`] = `
+.c0 {
+  position: relative;
+}
+
 .c1 {
   display: inline-block;
   vertical-align: top;
@@ -515,7 +531,11 @@ exports[`StoryPromo should render correctly 1`] = `
   max-width: 33.33%;
 }
 
-.c3 {
+.c2 {
+  display: relative;
+}
+
+.c4 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-size: 0.9375rem;
@@ -527,7 +547,7 @@ exports[`StoryPromo should render correctly 1`] = `
   font-weight: 700;
 }
 
-.c5 {
+.c6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #3F3F42;
@@ -536,21 +556,21 @@ exports[`StoryPromo should render correctly 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c2 {
+.c3 {
   display: inline-block;
   vertical-align: top;
   max-width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c4 {
+.c5 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c4:before {
+.c5:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -562,20 +582,14 @@ exports[`StoryPromo should render correctly 1`] = `
   z-index: 1;
 }
 
-.c4:hover,
-.c4:focus {
+.c5:hover,
+.c5:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c4:visited {
+.c5:visited {
   color: #6E6E73;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    position: relative;
-  }
 }
 
 @supports (display:grid) {
@@ -601,75 +615,75 @@ exports[`StoryPromo should render correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
+  .c6 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 {
+  .c6 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c5 {
+  .c6 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c3 {
     max-width: 66.67%;
   }
 }
 
 @supports (display:grid) {
-  .c2 {
+  .c3 {
     display: block;
     max-width: initial;
     padding: initial;
@@ -683,26 +697,30 @@ exports[`StoryPromo should render correctly 1`] = `
   <div
     className="c1"
   >
-    <img
-      alt="Alt text"
-      src="https://foobar.com/image.png"
-    />
+    <div
+      className="c2"
+    >
+      <img
+        alt="Alt text"
+        src="https://foobar.com/image.png"
+      />
+    </div>
   </div>
   <div
-    className="c2"
+    className="c3"
   >
     <h3
-      className="c3"
+      className="c4"
     >
       <a
-        className="c4"
+        className="c5"
         href="https://www.bbc.co.uk/news"
       >
         The headline of the promo
       </a>
     </h3>
     <p
-      className="c5"
+      className="c6"
     >
       The summary of the promo
     </p>
@@ -714,7 +732,7 @@ exports[`StoryPromo should render correctly 1`] = `
 `;
 
 exports[`StoryPromo with Media Indicator should render correctly 1`] = `
-.c7 {
+.c8 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -725,7 +743,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   width: 1px;
 }
 
-.c3 {
+.c4 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
   display: inline-block;
@@ -735,7 +753,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   color: #222222;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -746,15 +764,19 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
 }
 
-.c6 {
+.c7 {
   vertical-align: middle;
   margin: 0 0.25rem;
+}
+
+.c0 {
+  position: relative;
 }
 
 .c1 {
@@ -764,7 +786,11 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   max-width: 33.33%;
 }
 
-.c9 {
+.c2 {
+  display: relative;
+}
+
+.c10 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-size: 0.9375rem;
@@ -776,7 +802,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   font-weight: 700;
 }
 
-.c11 {
+.c12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #3F3F42;
@@ -785,21 +811,21 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   vertical-align: top;
   max-width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c10 {
+.c11 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c10:before {
+.c11:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -811,20 +837,14 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   z-index: 1;
 }
 
-.c10:hover,
-.c10:focus {
+.c11:hover,
+.c11:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c10:visited {
+.c11:visited {
   color: #6E6E73;
-}
-
-@media (min-width:25rem) {
-  .c0 {
-    position: relative;
-  }
 }
 
 @supports (display:grid) {
@@ -850,82 +870,82 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 }
 
 @media (min-width:25rem) {
-  .c2 {
+  .c3 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c11 {
+  .c12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c11 {
+  .c12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c11 {
+  .c12 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c8 {
+  .c9 {
     max-width: 66.67%;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c9 {
     display: block;
     max-width: initial;
     padding: initial;
@@ -939,65 +959,69 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   <div
     className="c1"
   >
-    <img
-      alt="Alt text"
-      src="https://foobar.com/image.png"
-    />
     <div
       className="c2"
     >
+      <img
+        alt="Alt text"
+        src="https://foobar.com/image.png"
+      />
       <div
         className="c3"
       >
         <div
           className="c4"
         >
-          <svg
-            aria-hidden="true"
+          <div
             className="c5"
-            focusable="false"
-            height="12px"
-            viewBox="0 0 32 32"
-            width="12px"
           >
-            <polygon
-              points="3,32 29,16 3,0"
-            />
-          </svg>
-          <time
-            className="c6"
-            dateTime="PT2M15S"
-          >
-            <span
-              className="c7"
-            >
-              Video 2 minutes 15 seconds
-            </span>
-            <span
+            <svg
               aria-hidden="true"
+              className="c6"
+              focusable="false"
+              height="12px"
+              viewBox="0 0 32 32"
+              width="12px"
             >
-              2:15
-            </span>
-          </time>
+              <polygon
+                points="3,32 29,16 3,0"
+              />
+            </svg>
+            <time
+              className="c7"
+              dateTime="PT2M15S"
+            >
+              <span
+                className="c8"
+              >
+                Video 2 minutes 15 seconds
+              </span>
+              <span
+                aria-hidden="true"
+              >
+                2:15
+              </span>
+            </time>
+          </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="c8"
+    className="c9"
   >
     <h3
-      className="c9"
+      className="c10"
     >
       <a
-        className="c10"
+        className="c11"
         href="https://www.bbc.co.uk/news"
       >
         The headline of the promo
       </a>
     </h3>
     <p
-      className="c11"
+      className="c12"
     >
       The summary of the promo
     </p>

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -36,9 +36,7 @@ const eightOfTwelveColumnsMaxScaleable = `66.67%`;
 // (8 / 12) * 100 = 66.6666666667 = 66.67%
 
 const StoryPromoWrapper = styled.div`
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    position: relative;
-  }
+  position: relative;
 
   @supports (display: grid) {
     display: grid;
@@ -107,6 +105,10 @@ const ImageGridItem = styled.div`
     ${({ topStory }) =>
       topStory ? ImageGridColumnsTopStory : ImageGridColumns}
   }
+`;
+
+const ImageContentsWrap = styled.div`
+  display: relative;
 `;
 
 const InlineMediaIndicator = styled.div`
@@ -246,12 +248,14 @@ export const Link = styled.a`
 const StoryPromo = ({ image, info, mediaIndicator, topStory }) => (
   <StoryPromoWrapper>
     <ImageGridItem topStory={topStory}>
-      {image}
-      {mediaIndicator && (
-        <InlineMediaIndicator topStory={topStory}>
-          {mediaIndicator}
-        </InlineMediaIndicator>
-      )}
+      <ImageContentsWrap>
+        {image}
+        {mediaIndicator && (
+          <InlineMediaIndicator topStory={topStory}>
+            {mediaIndicator}
+          </InlineMediaIndicator>
+        )}
+      </ImageContentsWrap>
     </ImageGridItem>
     <TextGridItem topStory={topStory}>{info}</TextGridItem>
   </StoryPromoWrapper>

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -107,7 +107,7 @@ const ImageGridItem = styled.div`
   }
 `;
 
-const ImageContentsWrap = styled.div`
+const ImageContentsWrapper = styled.div`
   position: relative;
 `;
 
@@ -248,14 +248,14 @@ export const Link = styled.a`
 const StoryPromo = ({ image, info, mediaIndicator, topStory }) => (
   <StoryPromoWrapper>
     <ImageGridItem topStory={topStory}>
-      <ImageContentsWrap>
+      <ImageContentsWrapper>
         {image}
         {mediaIndicator && (
           <InlineMediaIndicator topStory={topStory}>
             {mediaIndicator}
           </InlineMediaIndicator>
         )}
-      </ImageContentsWrap>
+      </ImageContentsWrapper>
     </ImageGridItem>
     <TextGridItem topStory={topStory}>{info}</TextGridItem>
   </StoryPromoWrapper>

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -108,7 +108,7 @@ const ImageGridItem = styled.div`
 `;
 
 const ImageContentsWrap = styled.div`
-  display: relative;
+  position: relative;
 `;
 
 const InlineMediaIndicator = styled.div`

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { inputProvider } from '@bbc/psammead-storybook-helpers';
@@ -46,6 +47,12 @@ const MediaIndicatorComponent = (
   />
 );
 
+const Padding = styled.div`
+  width: 100%;
+  height: 400px;
+  background-color: blue;
+`;
+
 const generateStory = ({ mediaIndicator, topStory }) =>
   inputProvider(
     [{ name: 'Headline' }, { name: 'Summary' }],
@@ -60,12 +67,15 @@ const generateStory = ({ mediaIndicator, topStory }) =>
       );
 
       return (
-        <StoryPromo
-          image={Img}
-          info={Info}
-          mediaIndicator={mediaIndicator && MediaIndicatorComponent}
-          topStory={topStory}
-        />
+        <Fragment>
+          <Padding />
+          <StoryPromo
+            image={Img}
+            info={Info}
+            mediaIndicator={mediaIndicator && MediaIndicatorComponent}
+            topStory={topStory}
+          />
+        </Fragment>
       );
     },
   );

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { inputProvider } from '@bbc/psammead-storybook-helpers';
@@ -47,12 +46,6 @@ const MediaIndicatorComponent = (
   />
 );
 
-const Padding = styled.div`
-  width: 100%;
-  height: 400px;
-  background-color: blue;
-`;
-
 const generateStory = ({ mediaIndicator, topStory }) =>
   inputProvider(
     [{ name: 'Headline' }, { name: 'Summary' }],
@@ -67,15 +60,12 @@ const generateStory = ({ mediaIndicator, topStory }) =>
       );
 
       return (
-        <Fragment>
-          <Padding />
-          <StoryPromo
-            image={Img}
-            info={Info}
-            mediaIndicator={mediaIndicator && MediaIndicatorComponent}
-            topStory={topStory}
-          />
-        </Fragment>
+        <StoryPromo
+          image={Img}
+          info={Info}
+          mediaIndicator={mediaIndicator && MediaIndicatorComponent}
+          topStory={topStory}
+        />
       );
     },
   );


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/2071
Resolves #685

**Overall change:** Updates story promo to resolve 2 positioning bugs

**Code changes:**

- Adds some position: relative were needed

Testing #2071
Add a blank area to the story to ensure the link doesnt spill out. To do this I added a [padding component](https://github.com/bbc/psammead/blob/009e311cfa2884c649a43b412e9661e5a908f0ce/packages/components/psammead-story-promo/src/index.stories.jsx#L50-L54) and inserted this into the story [like this](https://github.com/bbc/psammead/blob/009e311cfa2884c649a43b412e9661e5a908f0ce/packages/components/psammead-story-promo/src/index.stories.jsx#L71) in browserstack, if I tap the blue area, it doesnt click the link, unlike before.

Testing #685
Edit the headline text in the dev tools to be reeeeeeally long, the media indicator shouldn't drop with it.

General regression of top story and media indicator behaviour needed :) 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval