### PR TITLE
Inline link color should be ebon

### DIFF
--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,8 +3,9 @@
 <! -- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.1 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Link default `color` should be `Ebon` not `Postbox` |
 | 1.1.0 | [PR#719](https://github.com/bbc/psammead/pull/719) Updates the link styling to new UX designs |
-| 1.0.1   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
+| 1.0.1 | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 1.0.0 | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.3.8 | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
 | 0.3.7 | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <! -- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.1 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Link default `color` should be `Ebon` not `Postbox` |
+| 1.1.1 | [PR#761](https://github.com/bbc/psammead/pull/761) Link default `color` should be `Ebon` not `Postbox` |
 | 1.1.0 | [PR#719](https://github.com/bbc/psammead/pull/719) Updates the link styling to new UX designs |
 | 1.0.1 | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 1.0.0 | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "repository": {

--- a/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InlineLink should render correctly 1`] = `
 .c0 {
-  color: #B80000;
+  color: #222222;
   border-bottom: 1px solid #B80000;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/packages/components/psammead-inline-link/src/index.jsx
+++ b/packages/components/psammead-inline-link/src/index.jsx
@@ -1,8 +1,13 @@
 import styled from 'styled-components';
-import { C_POSTBOX, C_CLOUD_DARK, C_WHITE } from '@bbc/psammead-styles/colours';
+import {
+  C_POSTBOX,
+  C_CLOUD_DARK,
+  C_WHITE,
+  C_EBON,
+} from '@bbc/psammead-styles/colours';
 
 const InlineLink = styled.a`
-  color: ${C_POSTBOX};
+  color: ${C_EBON};
   border-bottom: 1px solid ${C_POSTBOX};
   text-decoration: none;
 


### PR DESCRIPTION
Resolves N/A

UX spotted that the default link `color` should be `ebon` not `postbox`. Follows up https://github.com/bbc/psammead/pull/707

**Overall change:** _Changes the default inline link text color to be `ebon`_

**Code changes:**

_Changes the default inline link text color to be `ebon`_

**Testing notes**
Checkout branch, run storybook, in an incognito window check that the `inline link` story has text `color` of `Ebon` `#222222`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval