### PR TITLE
Ensure psammead-styles version is bumped

### DIFF
--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #765

**Overall change:** Bump version of psammead-styles to ensure changes made in previous PR are published to npm registry

**Code changes:**

- Bump version of psammead-styles to 1.0.1. Changelog was already merged in PR: https://github.com/bbc/psammead/pull/677/files#diff-adde2cd27c4e637a1f54c1fedf4b4f3aR6

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval