### PR TITLE
Add method to get serifbold font

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.2   | [PR#764](https://github.com/bbc/psammead/pull/764) Add functions to get serif bold font |
+| 1.1.0   | [PR#764](https://github.com/bbc/psammead/pull/764) Add functions to get serif bold font |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0   | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.6.0   | [PR#676](https://github.com/bbc/psammead/pull/676) Add Nassim Persian fonts v1.511 |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.2   | [PR#764](https://github.com/bbc/psammead/pull/764) Add functions to get serif bold font |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0   | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.6.0   | [PR#676](https://github.com/bbc/psammead/pull/676) Add Nassim Persian fonts v1.511 |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.0   | [PR#764](https://github.com/bbc/psammead/pull/764) Add functions to get serif bold font |
+| 1.1.0   | [PR#764](https://github.com/bbc/psammead/pull/764) Add function to get serif bold font |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0   | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.6.0   | [PR#676](https://github.com/bbc/psammead/pull/676) Add Nassim Persian fonts v1.511 |

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
@@ -4,23 +4,23 @@ exports[`should render SansBold correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
 exports[`should render SansBold correctly for news 1`] = `
 "
    font-family: ReithSans, Helvetica, Arial, sans-serif;
-   font-style: normal;
    font-weight: 700;
+   font-style: normal;
   "
 `;
 
 exports[`should render SansBold correctly for persian 1`] = `
 "
-    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif; 
-    font-style: normal;
+    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
     font-weight: 700;
+   font-style: normal;
   "
 `;
 
@@ -28,7 +28,7 @@ exports[`should render SansBold correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -36,7 +36,7 @@ exports[`should render SansBold correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -44,23 +44,23 @@ exports[`should render SansBoldItalic correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
 exports[`should render SansBoldItalic correctly for news 1`] = `
 "
    font-family: ReithSans, Helvetica, Arial, sans-serif;
-   font-style: italic;
    font-weight: 700;
+   font-style: italic;
   "
 `;
 
 exports[`should render SansBoldItalic correctly for persian 1`] = `
 "
-    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif; 
-    font-style: normal;
+    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
     font-weight: 700;
+   font-style: normal;
   "
 `;
 
@@ -68,7 +68,7 @@ exports[`should render SansBoldItalic correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -76,7 +76,7 @@ exports[`should render SansBoldItalic correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -84,23 +84,23 @@ exports[`should render SansItalic correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
 exports[`should render SansItalic correctly for news 1`] = `
 "
    font-family: ReithSans, Helvetica, Arial, sans-serif;
-   font-style: italic;
    font-weight: 400;
+   font-style: italic; 
   "
 `;
 
 exports[`should render SansItalic correctly for persian 1`] = `
 "
     font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
-    font-style: normal;
     font-weight: 400;
+   font-style: normal;
   "
 `;
 
@@ -108,7 +108,7 @@ exports[`should render SansItalic correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -116,7 +116,7 @@ exports[`should render SansItalic correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -124,23 +124,23 @@ exports[`should render SansRegular correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
 exports[`should render SansRegular correctly for news 1`] = `
 "
-   font-family: ReithSans, Helvetica, Arial, sans-serif; 
-   font-style: normal;
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
    font-weight: 400;
+   font-style: normal; 
   "
 `;
 
 exports[`should render SansRegular correctly for persian 1`] = `
 "
     font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
-    font-style: normal;
     font-weight: 400;
+   font-style: normal;
   "
 `;
 
@@ -148,7 +148,7 @@ exports[`should render SansRegular correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -156,7 +156,47 @@ exports[`should render SansRegular correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for igbo 1`] = `
+"
+    font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for news 1`] = `
+"
+    font-family: ReithSerif, Helvetica, Arial, sans-serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for persian 1`] = `
+"
+    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for pidgin 1`] = `
+"
+    font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for yoruba 1`] = `
+"
+    font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
+    font-weight: 700;
+   font-style: normal;
   "
 `;
 
@@ -164,23 +204,23 @@ exports[`should render SerifMedium correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
 exports[`should render SerifMedium correctly for news 1`] = `
 "
-   font-family: ReithSerif, Helvetica, Arial, sans-serif; 
-   font-style: normal;
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
    font-weight: 500;
+   font-style: italic; 
   "
 `;
 
 exports[`should render SerifMedium correctly for persian 1`] = `
 "
-    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif; 
-    font-style: normal;
+    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
     font-weight: 700;
+   font-style: normal;
   "
 `;
 
@@ -188,7 +228,7 @@ exports[`should render SerifMedium correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -196,7 +236,7 @@ exports[`should render SerifMedium correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -204,23 +244,23 @@ exports[`should render SerifMediumItalic correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
 exports[`should render SerifMediumItalic correctly for news 1`] = `
 "
-   font-family: ReithSerif, Helvetica, Arial, sans-serif; 
-   font-style: italic;
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
    font-weight: 500;
+   font-style: italic;
   "
 `;
 
 exports[`should render SerifMediumItalic correctly for persian 1`] = `
 "
-    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif; 
-    font-style: normal;
+    font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
     font-weight: 700;
+   font-style: normal;
   "
 `;
 
@@ -228,7 +268,7 @@ exports[`should render SerifMediumItalic correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -236,7 +276,7 @@ exports[`should render SerifMediumItalic correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 700;
-    font-style: italic;
+   font-style: italic;
   "
 `;
 
@@ -244,23 +284,23 @@ exports[`should render SerifRegular correctly for igbo 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
 exports[`should render SerifRegular correctly for news 1`] = `
 "
-   font-family: ReithSerif, Helvetica, Arial, sans-serif;,
-   font-style: normal;
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
    font-weight: 400;
+   font-style: normal;
   "
 `;
 
 exports[`should render SerifRegular correctly for persian 1`] = `
 "
     font-family: NassimPersian, Arial, Verdana, Geneva, Helvetica, sans serif;
-    font-style: normal;
     font-weight: 400;
+   font-style: normal;
   "
 `;
 
@@ -268,7 +308,7 @@ exports[`should render SerifRegular correctly for pidgin 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
   "
 `;
 
@@ -276,6 +316,6 @@ exports[`should render SerifRegular correctly for yoruba 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans serif;
     font-weight: 400;
-    font-style: normal;
+   font-style: normal;
   "
 `;

--- a/packages/utilities/psammead-styles/src/font-families.js
+++ b/packages/utilities/psammead-styles/src/font-families.js
@@ -2,10 +2,9 @@ const reithFallback = `Helvetica, Arial, sans-serif;`;
 const reithSans = `font-family: ReithSans, ${reithFallback}`;
 const reithSerif = `font-family: ReithSerif, ${reithFallback}`;
 
-const getFontStyleAndWeight = (style, weight) => `
-   font-style: ${style};
-   font-weight: ${weight};
-  `;
+const getFontStyleAndWeight = (style, weight) =>
+  `font-weight: ${weight};
+   font-style: ${style};`;
 
 export const news = {
   sansRegular: `

--- a/packages/utilities/psammead-styles/src/font-families.js
+++ b/packages/utilities/psammead-styles/src/font-families.js
@@ -2,41 +2,43 @@ const reithFallback = `Helvetica, Arial, sans-serif;`;
 const reithSans = `font-family: ReithSans, ${reithFallback}`;
 const reithSerif = `font-family: ReithSerif, ${reithFallback}`;
 
+const getFontStyleAndWeight = (style, weight) => `
+   font-style: ${style};
+   font-weight: ${weight};
+  `;
+
 export const news = {
   sansRegular: `
-   ${reithSans} 
-   font-style: normal;
-   font-weight: 400;
+   ${reithSans}
+   ${getFontStyleAndWeight('normal', 400)} 
   `,
   sansItalic: `
    ${reithSans}
-   font-style: italic;
-   font-weight: 400;
+   ${getFontStyleAndWeight('italic', 400)} 
   `,
   sansBold: `
    ${reithSans}
-   font-style: normal;
-   font-weight: 700;
+   ${getFontStyleAndWeight('normal', 700)}
   `,
   sansBoldItalic: `
    ${reithSans}
-   font-style: italic;
-   font-weight: 700;
+   ${getFontStyleAndWeight('italic', 700)}
   `,
   serifRegular: `
-   ${reithSerif},
-   font-style: normal;
-   font-weight: 400;
+   ${reithSerif}
+   ${getFontStyleAndWeight('normal', 400)}
   `,
   serifMedium: `
-   ${reithSerif} 
-   font-style: normal;
-   font-weight: 500;
+   ${reithSerif}
+   ${getFontStyleAndWeight('italic', 500)} 
   `,
   serifMediumItalic: `
-   ${reithSerif} 
-   font-style: italic;
-   font-weight: 500;
+   ${reithSerif}
+   ${getFontStyleAndWeight('italic', 500)}
+  `,
+  serifBold: `
+    ${reithSerif}
+    ${getFontStyleAndWeight('normal', 700)}
   `,
 };
 
@@ -45,23 +47,19 @@ const helmet = `font-family: Helmet, Freesans, Helvetica, Arial, sans serif;`;
 const helmetFontStyles = {
   sansRegular: `
     ${helmet}
-    font-weight: 400;
-    font-style: normal;
+    ${getFontStyleAndWeight('normal', 400)}
   `,
   sansItalic: `
     ${helmet}
-    font-weight: 400;
-    font-style: italic;
+    ${getFontStyleAndWeight('italic', 400)}
   `,
   sansBold: `
     ${helmet}
-    font-weight: 700;
-    font-style: normal;
+    ${getFontStyleAndWeight('normal', 700)}
   `,
   sansBoldItalic: `
     ${helmet}
-    font-weight: 700;
-    font-style: italic;
+    ${getFontStyleAndWeight('italic', 700)}
   `,
 };
 
@@ -70,13 +68,11 @@ const nassimPersian = `font-family: NassimPersian, Arial, Verdana, Geneva, Helve
 const persianStyles = {
   sansRegular: `
     ${nassimPersian}
-    font-style: normal;
-    font-weight: 400;
+    ${getFontStyleAndWeight('normal', 400)}
   `,
   sansBold: `
-    ${nassimPersian} 
-    font-style: normal;
-    font-weight: 700;
+    ${nassimPersian}
+    ${getFontStyleAndWeight('normal', 700)}
   `,
 };
 

--- a/packages/utilities/psammead-styles/src/font-styles.js
+++ b/packages/utilities/psammead-styles/src/font-styles.js
@@ -54,3 +54,11 @@ export const getSerifMediumItalic = service => {
   const { serifMediumItalic } = fonts[service];
   return serifMediumItalic || getSansBoldItalic(service);
 };
+
+export const getSerifBold = service => {
+  if (!fonts[service]) {
+    return null;
+  }
+  const { serifBold } = fonts[service];
+  return serifBold || getSansBold(service);
+};


### PR DESCRIPTION
Resolves #717 

**Overall change:** _Add a method to get serifBold font in font styles._

**Code changes:**

- _Create a `getSerifBold` method in `/font-styles`._
- _Adds a serifBold font for news service._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval