### PR TITLE
use latest versions

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.3 | [PR#783](https://github.com/bbc/psammead/pull/783) use `psammead-test-helpers@1.0.2` |
+| 3.0.3 | [PR#1155](https://github.com/bbc/psammead/pull/1155) use `psammead-test-helpers@1.0.2` |
 | 3.0.2 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 3.0.1 | [PR#701](https://github.com/bbc/psammead/pull/701) Update README `rem` doc link |
 | 3.0.0 | [PR#586](https://github.com/bbc/psammead/pull/586) Update GEL Types values |

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,8 +3,9 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.6   | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `psammead-test-helpers@1.0.2`|
 | 1.0.5   | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
-| 1.0.4 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
+| 1.0.4   | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.0.3   | [PR#787](https://github.com/bbc/psammead/pull/787) Fix brand stories in Firefox high contrast mode |
 | 1.0.2   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 1.0.1   | [PR#704](https://github.com/bbc/psammead/pull/704) Remove `fill` from SVGs |

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.6   | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `psammead-test-helpers@1.0.2`|
+| 1.0.6   | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `psammead-test-helpers@1.0.2`|
 | 1.0.5   | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
 | 1.0.4   | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.0.3   | [PR#787](https://github.com/bbc/psammead/pull/787) Fix brand stories in Firefox high contrast mode |

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,12 +138,12 @@
       }
     },
     "@bbc/psammead-test-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-1.0.1.tgz",
-      "integrity": "sha512-bZVg3gHoduwKsVGPZ622eVMeff+r8NFMhM+RnUTQvSPV/+0f5tgTbygcYQ6HiUsGip3hqW2+FmVxn16zEy0qaQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-1.0.2.tgz",
+      "integrity": "sha512-JqyVgwyS7lyop4rcnq4vMJUgS/YGw/BOpzOyZgS7j0YLDw4z9gGPVsNmu1WjXtmgly8yb2X3Zc1gAE/6G8n7Xw==",
       "dev": true,
       "requires": {
-        "jest-styled-components": "^6.3.1"
+        "jest-styled-components": "^6.3.3"
       }
     },
     "@emotion/is-prop-valid": {

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "amp"
   ],
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^1.0.1",
+    "@bbc/psammead-test-helpers": "^1.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "styled-components": "^4.3.2"

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.3 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
+| 3.1.3 | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
 | 3.1.2 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `react-helmet@5.2.1` |
 | 3.1.1 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 3.1.0   | [PR#758](https://github.com/bbc/psammead/pull/758) Add ability to limit set of services |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.3 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
 | 3.1.2 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `react-helmet@5.2.1` |
 | 3.1.1 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 3.1.0   | [PR#758](https://github.com/bbc/psammead/pull/758) Add ability to limit set of services |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.0.tgz",
-      "integrity": "sha512-dHVZ+ig1P/crQtvAOP0bB0PAuuqT2R8hs15pZDsJsO1wvPtbvEe2TO6AxXUIODk9TZgod2j+9K6TB4WV/I2LDw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
+      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
     },
     "@bbc/psammead-test-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-1.0.1.tgz",
-      "integrity": "sha512-bZVg3gHoduwKsVGPZ622eVMeff+r8NFMhM+RnUTQvSPV/+0f5tgTbygcYQ6HiUsGip3hqW2+FmVxn16zEy0qaQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-1.0.2.tgz",
+      "integrity": "sha512-JqyVgwyS7lyop4rcnq4vMJUgS/YGw/BOpzOyZgS7j0YLDw4z9gGPVsNmu1WjXtmgly8yb2X3Zc1gAE/6G8n7Xw==",
       "dev": true,
       "requires": {
-        "jest-styled-components": "^6.3.1"
+        "jest-styled-components": "^6.3.3"
       }
     },
     "atob": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "dist/index.js",
   "description": "A collection of common values that are used in storybook by the Psammead components.",
   "repository": {
@@ -24,11 +24,11 @@
     "knobs"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.0",
+    "@bbc/gel-foundations": "^3.0.3",
     "react-helmet": "^5.2.1"
   },
   "devDependencies": {
-    "@bbc/psammead-test-helpers": "^1.0.1",
+    "@bbc/psammead-test-helpers": "^1.0.2",
     "react": "^16.8.6"
   }
 }

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.2   | [PR#732](https://github.com/bbc/psammead/pull/732) Use `jest-styled-components@6.3.3` |
+| 1.0.2   | [PR#1083](https://github.com/bbc/psammead/pull/1083) Use `jest-styled-components@6.3.3` |
 | 1.0.1   | [PR#732](https://github.com/bbc/psammead/pull/732) Use @testing-library/react for generating snapshots |
 | 1.0.0   | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
 | 0.3.4   | [PR#424](https://github.com/bbc/psammead/pull/424) Add Snyk badge to readme |


### PR DESCRIPTION
Resolves n/a

**Overall change:** _bumped storybook-helper and psammead assets._



**Code changes:**

- _update changelog_
- _update package versions_


> Gel foundation changelog

3.0.3 | PR#783 use psammead-test-helpers@1.0.2
-- | --
3.0.2 | PR#783 Update to latest psammead-test-helpers. Update snapshots.
3.0.1 | PR#701 Update README rem doc link

> test-helper

1.0.2 | PR#732 Use jest-styled-components@6.3.3
-- | --
1.0.1 | PR#732 Use @testing-library/react for generating snapshots
1.0.0 | PR#679 Bump version number



---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval