### PR TITLE
Use rem instead of px in the Media Indicator SVGs

### DIFF
--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,12 +3,12 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.4   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use rem for the width and height of the Media SVGs |
-| 1.0.3   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
-| 1.0.2   | [PR#722](https://github.com/bbc/psammead/pull/722) Fix hover cap on older browsers |
-| 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
-| 1.0.0   | [PR#679](https://github.com/BBC-News/psammead/pull/679) Bump version number |
-| 0.2.1   | [PR#644](https://github.com/BBC-News/psammead/pull/644) Fixes for screenreader UX |
-| 0.2.0   | [PR#550](https://github.com/BBC-News/psammead/pull/550) Add audio svg and type prop to switch media icon |
-| 0.1.1   | [PR#515](https://github.com/BBC-News/psammead/pull/515) Update story to use dirDecorator |
-| 0.1.0   | [PR#448](https://github.com/BBC-News/psammead/pull/448) Create initial package. |
+| 1.0.4   | [PR#788](https://github.com/BBC/psammead/pull/788) Use rem for the width and height of the Media SVGs |
+| 1.0.3   | [PR#713](https://github.com/BBC/psammead/pull/713) Update `styled-components` to 4.3.2 |
+| 1.0.2   | [PR#722](https://github.com/BBC/psammead/pull/722) Fix hover cap on older browsers |
+| 1.0.1   | [PR#677](https://github.com/BBC/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
+| 1.0.0   | [PR#679](https://github.com/BBC/psammead/pull/679) Bump version number |
+| 0.2.1   | [PR#644](https://github.com/BBC/psammead/pull/644) Fixes for screenreader UX |
+| 0.2.0   | [PR#550](https://github.com/BBC/psammead/pull/550) Add audio svg and type prop to switch media icon |
+| 0.1.1   | [PR#515](https://github.com/BBC/psammead/pull/515) Update story to use dirDecorator |
+| 0.1.0   | [PR#448](https://github.com/BBC/psammead/pull/448) Create initial package. |

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.4   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use rem for the width and height of the Media SVGs |
 | 1.0.3   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 1.0.2   | [PR#722](https://github.com/bbc/psammead/pull/722) Fix hover cap on older browsers |
 | 1.0.1   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -138,67 +138,38 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.0.tgz",
-      "integrity": "sha512-dHVZ+ig1P/crQtvAOP0bB0PAuuqT2R8hs15pZDsJsO1wvPtbvEe2TO6AxXUIODk9TZgod2j+9K6TB4WV/I2LDw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.1.tgz",
+      "integrity": "sha512-Ak0/+lPuCq8aPbOlzxj6/ayr5SmwNZo49dcnK3NHNugH5TEKmt+gjQhsZG6PSxpCEPk5OXhviPiNUEVr4wVObA=="
     },
     "@bbc/psammead-storybook-helpers": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-2.1.1.tgz",
-      "integrity": "sha512-kKpeH97+PY439LoUkTceNtgJynjRbwU9AbmNjsZ18h+alVR2PbZ2j2uYXTo6ux1DiCN3L15aLZmu4K3VordLmw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-3.1.0.tgz",
+      "integrity": "sha512-mah7Mh+Gh6apbCEF+WVxCeMtxrDzck06oPYsVqUb/gaKGziJ7U0Sf8vh0VkorcZy0i1DfDWr75NKDBIf45QiMQ==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^1.2.0",
+        "@bbc/gel-foundations": "^3.0.0",
         "react-helmet": "^5.2.0"
-      },
-      "dependencies": {
-        "@bbc/gel-foundations": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-1.2.0.tgz",
-          "integrity": "sha512-OpEJf42FSgyZRN0e9pJFm9eYmzbhfB7W7EWlrjh46fWlozyVwKA4uaTPUoGHLbXJkMOhPdpfM3gOAxbuM0FnrQ==",
-          "dev": true
-        }
       }
     },
     "@bbc/psammead-styles": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.3.3.tgz",
-      "integrity": "sha512-9SG698tmq8o7Ja6sFQ6WwHpVEJtCbP99Z80wSnnB4ZWryfasd+EaRXtvGwGvWG2U9oA34S27syJQIh062Mkztw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.1.0.tgz",
+      "integrity": "sha512-nGNN/tGYQ9Gn+W3NK/1ELHTx8F+i6kxgfNv9pPRcRAfYJH+spTseW82+etK3acbXXr29I5eucRW4XM+SMNeEwQ=="
     },
     "@bbc/psammead-test-helpers": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-0.3.3.tgz",
-      "integrity": "sha512-w/ENAOLuXZ8f2l3IJ2wYKEuNVH69xn0p4YIV6qx6GpZBYdP12n5sBi1lvGZOKD9tRa3UOGN5WZzxrZLjcUCh+w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-1.0.1.tgz",
+      "integrity": "sha512-bZVg3gHoduwKsVGPZ622eVMeff+r8NFMhM+RnUTQvSPV/+0f5tgTbygcYQ6HiUsGip3hqW2+FmVxn16zEy0qaQ==",
       "dev": true,
       "requires": {
-        "jest-styled-components": "^6.3.1",
-        "react-test-renderer": "^16.6.3"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-          "dev": true
-        },
-        "react-test-renderer": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-          "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.8.6",
-            "scheduler": "^0.13.6"
-          }
-        }
+        "jest-styled-components": "^6.3.1"
       }
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.12.tgz",
-      "integrity": "sha512-nTgniZ9edCscJs7xDoh/bWuoCkoa6AIoVpVH2/ekMBDG2UUgj9yGJZts0Ki89l2IlQBQOBZbE/vRzgsuVDszTg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.0.1.tgz",
+      "integrity": "sha512-e281xGygQEHoO5trmddHwNouA7EhpQ+p3Iq3srVPV0ItHxEOzcKc8cmiL0xdgZPsOxauCVcyb1isaS5eF3rNBg=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.2",
@@ -361,9 +332,9 @@
       "dev": true
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "is-what": {
@@ -373,9 +344,9 @@
       "dev": true
     },
     "jest-styled-components": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.1.tgz",
-      "integrity": "sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.3.tgz",
+      "integrity": "sha512-RBMPZSJJSgPDTTJsuYzx5fsij/CULaqQNZOWkn8J/L++rX6P830o2vB9CXGzfQf/bVq9qGr1ZBNoivi+v6JPYg==",
       "dev": true,
       "requires": {
         "css": "^2.2.4"

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "description": "Provides a play icon and media duration for media page promos",
   "repository": {

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -17,13 +17,13 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.0",
-    "@bbc/psammead-styles": "^0.3.3",
-    "@bbc/psammead-visually-hidden-text": "^0.1.12"
+    "@bbc/gel-foundations": "^3.0.1",
+    "@bbc/psammead-styles": "^1.0.1",
+    "@bbc/psammead-visually-hidden-text": "^1.0.1"
   },
   "devDependencies": {
-    "@bbc/psammead-storybook-helpers": "^2.1.1",
-    "@bbc/psammead-test-helpers": "^0.3.3",
+    "@bbc/psammead-storybook-helpers": "^3.1.0",
+    "@bbc/psammead-test-helpers": "^1.0.0",
     "react": "^16.8.6",
     "styled-components": "^4.3.2"
   },

--- a/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
@@ -45,13 +45,13 @@ exports[`MediaIndicator should render audio correctly without duration details 1
 
 <div
   aria-hidden="true"
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
-      className="c2"
+      class="c2"
       focusable="false"
       viewBox="0 0 13 12"
     >
@@ -63,7 +63,7 @@ exports[`MediaIndicator should render audio correctly without duration details 1
       />
     </svg>
     <span
-      className="c3"
+      class="c3"
     >
       Audio
     </span>
@@ -121,13 +121,13 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
 
 <div
   aria-hidden="true"
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
-      className="c2"
+      class="c2"
       focusable="false"
       viewBox="0 0 13 12"
     >
@@ -139,13 +139,13 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
       />
     </svg>
     <span
-      className="c3"
+      class="c3"
     >
       Audio
     </span>
     <time
-      className="c4"
-      dateTime="PT2M15S"
+      class="c4"
+      datetime="PT2M15S"
     >
       2:15
     </time>
@@ -198,13 +198,13 @@ exports[`MediaIndicator should render video by default 1`] = `
 
 <div
   aria-hidden="true"
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
-      className="c2"
+      class="c2"
       focusable="false"
       viewBox="0 0 32 32"
     >
@@ -213,7 +213,7 @@ exports[`MediaIndicator should render video by default 1`] = `
       />
     </svg>
     <span
-      className="c3"
+      class="c3"
     >
       Video
     </span>
@@ -266,13 +266,13 @@ exports[`MediaIndicator should render video correctly without duration details 1
 
 <div
   aria-hidden="true"
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
-      className="c2"
+      class="c2"
       focusable="false"
       viewBox="0 0 32 32"
     >
@@ -281,7 +281,7 @@ exports[`MediaIndicator should render video correctly without duration details 1
       />
     </svg>
     <span
-      className="c3"
+      class="c3"
     >
       Video
     </span>
@@ -339,13 +339,13 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
 
 <div
   aria-hidden="true"
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
-      className="c2"
+      class="c2"
       focusable="false"
       viewBox="0 0 32 32"
     >
@@ -354,13 +354,13 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
       />
     </svg>
     <span
-      className="c3"
+      class="c3"
     >
       Video
     </span>
     <time
-      className="c4"
-      dateTime="PT2M15S"
+      class="c4"
+      datetime="PT2M15S"
     >
       2:15
     </time>

--- a/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,8 @@ exports[`MediaIndicator should render audio correctly without duration details 1
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
+  width: 0.8125rem;
+  height: 0.75rem;
 }
 
 .c0 {
@@ -51,9 +53,7 @@ exports[`MediaIndicator should render audio correctly without duration details 1
     <svg
       className="c2"
       focusable="false"
-      height="12px"
       viewBox="0 0 13 12"
-      width="13px"
     >
       <path
         d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
@@ -87,6 +87,8 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
+  width: 0.8125rem;
+  height: 0.75rem;
 }
 
 .c0 {
@@ -127,9 +129,7 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
     <svg
       className="c2"
       focusable="false"
-      height="12px"
       viewBox="0 0 13 12"
-      width="13px"
     >
       <path
         d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
@@ -169,6 +169,8 @@ exports[`MediaIndicator should render video by default 1`] = `
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .c0 {
@@ -204,9 +206,7 @@ exports[`MediaIndicator should render video by default 1`] = `
     <svg
       className="c2"
       focusable="false"
-      height="12px"
       viewBox="0 0 32 32"
-      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"
@@ -237,6 +237,8 @@ exports[`MediaIndicator should render video correctly without duration details 1
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .c0 {
@@ -272,9 +274,7 @@ exports[`MediaIndicator should render video correctly without duration details 1
     <svg
       className="c2"
       focusable="false"
-      height="12px"
       viewBox="0 0 32 32"
-      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"
@@ -305,6 +305,8 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
   vertical-align: middle;
   margin: 0 0.25rem;
   fill: #222222;
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .c0 {
@@ -345,9 +347,7 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
     <svg
       className="c2"
       focusable="false"
-      height="12px"
       viewBox="0 0 32 32"
-      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"

--- a/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-indicator/src/__snapshots__/index.test.jsx.snap
@@ -53,7 +53,9 @@ exports[`MediaIndicator should render audio correctly without duration details 1
     <svg
       class="c2"
       focusable="false"
+      height="12px"
       viewBox="0 0 13 12"
+      width="13px"
     >
       <path
         d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
@@ -129,7 +131,9 @@ exports[`MediaIndicator should render audio indicator correctly 1`] = `
     <svg
       class="c2"
       focusable="false"
+      height="12px"
       viewBox="0 0 13 12"
+      width="13px"
     >
       <path
         d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
@@ -206,7 +210,9 @@ exports[`MediaIndicator should render video by default 1`] = `
     <svg
       class="c2"
       focusable="false"
+      height="12px"
       viewBox="0 0 32 32"
+      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"
@@ -274,7 +280,9 @@ exports[`MediaIndicator should render video correctly without duration details 1
     <svg
       class="c2"
       focusable="false"
+      height="12px"
       viewBox="0 0 32 32"
+      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"
@@ -347,7 +355,9 @@ exports[`MediaIndicator should render video indicator correctly 1`] = `
     <svg
       class="c2"
       focusable="false"
+      height="12px"
       viewBox="0 0 32 32"
+      width="12px"
     >
       <polygon
         points="3,32 29,16 3,0"

--- a/packages/components/psammead-media-indicator/src/mediaIcons.jsx
+++ b/packages/components/psammead-media-indicator/src/mediaIcons.jsx
@@ -9,17 +9,27 @@ const MediaIcon = styled.svg`
   fill: ${C_EBON};
 `;
 
+const VideoMediaIcon = styled(MediaIcon)`
+  width: 0.75rem;
+  height: 0.75rem;
+`;
+
+const AudioMediaIcon = styled(MediaIcon)`
+  width: 0.8125rem;
+  height: 0.75rem;
+`;
+
 const icons = {
   video: (
-    <MediaIcon viewBox="0 0 32 32" width="12px" height="12px" focusable="false">
+    <VideoMediaIcon viewBox="0 0 32 32" focusable="false">
       <polygon points="3,32 29,16 3,0" />
-    </MediaIcon>
+    </VideoMediaIcon>
   ),
   audio: (
-    <MediaIcon viewBox="0 0 13 12" width="13px" height="12px" focusable="false">
+    <AudioMediaIcon viewBox="0 0 13 12" focusable="false">
       <path d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z" />
       <path d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z" />
-    </MediaIcon>
+    </AudioMediaIcon>
   ),
 };
 

--- a/packages/components/psammead-media-indicator/src/mediaIcons.jsx
+++ b/packages/components/psammead-media-indicator/src/mediaIcons.jsx
@@ -21,12 +21,22 @@ const AudioMediaIcon = styled(MediaIcon)`
 
 const icons = {
   video: (
-    <VideoMediaIcon viewBox="0 0 32 32" focusable="false">
+    <VideoMediaIcon
+      viewBox="0 0 32 32"
+      width="12px"
+      height="12px"
+      focusable="false"
+    >
       <polygon points="3,32 29,16 3,0" />
     </VideoMediaIcon>
   ),
   audio: (
-    <AudioMediaIcon viewBox="0 0 13 12" focusable="false">
+    <AudioMediaIcon
+      viewBox="0 0 13 12"
+      width="13px"
+      height="12px"
+      focusable="false"
+    >
       <path d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z" />
       <path d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z" />
     </AudioMediaIcon>


### PR DESCRIPTION
Resolves #784

**Overall change:** 
 In order to make the Media Indicator scale as the text is resized, they should use `rem` instead of `px`.

**Code changes:**
- Use `VideoMediaIcon` and `AudioMediaIcon` styled components with the width and height in `rem`s.
- Update snapshots

![Screenshot 2019-07-05 at 13 34 48](https://user-images.githubusercontent.com/46446236/60722726-b0313080-9f29-11e9-862e-360db7678400.png)
![Screenshot 2019-07-05 at 13 35 40](https://user-images.githubusercontent.com/46446236/60722784-cdfe9580-9f29-11e9-9b49-9e0a47741a60.png)

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval