### PR TITLE
Npm deprecate branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,9 @@ pipeline {
         }
       }
       steps {
-        sh "make deprecate packageName='@bbc/psammead-caption' version='>=1.1.9 <=1.1.11' reason='inline link styling bug'"
+        withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {	
+          sh "make deprecate packageName='@bbc/psammead-caption' version='>=1.1.9 <=1.1.11' reason='inline link styling bug'"
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     CI = true
   }
   stages {
-    stage ('Run application tests') {
+    stage ('Deprecate a package') {
       agent {
         docker {
           image "${nodeImage}"
@@ -39,50 +39,7 @@ pipeline {
         }
       }
       steps {
-        sh 'rm -rf ./app'
-        script {
-          if (GIT_BRANCH == 'latest') {
-            getCommitInfo()
-          }
-        }
-        sh 'make install'
-        sh 'make code-coverage-before-build'
-        sh 'make tests'
-        withCredentials([string(credentialsId: 'psammead-cc-reporter-id', variable: 'CC_TEST_REPORTER_ID')]) {
-          sh 'make code-coverage-after-build'
-        }
-      }
-      post {
-        always {
-          script {
-            stageName = env.STAGE_NAME
-          }
-        }
-      }
-    }
-    stage ('Deploy Storybook & Publish to NPM') {
-      when {
-        expression { env.BRANCH_NAME == 'latest' }
-      }
-      agent {
-        docker {
-          image "${nodeImage}"
-          label nodeName
-          args '-u root -v /etc/pki:/certs'
-        }
-      }
-      steps {
-        sh 'make storybook'
-        withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {
-          sh 'make publish'
-        }
-      }
-      post {
-        always {
-          script {
-            stageName = env.STAGE_NAME
-          }
-        }
+        sh "make deprecate packageName='@bbc/psammead-caption' version='>=1.1.9 <=1.1.11' reason='inline link styling bug'"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
       }
       steps {
         withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {	
-          sh "make deprecate packageName='@bbc/psammead-caption' version='>=1.1.9 <=1.1.11' reason='inline link styling bug'"
+          sh "make deprecate packageName='@bbc/psammead-paragraph' version='>=1.0.7 <=2.0.0' reason='inline link styling bug'"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
       }
       steps {
         withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {	
-          sh "make deprecate packageName='@bbc/psammead-paragraph' version='>=1.0.7 <=2.0.0' reason='inline link styling bug'"
+          sh "make deprecate packageName='@bbc/psammead-inline-link' version='>=1.1.0 <=1.1.5' reason='inline link styling bug'"
         }
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ storybook:
 publish:
 	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 	npm run publish;
+
+deprecate:
+	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+	npm deprecate ${packageName}@${version} ${reason}

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ publish:
 
 deprecate:
 	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-	npm deprecate ${packageName}@${version} ${reason}
+	npm deprecate ${packageName}@"${version}" "${reason}"


### PR DESCRIPTION
Change the makefile and jenkinsfile to run `npm deprecate` with a given `packageName`, `version` and `reason`

The build `jenkins/psammead/detail/npm-deprecate-branch/3/pipeline` was successful in running the command: 
```
npm deprecate @bbc/psammead-caption@">=1.1.9 <=1.1.11" "inline link styling bug"
``` 

Which can be seen by the versions highlighted in red in the screenshot below. 

![image](https://user-images.githubusercontent.com/7791726/60970572-2cf14f80-a31a-11e9-9e18-82d0ad9ded3d.png)

---

I wrote this job as we needed to deprecate a range of versions for `psammead-paragraph`, `psammead-inline-link` and `psammead-caption`.
