### PR TITLE
Use rem for the Brand SVG height

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.1.5   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use rem for the `BrandSvg` height |
+| 4.1.5   | [PR#789](https://github.com/bbc/psammead/pull/789) Use rem for the `BrandSvg` height |
 | 4.1.4   | [PR#747](https://github.com/bbc/psammead/pull/747) Add text role to avoid link fragmented on ios voiceover |
 | 4.1.3   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 4.1.2   | [PR#684](https://github.com/bbc/psammead/pull/684) Update brand spacing breakpoint to kick in at 25rem |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.1.5   | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use rem for the `BrandSvg` height |
 | 4.1.4   | [PR#747](https://github.com/bbc/psammead/pull/747) Add text role to avoid link fragmented on ios voiceover |
 | 4.1.3   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 4.1.2   | [PR#684](https://github.com/bbc/psammead/pull/684) Update brand spacing breakpoint to kick in at 25rem |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": "dist/index.js",
   "description": "Provides the BBC News logo (as SVG), nested a hardcoded link to https://www.bbc.co.uk/news",
   "repository": {

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -29,6 +29,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
   fill: #FFFFFF;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 17.5rem;
   min-width: 11.25rem;
@@ -135,6 +136,7 @@ exports[`Brand should render correctly with link provided 1`] = `
   fill: #FFFFFF;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 17.5rem;
   min-width: 11.25rem;
@@ -239,6 +241,7 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
   fill: #FFFFFF;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 17.5rem;
   min-width: 11.25rem;
@@ -333,6 +336,7 @@ exports[`Brand should render correctly with transparent borders 1`] = `
   fill: #FFFFFF;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 17.5rem;
   min-width: 11.25rem;

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -61,7 +61,8 @@ const BrandSvg = styled.svg`
   fill: ${C_WHITE};
   padding-top: ${GEL_SPACING_DBL};
   padding-bottom: ${SVG_BOTTOM_OFFSET_BELOW_400PX};
-
+  height: ${props => props.height / 16}rem;
+  
   ${({ maxWidth, minWidth }) => brandWidth(minWidth, maxWidth)}
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {


### PR DESCRIPTION
Resolves #784

**Overall change:** 
 In order to make the Brand SVG scale as the text is resized, its height should be defined in `rem` apart from the `html` attribute (used if the CSS is disabled).

**Code changes:**
- Add `height: ${props => props.height / 16}rem;` to the `BrandSvg`
- Update snapshots

![Screenshot 2019-07-05 at 15 57 52](https://user-images.githubusercontent.com/46446236/60731442-78cd7e80-9f3f-11e9-9217-32bc533a7afc.png)
![Screenshot 2019-07-05 at 13 35 40](https://user-images.githubusercontent.com/46446236/60731445-79feab80-9f3f-11e9-8077-0cba71ae5920.png)

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval