### PR TITLE
Hover gap below media indicator 

### DIFF
--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.2   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Fix hover cap on older browsers |
+| 1.0.2   | [PR#722](https://github.com/bbc/psammead/pull/722) Fix hover cap on older browsers |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0   | [PR#679](https://github.com/BBC-News/psammead/pull/679) Bump version number |
 | 0.2.1   | [PR#644](https://github.com/BBC-News/psammead/pull/644) Fixes for screenreader UX |

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.2   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Fix hover cap on older browsers |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0   | [PR#679](https://github.com/BBC-News/psammead/pull/679) Bump version number |
 | 0.2.1   | [PR#644](https://github.com/BBC-News/psammead/pull/644) Fixes for screenreader UX |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "description": "Provides a play icon and media duration for media page promos",
   "repository": {

--- a/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`MediaIndicator should render audio correctly without duration details 1
 .c0 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
-  display: inline-block;
+  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -92,7 +92,7 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
 .c0 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
-  display: inline-block;
+  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -174,7 +174,7 @@ exports[`MediaIndicator should render video by default 1`] = `
 .c0 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
-  display: inline-block;
+  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -242,7 +242,7 @@ exports[`MediaIndicator should render video correctly without duration details 1
 .c0 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
-  display: inline-block;
+  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -310,7 +310,7 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
 .c0 {
   padding: 0.5rem 0.25rem;
   background-color: #FFFFFF;
-  display: inline-block;
+  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-size: 0.75rem;
   line-height: 1rem;

--- a/packages/components/psammead-media-indicator/src/index.jsx
+++ b/packages/components/psammead-media-indicator/src/index.jsx
@@ -10,7 +10,7 @@ import mediaIcons from './mediaIcons';
 const MediaIndicatorWrapper = styled.div`
   padding: ${GEL_SPACING} ${GEL_SPACING_HLF};
   background-color: ${C_WHITE};
-  display: inline-block;
+  display: block;
   font-family: ${GEL_FF_REITH_SANS};
   ${GEL_MINION};
   color: ${C_EBON};


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/620

**Overall change:** Fixes gap below media indicator

![image](https://user-images.githubusercontent.com/11341355/60299644-21b72080-9925-11e9-8354-6b7ac55ad8dd.png)


**Code changes:**

- Changed a display style

**Testing:**
1) Checkout branch in psammead 
2) `npm run ci:packages && npm run build`
3) In Simorgh `cp -r ../psammead/packages/components/psammead-media-indicator/dist/ ./node_modules/@bbc/psammead-media-indicator/dist`
4) In Simorgh `npm run build && npm start`
5) Test using browserstack on `http://localhost:7080/igbo`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval