### PR TITLE
Give Navigation a max-width of 80rem

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0-alpha.1 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Update Navigation to have a max-width of 80rem. |
+| 1.0.0-alpha.1 | [PR#711](https://github.com/BBC/psammead/pull/711) Update Navigation to have a max-width of 80rem. |
 | 1.0.0-alpha.0 | [PR#637](https://github.com/BBC/psammead/pull/637) Create initial package with Navigation component. |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0-alpha.1 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Update Navigation to have a max-width of 80rem. |
 | 1.0.0-alpha.0 | [PR#637](https://github.com/BBC/psammead/pull/637) Create initial package with Navigation component. |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -149,20 +149,20 @@
       "dev": true
     },
     "@bbc/psammead-brand": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-4.1.0.tgz",
-      "integrity": "sha512-UO7qPmjREEajIHTb+GTLDcldJQcQkiVszgpDvtDFL835lpHCI+Bg2+ltidnG76ix5PyburaNl045+nX9F5jRTA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-4.1.2.tgz",
+      "integrity": "sha512-yBvMdmonCCmDzmLSBI1R7MqO4fgABNaIsyA2qpcwYgxi5pYfVyDjxBZs7m03tblxwtrKal4OIWgDc7salhTEnw==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^0.3.0",
+        "@bbc/gel-foundations": "^3.0.0",
         "@bbc/psammead-styles": "^0.3.2",
         "@bbc/psammead-visually-hidden-text": "^0.1.10"
       },
       "dependencies": {
         "@bbc/gel-foundations": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-0.3.0.tgz",
-          "integrity": "sha512-YWnHJ4b7ejvKX5IvTL5ualBCwrAEc/4yfn3hNp8h8v5URnb2zQ8l7lWjbhcxjmbLbVVRqPNa97mkp75ApyxvwQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.0.tgz",
+          "integrity": "sha512-dHVZ+ig1P/crQtvAOP0bB0PAuuqT2R8hs15pZDsJsO1wvPtbvEe2TO6AxXUIODk9TZgod2j+9K6TB4WV/I2LDw==",
           "dev": true
         }
       }

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -27,7 +27,7 @@
     "@bbc/psammead-test-helpers": "^0.3.3",
     "react": "^16.8.6",
     "styled-components": "^4.1.3",
-    "@bbc/psammead-brand": "^4.1.0"
+    "@bbc/psammead-brand": "^4.1.2"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Navigation should render correctly 1`] = `
-.c6 {
+.c7 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -14,10 +14,15 @@ exports[`Navigation should render correctly 1`] = `
 
 .c0 {
   background-color: #B80000;
-  position: relative;
 }
 
 .c1 {
+  position: relative;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c2 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -37,18 +42,18 @@ exports[`Navigation should render correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c1:focus {
+.c2:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
   clip: auto;
-  top: -3.75rem;
-  left: 1rem;
   height: auto;
   width: auto;
+  top: -3rem;
+  left: 0.5rem;
 }
 
-.c2 {
+.c3 {
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -56,13 +61,13 @@ exports[`Navigation should render correctly 1`] = `
   overflow: hidden;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
-.c3::after {
+.c4::after {
   content: '';
   position: absolute;
   bottom: 0;
@@ -72,7 +77,7 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
 }
 
-.c4 {
+.c5 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -84,7 +89,7 @@ exports[`Navigation should render correctly 1`] = `
   padding: 0.75rem 1rem;
 }
 
-.c4:hover::after {
+.c5:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -94,7 +99,7 @@ exports[`Navigation should render correctly 1`] = `
   border-bottom: 0.3125rem solid #FFFFFF;
 }
 
-.c4:focus::after {
+.c5:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -105,7 +110,7 @@ exports[`Navigation should render correctly 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
-.c7 {
+.c8 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -117,7 +122,7 @@ exports[`Navigation should render correctly 1`] = `
   padding: 0.75rem 1rem;
 }
 
-.c7:hover::after {
+.c8:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -126,7 +131,7 @@ exports[`Navigation should render correctly 1`] = `
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.c7:focus::after {
+.c8:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -137,7 +142,7 @@ exports[`Navigation should render correctly 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
-.c5::after {
+.c6::after {
   content: '';
   position: absolute;
   left: 0;
@@ -147,62 +152,67 @@ exports[`Navigation should render correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c1 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-@media (max-width:24.9375rem) {
-  .c1:focus {
-    top: -3rem;
-    left: 0.5rem;
+@media (min-width:37.5rem) {
+  .c2:focus {
+    top: -4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c2:focus {
+    left: 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c4 {
+  .c5 {
     padding: 0.75rem 0.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
+  .c8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c7 {
+  .c8 {
     padding: 0.75rem 0.5rem;
   }
 }
@@ -211,75 +221,79 @@ exports[`Navigation should render correctly 1`] = `
   className="c0"
   role="navigation"
 >
-  <a
+  <div
     className="c1"
-    href="#content"
   >
-    Wụga n’ọdịnaya
-  </a>
-  <ul
-    className="c2"
-    role="list"
-  >
-    <li
-      className="c3"
-      dir="ltr"
-      role="listitem"
+    <a
+      className="c2"
+      href="#content"
     >
-      <a
+      Wụga n’ọdịnaya
+    </a>
+    <ul
+      className="c3"
+      role="list"
+    >
+      <li
         className="c4"
-        href="/igbo"
+        dir="ltr"
+        role="listitem"
       >
-        <span
+        <a
           className="c5"
-          role="text"
+          href="/igbo"
         >
           <span
             className="c6"
+            role="text"
           >
-            Current page
-            , 
+            <span
+              className="c7"
+            >
+              Current page
+              , 
+            </span>
+            Akụkọ
           </span>
-          Akụkọ
-        </span>
-      </a>
-    </li>
-    <li
-      className="c3"
-      dir="ltr"
-      role="listitem"
-    >
-      <a
-        className="c7"
-        href="/igbo/egwuregwu"
+        </a>
+      </li>
+      <li
+        className="c4"
+        dir="ltr"
+        role="listitem"
       >
-        Egwuregwu
-      </a>
-    </li>
-    <li
-      className="c3"
-      dir="ltr"
-      role="listitem"
-    >
-      <a
-        className="c7"
-        href="/igbo/media/video"
+        <a
+          className="c8"
+          href="/igbo/egwuregwu"
+        >
+          Egwuregwu
+        </a>
+      </li>
+      <li
+        className="c4"
+        dir="ltr"
+        role="listitem"
       >
-        Ihe nkiri
-      </a>
-    </li>
-    <li
-      className="c3"
-      dir="ltr"
-      role="listitem"
-    >
-      <a
-        className="c7"
-        href="/igbo/popular/read"
+        <a
+          className="c8"
+          href="/igbo/media/video"
+        >
+          Ihe nkiri
+        </a>
+      </li>
+      <li
+        className="c4"
+        dir="ltr"
+        role="listitem"
       >
-        Nke ka ewuewu
-      </a>
-    </li>
-  </ul>
+        <a
+          className="c8"
+          href="/igbo/popular/read"
+        >
+          Nke ka ewuewu
+        </a>
+      </li>
+    </ul>
+  </div>
 </nav>
 `;

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -10,6 +10,7 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import { getPica, GEL_FF_REITH_SANS } from '@bbc/gel-foundations/typography';
@@ -24,12 +25,17 @@ const BORDER_COLOR = '#eab3b3';
 /* Skip to content */
 const SKIP_LINK_COLOR = '#333';
 const SKIP_LINK_BORDER = '0.1875rem'; // 3px
-const SKIP_LINK_TOP_POSITION_LARGE = '-3.75rem'; // -60px
+const SKIP_LINK_TOP_POSITION_LARGE = '-4rem'; // -64px
 const SKIP_LINK_TOP_POSITION_SMALL = '-3rem'; // -48px
 
 const StyledNav = styled.nav`
   background-color: ${C_POSTBOX};
+`;
+
+const NavWrapper = styled.div`
   position: relative;
+  max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
+  margin: 0 auto;
 `;
 
 const SkipLink = styled.a`
@@ -50,14 +56,17 @@ const SkipLink = styled.a`
   &:focus {
     clip-path: none;
     clip: auto;
-    top: ${SKIP_LINK_TOP_POSITION_LARGE};
-    left: ${GEL_SPACING_DBL};
     height: auto;
     width: auto;
+    top: ${SKIP_LINK_TOP_POSITION_SMALL};
+    left: ${GEL_SPACING};
 
-    @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
-      top: ${SKIP_LINK_TOP_POSITION_SMALL};
-      left: ${GEL_SPACING};
+    @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+      top: ${SKIP_LINK_TOP_POSITION_LARGE};
+    }
+
+    @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+      left: 0;
     }
   }
 `;
@@ -183,10 +192,12 @@ export const NavigationLi = ({
 
 const Navigation = ({ children, script, skipLinkText }) => (
   <StyledNav role="navigation">
-    <SkipLink href="#content" script={script}>
-      {skipLinkText}
-    </SkipLink>
-    {children}
+    <NavWrapper>
+      <SkipLink href="#content" script={script}>
+        {skipLinkText}
+      </SkipLink>
+      {children}
+    </NavWrapper>
   </StyledNav>
 );
 

--- a/packages/components/psammead-navigation/src/index.stories.jsx
+++ b/packages/components/psammead-navigation/src/index.stories.jsx
@@ -101,6 +101,7 @@ const getBrand = () => {
       minWidth={minWidthInput}
       maxWidth={maxWidthInput}
       svg={svgs[svgChoice]}
+      url="https://www.bbc.com/news"
       borderBottom={borderBottom}
       borderTop={borderTop}
     />


### PR DESCRIPTION
Resolves #708

**Overall change:**
Update Navigation to have a max-width of 80rem.

**Code changes:**
- Add a wrapper within the `StyledNav` with a max-width of 80rem.
- Tweak `SkipLink` to match with the brand.
- Use the brand with a link in the igbo story.
- Update snapshots.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval