### PR TITLE
Remove alpha tag from Navigation

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#XX](https://github.com/BBC/psammead/pull/XX) Remove alpha tag |
+| 1.0.0 | [PR#740](https://github.com/BBC/psammead/pull/740) Remove alpha tag |
 | 1.0.0-alpha.1 | [PR#711](https://github.com/BBC/psammead/pull/711) Update Navigation to have a max-width of 80rem. |
 | 1.0.0-alpha.0 | [PR#637](https://github.com/BBC/psammead/pull/637) Create initial package with Navigation component. |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,5 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#XX](https://github.com/BBC/psammead/pull/XX) Remove alpha tag |
 | 1.0.0-alpha.1 | [PR#711](https://github.com/BBC/psammead/pull/711) Update Navigation to have a max-width of 80rem. |
 | 1.0.0-alpha.0 | [PR#637](https://github.com/BBC/psammead/pull/637) Create initial package with Navigation component. |

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -1,7 +1,3 @@
-# ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-navigation - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-navigation%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-navigation%2Fpackage.json) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/section-label--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-navigation.svg)](https://www.npmjs.com/package/@bbc/psammead-navigation) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "repository": {
@@ -37,8 +37,5 @@
   "keywords": [
     "bbc",
     "navigation"
-  ],
-  "publishConfig": {
-    "tag": "alpha"
-  }
+  ]
 }


### PR DESCRIPTION
Resolves #739

**Overall change:** 
After carried out an [Accessibility Swarm](https://github.com/bbc/psammead/issues/614) for the `Navigation` component and double checked that everything tested during its [development](https://github.com/bbc/psammead/pull/637) is fine, we can move forward and remove the alpha tag from the component.

**Code changes:**
- Remove `alpha` tag from the `package.json`
- Bump package to a stable version
- Remove alpha text from `README`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval