### PR TITLE
Add package change scanner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
         withCredentials([string(credentialsId: 'psammead-cc-reporter-id', variable: 'CC_TEST_REPORTER_ID')]) {
           sh 'make code-coverage-after-build'
         }
+        sh 'make change-scanner'
       }
       post {
         always {

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ storybook:
 publish:
 	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 	npm run publish;
+
+change-scanner:
+	npm run changeScanner;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "lerna exec --parallel -- babel src -d dist --ignore '**/*.test.js,**/*.test.jsx,**/*.stories.js,**/*.stories.jsx' --root-mode upward",
     "ci:packages": "npm ci && lerna exec -- npm ci",
+    "changeScanner": "node scripts/changeScanner",
     "deploy-storybook": "build-storybook -o storybook_dist && gh-pages -d storybook_dist",
     "force-package-lock-https": "find . -type f -name \"package-lock.json\" | grep -v node_modules | xargs -I % sh -c 'echo \"Replacing http->https in %\"; sed -i \"\" -e \"s/http:\\/\\//https:\\/\\//g\" %'",
     "install:packages": "npm i && lerna clean --yes && lerna bootstrap --hoist",

--- a/scripts/changeScanner/getChanges.js
+++ b/scripts/changeScanner/getChanges.js
@@ -1,14 +1,11 @@
 const { exec } = require('shelljs');
 
 const getChanges = () => {
-  const execute = exec(`git diff --name-status latest`, {
+  const execute = exec(`git diff --name-only latest ./packages`, {
     silent: true,
   }).stdout;
 
-  const changedFiles = execute
-    .replace(/M\t/g, '')
-    .split('\n')
-    .filter(val => val);
+  const changedFiles = execute.split('\n').filter(val => val);
 
   const changedPackages = {};
 

--- a/scripts/changeScanner/getChanges.js
+++ b/scripts/changeScanner/getChanges.js
@@ -1,0 +1,28 @@
+const { exec } = require('shelljs');
+
+const getChanges = () => {
+  const execute = exec(`git diff --name-status latest`, {
+    silent: true,
+  }).stdout;
+
+  const changedFiles = execute
+    .replace(/M\t/g, '')
+    .split('\n')
+    .filter(val => val);
+
+  const changedPackages = {};
+
+  changedFiles.forEach(fileName => {
+    const nameParts = fileName.split('/');
+    const packageName = nameParts[2];
+    const filePath = nameParts.splice(3).join('/');
+
+    (changedPackages[packageName] = changedPackages[packageName] || []).push(
+      filePath,
+    );
+  });
+
+  return changedPackages;
+};
+
+module.exports = getChanges;

--- a/scripts/changeScanner/getChanges.js
+++ b/scripts/changeScanner/getChanges.js
@@ -5,7 +5,7 @@ const getChanges = () => {
     silent: true,
   }).stdout;
 
-  const changedFiles = execute.split('\n').filter(val => val);
+  const changedFiles = execute.split('\n').filter(Boolean);
 
   const changedPackages = {};
 

--- a/scripts/changeScanner/getChanges.test.js
+++ b/scripts/changeScanner/getChanges.test.js
@@ -12,6 +12,7 @@ describe(`changeScanner - getChanges`, () => {
           'packages/components/foobar/index.test.js',
           'packages/components/barfoo/package.json',
           'packages/components/apples/dist/package.json',
+          '',
         ].join('\n'),
       }),
     }));

--- a/scripts/changeScanner/getChanges.test.js
+++ b/scripts/changeScanner/getChanges.test.js
@@ -16,9 +16,9 @@ describe(`changeScanner - getChanges`, () => {
       }),
     }));
 
-    const getPackages = require('./getChanges');
+    const getChanges = require('./getChanges');
 
-    expect(getPackages()).toEqual({
+    expect(getChanges()).toEqual({
       barfoo: ['package.json'],
       foobar: ['index.js', 'index.test.js'],
       apples: ['dist/package.json'],

--- a/scripts/changeScanner/getChanges.test.js
+++ b/scripts/changeScanner/getChanges.test.js
@@ -1,0 +1,27 @@
+/* eslint-disable global-require */
+describe(`changeScanner - getChanges`, () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns object mapping changed files to their package', () => {
+    jest.mock('shelljs', () => ({
+      exec: () => ({
+        stdout: [
+          'packages/components/foobar/index.js',
+          'packages/components/foobar/index.test.js',
+          'packages/components/barfoo/package.json',
+          'packages/components/apples/dist/package.json',
+        ].join('\n'),
+      }),
+    }));
+
+    const getPackages = require('./getChanges');
+
+    expect(getPackages()).toEqual({
+      barfoo: ['package.json'],
+      foobar: ['index.js', 'index.test.js'],
+      apples: ['dist/package.json'],
+    });
+  });
+});

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -18,7 +18,7 @@ Object.keys(changes).forEach(packageName => {
 
 if (errors.length > 0) {
   // eslint-disable-next-line no-console
-  errors.forEach(error => console.log(chalk.red(error)));
+  errors.forEach(error => console.error(chalk.red(error)));
   process.exit(1);
 } else {
   // eslint-disable-next-line no-console

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -1,0 +1,28 @@
+const chalk = require('chalk');
+const getChanges = require('./getChanges');
+
+const errors = [];
+
+// Files required to have been changed with every psammead package change.
+const requiredChanges = ['CHANGELOG.md', 'package-lock.json', 'package.json'];
+
+const changes = getChanges();
+
+Object.keys(changes).forEach(packageName => {
+  requiredChanges.forEach(requiredFile => {
+    if (!changes[packageName].includes(requiredFile)) {
+      errors.push(`Must change ${requiredFile} in ${packageName}`);
+    }
+  });
+});
+
+if (errors.length > 0) {
+  // eslint-disable-next-line no-console
+  errors.forEach(error => console.log(chalk.red(error)));
+  process.exit(1);
+} else {
+  // eslint-disable-next-line no-console
+  console.log(
+    chalk.green('All packages have met minmum change requirements 🎉'),
+  );
+}

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -23,6 +23,6 @@ if (errors.length > 0) {
 } else {
   // eslint-disable-next-line no-console
   console.log(
-    chalk.green('All packages have met minmum change requirements 🎉'),
+    chalk.green('All packages have met minimum change requirements 🎉'),
   );
 }

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -11,7 +11,7 @@ const changes = getChanges();
 Object.keys(changes).forEach(packageName => {
   requiredChanges.forEach(requiredFile => {
     if (!changes[packageName].includes(requiredFile)) {
-      errors.push(`Must change ${requiredFile} in ${packageName}`);
+      errors.push(`Branch must update ${requiredFile} in ${packageName}`);
     }
   });
 });

--- a/scripts/changeScanner/index.test.js
+++ b/scripts/changeScanner/index.test.js
@@ -1,0 +1,79 @@
+/* eslint-disable global-require */
+const stripAnsi = require('strip-ansi');
+
+const consoleLogOutput = jest.fn();
+const consoleErrorOutput = jest.fn();
+const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+jest
+  .spyOn(global.console, 'log')
+  .mockImplementation((...args) => consoleLogOutput(stripAnsi(...args)));
+jest
+  .spyOn(global.console, 'error')
+  .mockImplementation((...args) => consoleErrorOutput(stripAnsi(...args)));
+
+describe(`changeScanner - index`, () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('returns success messaging when no further changes required', () => {
+    jest.mock('./getChanges', () => () => ({
+      barfoo: ['package.json', 'package-lock.json', 'CHANGELOG.md'],
+    }));
+
+    require('./index');
+
+    expect(mockExit).not.toHaveBeenCalled();
+    expect(consoleErrorOutput).not.toHaveBeenCalled();
+    expect(consoleLogOutput).toHaveBeenCalledTimes(1);
+    expect(consoleLogOutput).toHaveBeenCalledWith(
+      'All packages have met minmum change requirements 🎉',
+    );
+  });
+
+  it('returns success messaging when no changes made', () => {
+    jest.mock('./getChanges', () => () => ({}));
+
+    require('./index');
+
+    expect(mockExit).not.toHaveBeenCalled();
+    expect(consoleErrorOutput).not.toHaveBeenCalled();
+    expect(consoleLogOutput).toHaveBeenCalledTimes(1);
+    expect(consoleLogOutput).toHaveBeenCalledWith(
+      'All packages have met minmum change requirements 🎉',
+    );
+  });
+
+  it('returns detailed error messaging when further changes required', () => {
+    jest.mock('./getChanges', () => () => ({
+      barfoo: ['package.json'],
+      pears: ['package.json', 'package-lock.json', 'CHANGELOG.md'],
+      foobar: ['index.js', 'index.test.js'],
+      apples: ['dist/package.json'],
+    }));
+
+    require('./index');
+
+    expect(mockExit).toHaveBeenCalled();
+
+    const expectedMessages = [
+      'Must change CHANGELOG.md in barfoo',
+      'Must change package-lock.json in barfoo',
+      'Must change CHANGELOG.md in foobar',
+      'Must change package-lock.json in foobar',
+      'Must change package.json in foobar',
+      'Must change CHANGELOG.md in apples',
+      'Must change package-lock.json in apples',
+      'Must change package.json in apples',
+    ];
+
+    expect(consoleLogOutput).not.toHaveBeenCalled();
+
+    expect(consoleErrorOutput).toHaveBeenCalledTimes(expectedMessages.length);
+
+    expectedMessages.forEach(msg =>
+      expect(consoleErrorOutput).toHaveBeenCalledWith(msg),
+    );
+  });
+});

--- a/scripts/changeScanner/index.test.js
+++ b/scripts/changeScanner/index.test.js
@@ -28,7 +28,7 @@ describe(`changeScanner - index`, () => {
     expect(consoleErrorOutput).not.toHaveBeenCalled();
     expect(consoleLogOutput).toHaveBeenCalledTimes(1);
     expect(consoleLogOutput).toHaveBeenCalledWith(
-      'All packages have met minmum change requirements 🎉',
+      'All packages have met minimum change requirements 🎉',
     );
   });
 
@@ -41,7 +41,7 @@ describe(`changeScanner - index`, () => {
     expect(consoleErrorOutput).not.toHaveBeenCalled();
     expect(consoleLogOutput).toHaveBeenCalledTimes(1);
     expect(consoleLogOutput).toHaveBeenCalledWith(
-      'All packages have met minmum change requirements 🎉',
+      'All packages have met minimum change requirements 🎉',
     );
   });
 

--- a/scripts/changeScanner/index.test.js
+++ b/scripts/changeScanner/index.test.js
@@ -58,14 +58,14 @@ describe(`changeScanner - index`, () => {
     expect(mockExit).toHaveBeenCalled();
 
     const expectedMessages = [
-      'Must change CHANGELOG.md in barfoo',
-      'Must change package-lock.json in barfoo',
-      'Must change CHANGELOG.md in foobar',
-      'Must change package-lock.json in foobar',
-      'Must change package.json in foobar',
-      'Must change CHANGELOG.md in apples',
-      'Must change package-lock.json in apples',
-      'Must change package.json in apples',
+      'Branch must update CHANGELOG.md in barfoo',
+      'Branch must update package-lock.json in barfoo',
+      'Branch must update CHANGELOG.md in foobar',
+      'Branch must update package-lock.json in foobar',
+      'Branch must update package.json in foobar',
+      'Branch must update CHANGELOG.md in apples',
+      'Branch must update package-lock.json in apples',
+      'Branch must update package.json in apples',
     ];
 
     expect(consoleLogOutput).not.toHaveBeenCalled();


### PR DESCRIPTION
**Overall change:** Script to ensure any psammead change has a changelog, package.json and package-lock.json update

**Code changes:**

- Looks for any diff between current and latest
- Collates all changes and checks if changelog, package.json or package-lock.js are missing
- Throws error with info if some are missing

Runs on jenkins as the last branch check. If needed admin merge can override this. When this happens, latest would be in sync with itself, so no diff would be flagged again.

**Testing notes:**
1) checkout branch
2) Make a random change in a psammead package locally
4) run `npm run changeScanner`
5) You should see 
```
Branch must update CHANGELOG.md in <package>
Branch must update package-lock.json in <package>
Branch must update package.json in <package>
```
-
6) if you change these 3 files
7) run `npm run changeScanner`
8) you should see 
```
All packages have met minmum change requirements 🎉
```

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval