### PR TITLE
Add role of text to brand vis hid text

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.1.3   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add text role to avoid link fragmented on ios voiceover |
+| 4.1.3   | [PR#747](https://github.com/bbc/psammead/pull/747) Add text role to avoid link fragmented on ios voiceover |
 | 4.1.2   | [PR#684](https://github.com/bbc/psammead/pull/684) Update brand spacing breakpoint to kick in at 25rem |
 | 4.1.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 4.1.0   | [PR#647](https://github.com/bbc/psammead/pull/647) Add transparent borders with borderTop and borderBottom props |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.1.3   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add text role to avoid link fragmented on ios voiceover |
 | 4.1.2   | [PR#684](https://github.com/bbc/psammead/pull/684) Update brand spacing breakpoint to kick in at 25rem |
 | 4.1.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 4.1.0   | [PR#647](https://github.com/bbc/psammead/pull/647) Add transparent borders with borderTop and borderBottom props |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.1.1",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "main": "dist/index.js",
   "description": "Provides the BBC News logo (as SVG), nested a hardcoded link to https://www.bbc.co.uk/news",
   "repository": {

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -85,6 +85,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
     </svg>
     <span
       className="c3"
+      role="text"
     >
       <span
         lang="en-GB"
@@ -194,6 +195,7 @@ exports[`Brand should render correctly with link provided 1`] = `
       </svg>
       <span
         className="c5"
+        role="text"
       >
         <span
           lang="en-GB"

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -85,11 +85,12 @@ const BrandSvg = styled.svg`
 
 const LocalisedBrandName = ({ product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
-    <Fragment>
+    // eslint-disable-next-line jsx-a11y/aria-role
+    <VisuallyHiddenText role="text">
       <span lang="en-GB">{product}</span>, {serviceLocalisedName}
-    </Fragment>
+    </VisuallyHiddenText>
   ) : (
-    product
+    <VisuallyHiddenText>{product}</VisuallyHiddenText>
   );
 
 LocalisedBrandName.propTypes = {
@@ -124,12 +125,10 @@ const StyledBrand = ({
         >
           {svg.group}
         </BrandSvg>
-        <VisuallyHiddenText>
-          <LocalisedBrandName
-            product={product}
-            serviceLocalisedName={serviceLocalisedName}
-          />
-        </VisuallyHiddenText>
+        <LocalisedBrandName
+          product={product}
+          serviceLocalisedName={serviceLocalisedName}
+        />
       </Fragment>
     )}
   </Fragment>

--- a/packages/components/psammead-brand/src/index.test.jsx
+++ b/packages/components/psammead-brand/src/index.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { render } from '@testing-library/react';
 import Brand from './index';
 
 const svg = {
@@ -64,4 +65,39 @@ describe('Brand', () => {
       borderBottom
     />,
   );
+
+  describe('assertions - visually hidden text', () => {
+    it('should have role of text when serviceLocalisedName is provided', () => {
+      const { container } = render(
+        <Brand
+          product="Default Brand Name"
+          serviceLocalisedName="Service"
+          svgHeight={24}
+          maxWidth={280}
+          minWidth={180}
+          svg={svg}
+          url="https://www.bbc.co.uk/news"
+        />,
+      );
+
+      expect(container.querySelector('span').getAttribute('role')).toEqual(
+        'text',
+      );
+    });
+
+    it('should not have role of text when serviceLocalisedName is not provided', () => {
+      const { container } = render(
+        <Brand
+          product="Default Brand Name"
+          svgHeight={24}
+          maxWidth={280}
+          minWidth={180}
+          svg={svg}
+          url="https://www.bbc.co.uk/news"
+        />,
+      );
+
+      expect(container.querySelector('span').getAttribute('role')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Resolves #743

**Overall change:** Adds `role="text"` to brand to avoid fragmented link reading

**Code changes:**

- Adds `role="text"` to brand visually hidden text

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval