### PR TITLE
Remove extra margin in story promo on desktop

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.0.3   |  [PR#???](https://github.com/bbc/psammead/pull/???) Remove extra margin from 1st story promo |
+| 2.0.3   |  [PR#1089](https://github.com/bbc/psammead/pull/1089) Remove extra margin from 1st story promo |
 | 2.0.2   |  [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
 | 2.0.1   | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 2.0.0 | [PR#1022](https://github.com/bbc/psammead/pull/1022) Apply font based on service prop |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.0.3   |  [PR#???](https://github.com/bbc/psammead/pull/???) Remove extra margin from 1st story promo |
 | 2.0.2   |  [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
 | 2.0.1   | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 2.0.0 | [PR#1022](https://github.com/bbc/psammead/pull/1022) Apply font based on service prop |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "dist/index.js",
   "description": "A story promo for use on index pages",
   "repository": {

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -86,7 +86,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 @media (min-width:37.5rem) {
   .c1 {
     width: 33.33%;
-    margin-bottom: none;
+    margin-bottom: 0;
   }
 }
 
@@ -367,7 +367,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 @media (min-width:37.5rem) {
   .c1 {
     width: 33.33%;
-    margin-bottom: none;
+    margin-bottom: 0;
   }
 }
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -81,7 +81,7 @@ const ImageGridFallbackTopStory = css`
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     width: ${twoOfSixColumnsMaxWidthScaleable};
-    margin-bottom: none;
+    margin-bottom: 0;
   }
 `;
 


### PR DESCRIPTION
Resolves #1086 

**Overall change:** Remove margin-bottom on desktop devices for 1st story promo

**Code changes:**
- Change `margin-bottom: none` to `margin-bottom: 0`

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~~Tests added for new features~~
- [ ] Test engineer approval