### PR TITLE
bump inline-link to revert styling changes

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.12  | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump psammead-inline-link to revert styling changes |
+| 1.1.12  | [PR#1019](https://github.com/bbc/psammead/pull/1019) Bump psammead-inline-link to revert styling changes |
 | 1.1.11  | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.1.10  | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
 | 1.1.9   | [PR#745](https://github.com/bbc/psammead/pull/745) Use `@bbc/psammead-inline-link@1.1.1` and update 'with inline link' story |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,32 +3,33 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.11 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
-| 1.1.10   | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
-| 1.1.9 | [PR#745](https://github.com/bbc/psammead/pull/745) Use `@bbc/psammead-inline-link@1.1.1` and update 'with inline link' story |
-| 1.1.8 | [PR#763](https://github.com/bbc/psammead/pull/763) Change text colour to `C_CLOUD_DARK` for `C_METAL` |
-| 1.1.7 | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
-| 1.1.6 | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
-| 1.1.5 | [PR#524](https://github.com/bbc/psammead/pull/524) Add spacing for nested paragraph |
-| 1.1.4 | [PR#515](https://github.com/bbc/psammead/pull/515) Update story to use dirDecorator |
-| 1.1.3 | [PR#491](https://github.com/bbc/psammead/pull/491) Remove bottom padding from paragraphs within Caption |
-| 1.1.2 | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
-| 1.1.1 | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
-| 1.1.0 | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
-| 1.0.1 | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
-| 1.0.0 | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
-| 0.3.5 | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
-| 0.3.4 | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
-| 0.3.3 | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
-| 0.3.2 | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
-| 0.3.1 | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
-| 0.3.0 | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
-| 0.2.1 | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
-| 0.2.0 | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
-| 0.1.6 | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.1.5 | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
-| 0.1.4 | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
-| 0.1.3 | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
-| 0.1.2 | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
-| 0.1.1 | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
-| 0.1.0 | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |
+| 1.1.12  | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump psammead-inline-link to revert styling changes |
+| 1.1.11  | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
+| 1.1.10  | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
+| 1.1.9   | [PR#745](https://github.com/bbc/psammead/pull/745) Use `@bbc/psammead-inline-link@1.1.1` and update 'with inline link' story |
+| 1.1.8   | [PR#763](https://github.com/bbc/psammead/pull/763) Change text colour to `C_CLOUD_DARK` for `C_METAL` |
+| 1.1.7   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
+| 1.1.6   | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
+| 1.1.5   | [PR#524](https://github.com/bbc/psammead/pull/524) Add spacing for nested paragraph |
+| 1.1.4   | [PR#515](https://github.com/bbc/psammead/pull/515) Update story to use dirDecorator |
+| 1.1.3   | [PR#491](https://github.com/bbc/psammead/pull/491) Remove bottom padding from paragraphs within Caption |
+| 1.1.2   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider |
+| 1.1.1   | [PR#459](https://github.com/bbc/psammead/pull/459) Add custom propTypes shape |
+| 1.1.0   | [PR#446](https://github.com/bbc/psammead/pull/446) De-italicise text in italic tag |
+| 1.0.1   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |
+| 1.0.0   | [PR#413](https://github.com/bbc/psammead/pull/413) Add support for different scripts typographies |
+| 0.3.5   | [PR#377](https://github.com/bbc/psammead/pull/377) Add knobs addon using psammead-storybook-helpers |
+| 0.3.4   | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
+| 0.3.3   | [PR#410](https://github.com/bbc/psammead/pull/410) Update left/right padding to match article design |
+| 0.3.2   | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies |
+| 0.3.1   | [PR#393](https://github.com/bbc/psammead/pull/393) Remove padding from left/right of caption. |
+| 0.3.0   | [PR#365](https://github.com/bbc/psammead/pull/365) Remove background colour, update colour to Cloud Dark. Use font style italic. |
+| 0.2.1   | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
+| 0.2.0   | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
+| 0.1.6   | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
+| 0.1.5   | [PR#264](https://github.com/BBC/psammead/pull/319) Resolving package-lock issues. |
+| 0.1.4   | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
+| 0.1.3   | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
+| 0.1.2   | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
+| 0.1.1   | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
+| 0.1.0   | [PR#186](https://github.com/BBC-News/psammead/pull/186) Create initial package, pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -143,12 +143,12 @@
       "integrity": "sha512-dHVZ+ig1P/crQtvAOP0bB0PAuuqT2R8hs15pZDsJsO1wvPtbvEe2TO6AxXUIODk9TZgod2j+9K6TB4WV/I2LDw=="
     },
     "@bbc/psammead-inline-link": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-1.1.1.tgz",
-      "integrity": "sha512-2n94BFzp2coPhFmyIRGHit4RTjhp+X9L8BQm0NVvbZ/R7VxyK26d1oPPBKD3jw/AFzE2vtRLoOoi5MIjmhx0VA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-1.1.6.tgz",
+      "integrity": "sha512-yJ6bA2gvveTORRAgU/fJssPN4f3ReYokyrlV34ZGWNP9uSEcNqh+iXIKrjp7X6nOLfbCPe4kebLi9T8Zlp+CSA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-styles": "^1.0.0"
+        "@bbc/psammead-styles": "^1.0.1"
       }
     },
     "@bbc/psammead-paragraph": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "main": "dist/index.js",
   "description": "React styled components for a Caption",
   "repository": {
@@ -21,7 +21,7 @@
     "@bbc/psammead-styles": "^1.0.1"
   },
   "devDependencies": {
-    "@bbc/psammead-inline-link": "^1.1.1",
+    "@bbc/psammead-inline-link": "^1.1.6",
     "@bbc/psammead-paragraph": "^1.0.3",
     "@bbc/psammead-storybook-helpers": "^3.0.0",
     "@bbc/psammead-test-helpers": "^1.0.1",

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.9 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
+| 1.0.10  | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump psammead-inline-link to revert styling changes |
+| 1.0.9   | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.0.8   | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
 | 1.0.7   | [PR#746](https://github.com/bbc/psammead/pull/746) Use `@bbc/psammead-inline-link@1.1.1` and add a 'with inline link' story |
 | 1.0.6   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.10  | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Bump psammead-inline-link to revert styling changes |
+| 1.0.10  | [PR#1019](https://github.com/bbc/psammead/pull/1019) Bump psammead-inline-link to revert styling changes |
 | 1.0.9   | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.0.8   | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
 | 1.0.7   | [PR#746](https://github.com/bbc/psammead/pull/746) Use `@bbc/psammead-inline-link@1.1.1` and add a 'with inline link' story |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -143,18 +143,18 @@
       "integrity": "sha512-dHVZ+ig1P/crQtvAOP0bB0PAuuqT2R8hs15pZDsJsO1wvPtbvEe2TO6AxXUIODk9TZgod2j+9K6TB4WV/I2LDw=="
     },
     "@bbc/psammead-inline-link": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-1.1.1.tgz",
-      "integrity": "sha512-2n94BFzp2coPhFmyIRGHit4RTjhp+X9L8BQm0NVvbZ/R7VxyK26d1oPPBKD3jw/AFzE2vtRLoOoi5MIjmhx0VA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-inline-link/-/psammead-inline-link-1.1.6.tgz",
+      "integrity": "sha512-yJ6bA2gvveTORRAgU/fJssPN4f3ReYokyrlV34ZGWNP9uSEcNqh+iXIKrjp7X6nOLfbCPe4kebLi9T8Zlp+CSA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-styles": "^1.0.0"
+        "@bbc/psammead-styles": "^1.0.1"
       },
       "dependencies": {
         "@bbc/psammead-styles": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.0.1.tgz",
-          "integrity": "sha512-lzbLfkMNpRgM+vyGLra9FFzaDrm2+2HDBMniKJmnWLGBmMPOm+qdRLYt1wEeiHdqQBwCju6sfrnBDqOKs29G8g==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.1.2.tgz",
+          "integrity": "sha512-bEHPHnQwpIQHMOVNATDVEFweOAEtlwU8g7cwwTi2QspNntmq9mTPlXGTqZT1EaFczTwgS8cnQaP/zoXN4F4z6A==",
           "dev": true
         }
       }

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@bbc/psammead-storybook-helpers": "^3.0.0",
-    "@bbc/psammead-inline-link": "1.1.1",
+    "@bbc/psammead-inline-link": "^1.1.6",
     "@bbc/psammead-test-helpers": "^1.0.1",
     "react": "^16.8.6",
     "styled-components": "^4.3.2"


### PR DESCRIPTION
Resolves #936

**Code changes:**

- Bumps `psammead-paragraph` and `psammead-inline-link` to use `psammead-inline-link@1.1.6`
- Re-formats a couple change logs 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval