### PR TITLE
Add service locale to inputProvider callback

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.2.3 | [PR#????](https://github.com/bbc/psammead/pull/????) `dirDecorator` now includes service `locale` in the object passed to the callback |
 | 3.1.3 | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
 | 3.1.2 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `react-helmet@5.2.1` |
 | 3.1.1 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.2.3 | [PR#1244](https://github.com/bbc/psammead/pull/1244) `dirDecorator` now includes service `locale` in the object passed to the callback |
+| 3.2.0 | [PR#1244](https://github.com/bbc/psammead/pull/1244) `dirDecorator` now includes service `locale` in the object passed to the callback |
 | 3.1.3 | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
 | 3.1.2 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `react-helmet@5.2.1` |
 | 3.1.1 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.2.3 | [PR#????](https://github.com/bbc/psammead/pull/????) `dirDecorator` now includes service `locale` in the object passed to the callback |
+| 3.2.3 | [PR#1244](https://github.com/bbc/psammead/pull/1244) `dirDecorator` now includes service `locale` in the object passed to the callback |
 | 3.1.3 | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|
 | 3.1.2 | [PR#1083](https://github.com/bbc/psammead/pull/1083) use `react-helmet@5.2.1` |
 | 3.1.1 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.2.3",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.1.3",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.1.3",
+  "version": "3.2.3",
   "main": "dist/index.js",
   "description": "A collection of common values that are used in storybook by the Psammead components.",
   "repository": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.2.3",
+  "version": "3.2.0",
   "main": "dist/index.js",
   "description": "A collection of common values that are used in storybook by the Psammead components.",
   "repository": {

--- a/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
@@ -64,6 +64,7 @@ describe('Psammead storybook helpers', () => {
         slotTexts: [],
         script: 'LATIN SCRIPT OBJECT',
         service: 'news',
+        locale: 'en',
       });
       expect(select).toHaveBeenCalledTimes(1);
       // Allows user to select all availible services
@@ -89,6 +90,7 @@ describe('Psammead storybook helpers', () => {
         slotTexts: [],
         script: 'LATIN SCRIPT OBJECT',
         service: 'news',
+        locale: 'en',
       });
       expect(select).toHaveBeenCalledTimes(1);
       expect(select.mock.calls[0][1]).toEqual(['mundo', 'pidgin', 'yoruba']);
@@ -106,6 +108,7 @@ describe('Psammead storybook helpers', () => {
         slotTexts: [],
         script: 'LATIN SCRIPT OBJECT',
         service: 'news',
+        locale: 'en',
       });
       expect(select).toHaveBeenCalledTimes(1);
       expect(text).toHaveBeenCalledTimes(0);
@@ -127,6 +130,7 @@ describe('Psammead storybook helpers', () => {
           script: 'LATIN SCRIPT OBJECT',
           dir: 'ltr',
           service: 'news',
+          locale: 'en',
         });
 
         expect(select).toHaveBeenCalledTimes(1);
@@ -151,6 +155,7 @@ describe('Psammead storybook helpers', () => {
           script: 'LATIN SCRIPT OBJECT',
           dir: 'ltr',
           service: 'news',
+          locale: 'en',
         });
 
         expect(select).toHaveBeenCalledTimes(1);
@@ -170,6 +175,7 @@ describe('Psammead storybook helpers', () => {
         script: 'LATIN SCRIPT OBJECT',
         dir: 'ltr',
         service: 'news',
+        locale: 'en',
       });
 
       expect(select).toHaveBeenCalledTimes(1);
@@ -193,6 +199,7 @@ describe('Psammead storybook helpers', () => {
         script: 'CYRILLIC SCRIPT OBJECT',
         dir: 'ltr',
         service: 'russian',
+        locale: 'ru',
       });
     });
 
@@ -204,12 +211,7 @@ describe('Psammead storybook helpers', () => {
         underTest.inputProvider([], renderFn)();
 
         expect(renderFn).toHaveBeenCalledTimes(1);
-        expect(renderFn).toHaveBeenCalledWith({
-          slotTexts: [],
-          script: 'CYRILLIC SCRIPT OBJECT',
-          dir: 'ltr',
-          service: 'russian',
-        });
+        expect(renderFn.mock.calls[0][0].dir).toBe('ltr');
       });
 
       it('returns value when specified', () => {
@@ -224,6 +226,7 @@ describe('Psammead storybook helpers', () => {
           script: 'ARABIC SCRIPT OBJECT',
           dir: 'rtl',
           service: 'arabic',
+          locale: 'ar',
         });
       });
     });

--- a/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
@@ -31,11 +31,18 @@ const inputProvider = (slots, componentFunction, services) => () => {
 
   const script = scripts[service.script];
   const dir = service.dir || 'ltr';
+  const { locale } = service;
 
   return (
     <Fragment>
       <Helmet htmlAttributes={{ dir }} />
-      {componentFunction({ slotTexts, script, dir, service: serviceName })}
+      {componentFunction({
+        slotTexts,
+        script,
+        dir,
+        locale,
+        service: serviceName,
+      })}
     </Fragment>
   );
 };

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -3,172 +3,230 @@ const LANGUAGE_VARIANTS = {
     text:
       "Gammadoo ta'uun akkanumaan hin dhufu, waan shaakalamuudha jetti saantoos.",
     script: 'latin',
+    locale: 'om',
   },
   afrique: {
     text:
       'La police surveille le cimetière de Christchurch où sont enterrées les premières victimes de la tuerie.',
     script: 'latinDiacritics',
+    locale: 'fr',
   },
-  amharic: { text: 'አቶ ባትሪ ለማ እና አቶ ደቻሳ ጉተማ', script: 'ethiopic' },
+  amharic: {
+    text: 'አቶ ባትሪ ለማ እና አቶ ደቻሳ ጉተማ',
+    script: 'ethiopic',
+    locale: 'am',
+  },
   arabic: {
     text:
       'المحكمة العليا الأمريكية ذات الأغلبية المحافظة وافقت على احتجاز غير المواطنين لأجل غير مسمى حتى بعد سنوات من خروجهم من السجن',
     script: 'arabic',
     dir: 'rtl',
+    locale: 'ar',
   },
   azeri: {
     text:
       'Qazaxıstan prezidenti vəzifələrini icra edəcək Kasım-Comərt Tokayev and içib',
     script: 'latinDiacritics',
+    locale: 'az',
   },
   bengali: {
     text: 'পাসওয়ার্ড হতে হবে খুব শক্ত যাতে কেউ সেটা ভাঙতে না পারে',
     script: 'bengali',
+    locale: 'bn',
   },
   brasil: {
     text:
       'Medidas anunciadas no encontro entre Bolsonaro e Trump celebram aproximação com o governo americano - mas elas agora precisam passar pelo teste da concretização',
     script: 'latinDiacritics',
+    locale: 'pt',
   },
   burmese: {
     text: 'အောက်စဖို့ဒ် ဆရာတော် ပါမောက္ခ ဒေါက်တာအရှင်ဓမ္မသာမိ',
     script: 'burmese',
+    locale: 'my',
   },
-  chineseSimp: { text: '家长们在学校门口维权。', script: 'chinese' },
-  chineseTrad: { text: '家長們在學校門口維權。', script: 'chinese' },
+  chineseSimp: {
+    text: '家长们在学校门口维权。',
+    script: 'chinese',
+    locale: 'zh',
+  },
+  chineseTrad: {
+    text: '家長們在學校門口維權。',
+    script: 'chinese',
+    locale: 'zh',
+  },
   news: {
     text: 'Could a computer ever create better art than a human?',
     script: 'latin',
+    locale: 'en',
   },
   gahuza: {
     text:
       'Abashika 100.000 ntawuzi irengero ryabo, abandi ibihumbi nabo ntibagira aho bakika umusaya',
     script: 'latin',
+    locale: 'rw',
   },
   gujarati: {
     text: 'જીતેન્દ્રસિંહ મૂળ ઉત્તર પ્રદેશના ફિરોઝાબાદના',
     script: 'hindi',
+    locale: 'gu',
   },
-  hausa: { text: 'Bayanin Ganduje kan ayyukan Gama', script: 'latin' },
-  hindi: { text: 'जय शाह', script: 'hindi' },
+  hausa: {
+    text: 'Bayanin Ganduje kan ayyukan Gama',
+    script: 'latin',
+    locale: 'ha',
+  },
+  hindi: { text: 'जय शाह', script: 'hindi', locale: 'hi' },
   igbo: {
     text:
       "Trade Fair: Ọ bụrụgodi na gọọmenti etiti chọrọ ire ọdọ ahịa a, ndị Igbo ga-egonwu ya'",
     script: 'latinDiacritics',
+    locale: 'ig',
   },
   indonesian: {
     text:
       '"Apa yang terjadi di Selandia Baru adalah kekerasan yang dibawa oleh seseorang yang tumbuh dan belajar ideologinya di tempat lain,\' kata Jacinda Ardern.',
     script: 'latin',
+    locale: 'id',
   },
   japanese: {
     text: '度目の採決認めなかった理由は？ 英下院議長に取材',
     script: 'chinese',
+    locale: 'ja',
   },
-  korean: { text: '마이크 폼페이오 미국 국무장관', script: 'korean' },
+  korean: {
+    text: '마이크 폼페이오 미국 국무장관',
+    script: 'korean',
+    locale: 'ko',
+  },
   kyrgyz: {
     text: 'Казакстан Назарбаевден башка президентти көрө элек',
     script: 'cyrillic',
+    locale: 'ky',
   },
-  marathi: { text: 'नीरव मोदी', script: 'hindi' },
+  marathi: { text: 'नीरव मोदी', script: 'hindi', locale: 'mr' },
   mundo: {
     text:
       'La caída en los precios de la vivienda ha hecho que algunas personas puedan comprar en zonas acomodadas de la ciudad.',
     script: 'latinDiacritics',
+    locale: 'es',
   },
-  nepali: { text: 'हेमन्तप्रकाश मल्ल', script: 'nepali' },
+  nepali: { text: 'हेमन्तप्रकाश मल्ल', script: 'nepali', locale: 'ne' },
   pashto: {
     text:
       'د ملګرو ملتونو د ماشومانو ادارې یونیسف افغان کرېکټ لوبغاړی راشد خان په افغانستان کې د ښه نیست ملي سفیر وټاکه.',
     script: 'arabicPashto',
     dir: 'rtl',
+    locale: 'ps',
   },
   persian: {
     text:
       'در این جشنواره برای نخستین بار از کارگران افغانستان در شهر تهران تقدیر شد',
     script: 'arabic',
     dir: 'rtl',
+    locale: 'fa',
   },
   pidgin: {
     text:
       'Di Nigeria Army don set up 9 man Committee to chook eye inside how dia men conduct demsef during di 2019 General Elections.',
     script: 'latin',
+    locale: 'pcm',
   },
   punjabi: {
     text:
       'ਪਾਕਿਸਤਾਨੀ ਮਹਿਲਾ ਰਾਹਿਲਾ ਨੇ ਭਾਰਤੀ ਵਕੀਲ ਜ਼ਰੀਏ ਅਦਾਲਤ ਵਿੱਚ ਦਿੱਤੀ ਅਰਜ਼ੀ ਵਿੱਚ ਕਿਹਾ ਕਿ ਮਾਮਲੇ ਨਾਲ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ',
     script: 'hindi',
+    locale: 'pa',
   },
   russian: {
     text:
       'Мнение Назарбаева будет иметь приоритетное значение при принятии важных для страны решений, сказал Токаев',
     script: 'cyrillic',
+    locale: 'ru',
   },
   serbianCyr: {
     text: 'Караџић се годинама крио пре него што је ухапшен 2008. године',
     script: 'cyrillic',
+    locale: 'sr',
   },
   serbianLat: {
     text: 'Karadžić se godinama krio pre nego što je uhapšen 2008. godine',
     script: 'latin',
+    locale: 'sr',
   },
   sinhala: {
     text: 'සිවිල් යුද ගැටුම් හමුවේ කොටු වී සිටි සිවිල් වැසියන්',
     script: 'sinhalese',
+    locale: 'si',
   },
   somali: {
     text: 'Qaar ka mid ah dadkii laga soo badbaadiyay Hotel Dusit2 ee Nairobi',
     script: 'latin',
+    locale: 'so',
   },
   swahili: {
     text:
       'Kimbunga Idai: ‘Watu milioni 1.7 wapo katika njia kuu’ ya kimbunga Msumbiji, Zimbabwe',
     script: 'latin',
+    locale: 'sw',
   },
-  tamil: { text: 'நீரவ் மோதி', script: 'tamil' },
+  tamil: { text: 'நீரவ் மோதி', script: 'tamil', locale: 'ta' },
   telugu: {
     text:
       'నల్లగొండ ఫ్లోరైడ్ సమస్య గురించి నాటి ప్రధాని అటల్ బిహారీ వాజపేయికి దుశ్చర్ల సత్యనారాయణ వివరించారు',
     script: 'hindi',
+    locale: 'te',
   },
-  thai: { text: 'ภาพวาดของตำรวจจากใบหน้าผู้เสียชีวิต', script: 'thai' },
-  tigrinya: { text: 'ዓብዱራሕማን ኣቡሃሽም', script: 'ethiopic' },
+  thai: {
+    text: 'ภาพวาดของตำรวจจากใบหน้าผู้เสียชีวิต',
+    script: 'thai',
+    locale: 'th',
+  },
+  tigrinya: { text: 'ዓብዱራሕማን ኣቡሃሽም', script: 'ethiopic', locale: 'ti' },
   turkish: {
     text:
       'Kassım Jomart Tokayev, parlamentoda yemin ederek devlet başkanlığı görevini resmen devraldı.',
     script: 'latin',
+    locale: 'tr',
   },
   ukChinaSimp: {
     text: '该计划的批评者说，这个政策不能解决住房短缺的问题（Credit: Alamy）',
     script: 'chinese',
+    locale: 'zh',
   },
   ukChinaTrad: {
     text: '該計劃的批評者說，這個政策不能解決住房短缺的問題（Credit: Alamy）',
     script: 'chinese',
+    locale: 'zh',
   },
   ukrainian: {
     text:
       "Олег Ляшко був традиційно емоційним, говорив на підвищених тонах. Прем'єр спочатку нервував, проте швидко опанував ситуацію.",
     script: 'cyrillic',
+    locale: 'uk',
   },
   urdu: {
     text:
       'وزیر اعظم جاسنڈا آرڈرن کا کہنا ہے کہ حملہ آور کا نام کسی واچ لسٹ پر نہیں تھا، نہ آسٹریلیا میں اور نہ ہی کہیں اور',
     script: 'arabic',
     dir: 'rtl',
+    locale: 'ur',
   },
   uzbek: {
     text:
       'Дариға Назарбоева Қозоғистон президентининг Британияга охирги сафарида отасига ҳамроҳлик қилган',
     script: 'cyrillic',
+    locale: 'uz',
   },
   vietnamese: {
     text: 'Ông Nazarbayev bất ngờ tuyên bố từ chức hôm 19/3/2019',
     script: 'latinDiacritics',
+    locale: 'vi',
   },
   yoruba: {
     text: 'Wo àwọn òrílẹ̀ èdè Mẹ́wàá tó láyọ̀ jùlọ Lágbàyé',
     script: 'latin',
+    locale: 'yo',
   },
 };
 


### PR DESCRIPTION
Dependency for https://github.com/bbc/psammead/issues/1185

**Overall change:** The inputProvider function within storybook helpers will now call the render function with an additional `locale` property based on the service selected

**Code changes:**

- Add `locales` for all services
- inputProvider now includes `locale` in the callback argument

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval