### PR TITLE
Remove alpha tag from Story Promo List

### DIFF
--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,8 +3,9 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0-alpha.1 | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
-| 1.0.0-alpha.0 | [PR#679](https://github.com/BBC-News/psammead/pull/679) Bump version number |
-| 0.1.0-alpha.3 | [PR#672](https://github.com/BBC-News/psammead/pull/672) Add margin to top of unordered list |
-| 0.1.0-alpha.2 | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |
-| 0.1.0-alpha.1 | [PR#486](https://github.com/BBC-News/psammead/pull/486) Create initial package. |
+| 1.0.0 | [PR#XX](https://github.com/BBC/psammead/pull/XX) Remove alpha tag |
+| 1.0.0-alpha.1 | [PR#677](https://github.com/BBC/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
+| 1.0.0-alpha.0 | [PR#679](https://github.com/BBC/psammead/pull/679) Bump version number |
+| 0.1.0-alpha.3 | [PR#672](https://github.com/BBC/psammead/pull/672) Add margin to top of unordered list |
+| 0.1.0-alpha.2 | [PR#534](https://github.com/BBC/psammead/pull/534) Remove Timestamp padding. |
+| 0.1.0-alpha.1 | [PR#486](https://github.com/BBC/psammead/pull/486) Create initial package. |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.0 | [PR#XX](https://github.com/BBC/psammead/pull/XX) Remove alpha tag |
+| 1.0.0 | [PR#741](https://github.com/BBC/psammead/pull/741) Remove alpha tag |
 | 1.0.0-alpha.1 | [PR#677](https://github.com/BBC/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0-alpha.0 | [PR#679](https://github.com/BBC/psammead/pull/679) Bump version number |
 | 0.1.0-alpha.3 | [PR#672](https://github.com/BBC/psammead/pull/672) Add margin to top of unordered list |

--- a/packages/components/psammead-story-promo-list/README.md
+++ b/packages/components/psammead-story-promo-list/README.md
@@ -1,6 +1,3 @@
-# ⛔️ This is an alpha component  ⛔️
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-story-promo-list - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-story-promo-list%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-story-promo-list%2Fpackage.json) [![Storybook](https://raw.githubusercontent.com/storybooks/story-promo-list/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/story-promo-list--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-story-promo-list.svg)](https://www.npmjs.com/package/@bbc/psammead-story-promo-list) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description
@@ -13,6 +10,7 @@ The `@bbc/psammead-story-promo-list` package is a set of two components, `StoryP
 
 ## Props
 
+<!-- prettier-ignore -->
 | Argument | Type | Required | Default | Example        |
 | -------- | ---- | -------- | ------- | -------------- |
 | children | node | Yes      | N/A     | `<StoryPromoLi><StoryPromo image={Image} info={Info} /></StoryPromoLi>` |
@@ -33,7 +31,7 @@ const Image = (
 
 const Info = (
   <Fragment>
-    <Headline script={latin}>    
+    <Headline script={latin}>
       <Link href="https://www.bbc.co.uk/news">The headline of the promo</Link>
    </Headline>
     <Summary script={latin}>The summary of the promo</Summary>

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "description": "List of story promos",
   "repository": {
@@ -39,8 +39,5 @@
     "story",
     "promo",
     "list"
-  ],
-  "publishConfig": {
-    "tag": "alpha"
-  }
+  ]
 }


### PR DESCRIPTION
Resolves #737

**Overall change:** 
After carried out an [Accessibility Swarm](https://github.com/bbc/psammead/issues/559) for the `Story Promo List` and didn't find any issue, we can move forward and remove the alpha tag from the component.

**Code changes:**
- Remove `alpha` tag from the `package.json`
- Bump package to a stable version
- Remove alpha text from `README`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval