### PR TITLE
why didn't this update first time

### DIFF
--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Follows up https://github.com/bbc/psammead/pull/1019 

The package-lock didn't update as the version conflicted and therefore needed _another_ install
