### PR TITLE
Use new custom grid detector

### DIFF
--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,12 +3,13 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `@bbc/psammead-styles/detection` to detect grid support |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
-| 2.0.3   | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3`, `psammead-storybook-helpers@3.1.3`, `psammead-test-helpers@1.0.2` |
-| 2.0.2   | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
-| 2.0.1   | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
+| 2.0.3 | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3`, `psammead-storybook-helpers@3.1.3`, `psammead-test-helpers@1.0.2` |
+| 2.0.2 | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
+| 2.0.1 | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 2.0.0 | [PR#1018](https://github.com/bbc/psammead/pull/1018) Apply font based on service prop |
-| 1.0.5   | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
+| 1.0.5 | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 1.0.4 | [PR#783](https://github.com/bbc/psammead/pull/783) Update to latest psammead-test-helpers. Update snapshots. |
 | 1.0.3 | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
 | 1.0.2 | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
@@ -23,12 +24,12 @@
 | 0.3.4 | [PR#407](https://github.com/bbc/psammead/pull/407) Organise dependencies properly |
 | 0.3.3 | [PR#398](https://github.com/bbc/psammead/pull/398) Update dependencies. Using `rem` for media queries. |
 | 0.3.2 | [PR#323](https://github.com/bbc/psammead/pull/323) Update storybook badge url |
-| 0.3.1 | [PR#347](https://github.com/BBC/psammead/pull/347) Constrain content width to Group 5 min width. |
-| 0.3.0 | [PR#318](https://github.com/BBC/psammead/pull/318) Update to new font face and family. |
-| 0.2.1 | [PR#323](https://github.com/BBC/psammead/pull/323) Update readme storybook badge |
-| 0.2.0 | [PR#306](https://github.com/BBC/psammead/pull/306) Update background colour to Ebon & border colours to Shadow. |
-| 0.1.4 | [PR#264](https://github.com/BBC/psammead/pull/264) Resolving package-lock issues. |
-| 0.1.3 | [PR#245](https://github.com/BBC-News/psammead/pull/245) Ensures documentation consistent across component packages. |
-| 0.1.2 | [PR#231](https://github.com/BBC-News/psammead/pull/231) Add link to Storybook to README |
-| 0.1.1 | [PR#227](https://github.com/BBC-News/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/BBC-News/psammead/issues/226). |
-| 0.1.0 | [PR#154](https://github.com/BBC-News/psammead/pull/154) Create initial package with SitewideLinks component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |
+| 0.3.1 | [PR#347](https://github.com/bbc/psammead/pull/347) Constrain content width to Group 5 min width. |
+| 0.3.0 | [PR#318](https://github.com/bbc/psammead/pull/318) Update to new font face and family. |
+| 0.2.1 | [PR#323](https://github.com/bbc/psammead/pull/323) Update readme storybook badge |
+| 0.2.0 | [PR#306](https://github.com/bbc/psammead/pull/306) Update background colour to Ebon & border colours to Shadow. |
+| 0.1.4 | [PR#264](https://github.com/bbc/psammead/pull/264) Resolving package-lock issues. |
+| 0.1.3 | [PR#245](https://github.com/bbc/psammead/pull/245) Ensures documentation consistent across component packages. |
+| 0.1.2 | [PR#231](https://github.com/bbc/psammead/pull/231) Add link to Storybook to README |
+| 0.1.1 | [PR#227](https://github.com/bbc/psammead/pull/227) Replace @bbc/gel-constants and @bbc/gel-foundations-styled-component with [@bbc/gel-foundations in Psammead](https://github.com/bbc/psammead/issues/226). |
+| 0.1.0 | [PR#154](https://github.com/bbc/psammead/pull/154) Create initial package with SitewideLinks component pulled in from [Simorgh](https://github.com/BBC-News/simorgh). |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.2.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `@bbc/psammead-styles/detection` to detect grid support |
+| 2.2.0 | [PR#1408](https://github.com/bbc/psammead/pull/1408) Use `@bbc/psammead-styles/detection` to detect grid support |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.3 | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3`, `psammead-storybook-helpers@3.1.3`, `psammead-test-helpers@1.0.2` |
 | 2.0.2 | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -153,9 +153,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.1.3.tgz",
-      "integrity": "sha512-h/R5fEvk01uUPf1/Wi44yEAs7GeLKTVdNK+6CPuWSLJM7iy5/ZlqYkkhXmyx1HpDGGUFPAJS5msJFbBKSR6+iA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.2.0.tgz",
+      "integrity": "sha512-BZ/pnWUaokw7WQ16d5NLudeagTxd3F70a7jWyis/YuoltD/aQexvH+QmrvJOEX2Inn6e8Qi828MXF5Z6cAgzdg=="
     },
     "@bbc/psammead-test-helpers": {
       "version": "1.0.2",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.0.3",
-    "@bbc/psammead-styles": "^1.1.3"
+    "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {
     "@bbc/psammead-storybook-helpers": "^3.1.3",

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -74,13 +74,13 @@ exports[`List should render correctly with 7 items 1`] = `
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c0 > li:first-child {
     width: 100%;
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: inline-block;
   }
@@ -272,13 +272,13 @@ exports[`List should render correctly with 8 items 1`] = `
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c0 > li:first-child {
     width: 100%;
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: inline-block;
   }

--- a/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/List/__snapshots__/index.test.jsx.snap
@@ -18,8 +18,6 @@ exports[`List should render correctly with 7 items 1`] = `
 
 .c0 {
   border-bottom: 1px solid #3F3F42;
-  display: grid;
-  grid-auto-flow: column;
   list-style-type: none;
   margin: 0;
   padding: 0 0 0.5rem;
@@ -34,6 +32,13 @@ exports[`List should render correctly with 7 items 1`] = `
 
 .c1 {
   min-width: 50%;
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c0 {
+    display: grid;
+    grid-auto-flow: column;
+  }
 }
 
 @media (max-width:14.9375rem) {
@@ -216,8 +221,6 @@ exports[`List should render correctly with 8 items 1`] = `
 
 .c0 {
   border-bottom: 1px solid #3F3F42;
-  display: grid;
-  grid-auto-flow: column;
   list-style-type: none;
   margin: 0;
   padding: 0 0 0.5rem;
@@ -232,6 +235,13 @@ exports[`List should render correctly with 8 items 1`] = `
 
 .c1 {
   min-width: 50%;
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c0 {
+    display: grid;
+    grid-auto-flow: column;
+  }
 }
 
 @media (max-width:14.9375rem) {

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -13,6 +13,7 @@ import {
   GEL_GROUP_4_SCREEN_WIDTH_MAX,
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
+import { grid } from '@bbc/psammead-styles/detection';
 
 import Link from '../Link';
 
@@ -68,7 +69,7 @@ const StyledList = styled.ul`
     padding: ${GEL_SPACING} 0;
     margin-bottom: ${GEL_SPACING};
     grid-column: 1/-1;
-    @supports not (display: grid) {
+    @supports not (${grid}) {
       width: 100%;
     }
   }
@@ -76,7 +77,7 @@ const StyledList = styled.ul`
 
 const StyledListItem = styled.li`
   min-width: 50%;
-  @supports not (display: grid) {
+  @supports not (${grid}) {
     display: inline-block;
   }
 `;

--- a/packages/components/psammead-sitewide-links/src/List/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/List/index.jsx
@@ -24,11 +24,15 @@ const getRowCount = (children, columns) =>
 
 const StyledList = styled.ul`
   border-bottom: 1px solid ${C_SHADOW};
-  display: grid;
-  grid-auto-flow: column;
   list-style-type: none;
   margin: 0;
   padding: 0 0 ${GEL_SPACING};
+
+  @supports (${grid}) {
+    display: grid;
+    grid-auto-flow: column;
+  }
+
   @media (max-width: ${GEL_GROUP_0_SCREEN_WIDTH_MAX}) {
     grid-auto-flow: row;
   }

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -103,13 +103,13 @@ exports[`SitewideLinks should render correctly 1`] = `
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c2 > li:first-child {
     width: 100%;
   }
 }
 
-@supports not (display:grid) {
+@supports not (grid-template-columns:fit-content(200px)) {
   .c3 {
     display: inline-block;
   }

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -27,8 +27,6 @@ exports[`SitewideLinks should render correctly 1`] = `
 
 .c2 {
   border-bottom: 1px solid #3F3F42;
-  display: grid;
-  grid-auto-flow: column;
   list-style-type: none;
   margin: 0;
   padding: 0 0 0.5rem;
@@ -63,6 +61,13 @@ exports[`SitewideLinks should render correctly 1`] = `
   color: #FFFFFF;
   margin: 0;
   padding: 1rem 0;
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c2 {
+    display: grid;
+    grid-auto-flow: column;
+  }
 }
 
 @media (max-width:14.9375rem) {

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,18 +3,19 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.2.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `@bbc/psammead-styles/detection` to detect grid support |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
-| 2.0.4   |  [PR#1089](https://github.com/bbc/psammead/pull/1089) Remove extra margin from 1st story promo |
-| 2.0.3  | [PR#1182](https://github.com/bbc/psammead/pull/1182) Bump dependencies and update test/story to have `service` prop |
-| 2.0.2   |  [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
-| 2.0.1   | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
+| 2.0.4 | [PR#1089](https://github.com/bbc/psammead/pull/1089) Remove extra margin from 1st story promo |
+| 2.0.3 | [PR#1182](https://github.com/bbc/psammead/pull/1182) Bump dependencies and update test/story to have `service` prop |
+| 2.0.2 | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |
+| 2.0.1 | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 2.0.0 | [PR#1022](https://github.com/bbc/psammead/pull/1022) Apply font based on service prop |
-| 1.0.1  | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
+| 1.0.1 | [PR#892](https://github.com/bbc/psammead/pull/892) Bump dependencies |
 | 1.0.0 | [PR#937](https://github.com/bbc/psammead/pull/937) Remove alpha tag, swarm done |
-| 1.0.0-alpha.6   | [PR#893](https://github.com/bbc/psammead/pull/893) Fix knobs for story promo stories |
-| 1.0.0-alpha.5   | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
+| 1.0.0-alpha.6 | [PR#893](https://github.com/bbc/psammead/pull/893) Fix knobs for story promo stories |
+| 1.0.0-alpha.5 | [PR#769](https://github.com/bbc/psammead/pull/769) Fix stories not appearing in storybook when using `install:packages:link` |
 | 1.0.0-alpha.4 | [PR#706](https://github.com/bbc/psammead/pull/706) Fix amp images not showing in IE11  |
-| 1.0.0-alpha.3   | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
+| 1.0.0-alpha.3 | [PR#713](https://github.com/bbc/psammead/pull/713) Update `styled-components` to 4.3.2 |
 | 1.0.0-alpha.2 | [PR#694](https://github.com/bbc/psammead/pull/694) Fix floating media indicator and promo link bugs  |
 | 1.0.0-alpha.1 | [PR#677](https://github.com/bbc/psammead/pull/677) Use `@bbc/gel-foundations@3.0.0` |
 | 1.0.0-alpha.0 | [PR#679](https://github.com/bbc/psammead/pull/679) Bump version number |
@@ -24,11 +25,11 @@
 | 0.2.0-alpha.6 | [PR#588](https://github.com/bbc/psammead/pull/588) Update Story promo headline to use Pica under 600px. |
 | 0.2.0-alpha.5 | [PR#522](https://github.com/bbc/psammead/pull/522) AddMediaIndicator. |
 | 0.2.0-alpha.4 | [PR#546](https://github.com/bbc/psammead/pull/546) Replace colours and hide summary under 600px width screen. |
-| 0.2.0-alpha.3 | [PR#534](https://github.com/BBC-News/psammead/pull/534) Remove Timestamp padding. |
+| 0.2.0-alpha.3 | [PR#534](https://github.com/bbc/psammead/pull/534) Remove Timestamp padding. |
 | 0.2.0-alpha.2 | [PR#535](https://github.com/bbc/psammead/pull/535) Fix issues with knobs on storybook. |
 | 0.2.0-alpha.1 | [PR#513](https://github.com/bbc/psammead/pull/513) Add Link with hover, focus and visited states. |
-| 0.1.4   | [PR#489](https://github.com/BBC-News/psammead/pull/489) Add grid fallback. |
-| 0.1.3   | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider. |
-| 0.1.2   | [PR#488](https://github.com/BBC-News/psammead/pull/488) Hide story summary on device width lower than 600px. |
-| 0.1.1   | [PR#474](https://github.com/BBC-News/psammead/pull/474) Update Story promo headline to use Great Primer. |
-| 0.1.0   | [PR#453](https://github.com/BBC-News/psammead/pull/453) Create initial package. |
+| 0.1.4 | [PR#489](https://github.com/bbc/psammead/pull/489) Add grid fallback. |
+| 0.1.3 | [PR#498](https://github.com/bbc/psammead/pull/498) Update stories to use new input provider. |
+| 0.1.2 | [PR#488](https://github.com/bbc/psammead/pull/488) Hide story summary on device width lower than 600px. |
+| 0.1.1 | [PR#474](https://github.com/bbc/psammead/pull/474) Update Story promo headline to use Great Primer. |
+| 0.1.0 | [PR#453](https://github.com/bbc/psammead/pull/453) Create initial package. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.2.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `@bbc/psammead-styles/detection` to detect grid support |
+| 2.2.0 | [PR#1408](https://github.com/bbc/psammead/pull/1408) Use `@bbc/psammead-styles/detection` to detect grid support |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.4 | [PR#1089](https://github.com/bbc/psammead/pull/1089) Remove extra margin from 1st story promo |
 | 2.0.3 | [PR#1182](https://github.com/bbc/psammead/pull/1182) Bump dependencies and update test/story to have `service` prop |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,9 +170,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.1.3.tgz",
-      "integrity": "sha512-h/R5fEvk01uUPf1/Wi44yEAs7GeLKTVdNK+6CPuWSLJM7iy5/ZlqYkkhXmyx1HpDGGUFPAJS5msJFbBKSR6+iA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.2.0.tgz",
+      "integrity": "sha512-BZ/pnWUaokw7WQ16d5NLudeagTxd3F70a7jWyis/YuoltD/aQexvH+QmrvJOEX2Inn6e8Qi828MXF5Z6cAgzdg=="
     },
     "@bbc/psammead-test-helpers": {
       "version": "1.0.2",

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.0.3",
-    "@bbc/psammead-styles": "^1.1.3"
+    "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {
     "@bbc/psammead-image": "^1.0.6",

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -75,7 +75,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   color: #6E6E73;
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c0 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
@@ -96,7 +96,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: block;
     width: initial;
@@ -171,7 +171,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c3 {
     display: block;
     width: initial;
@@ -358,7 +358,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c0 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
@@ -379,7 +379,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: block;
     width: initial;
@@ -454,7 +454,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c9 {
     display: block;
     width: initial;
@@ -614,7 +614,7 @@ exports[`StoryPromo should render correctly 1`] = `
   color: #6E6E73;
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c0 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
@@ -628,7 +628,7 @@ exports[`StoryPromo should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: block;
     width: initial;
@@ -704,7 +704,7 @@ exports[`StoryPromo should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c3 {
     display: block;
     width: initial;
@@ -887,7 +887,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c0 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
@@ -901,7 +901,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c1 {
     display: block;
     width: initial;
@@ -984,7 +984,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   }
 }
 
-@supports (display:grid) {
+@supports (grid-template-columns:fit-content(200px)) {
   .c9 {
     display: block;
     width: initial;

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -443,7 +443,7 @@ exports[`StoryPromo - Top Story with Media Indicator should render correctly 1`]
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c9 {
+  .c8 {
     display: block;
     width: initial;
     padding: initial;
@@ -956,7 +956,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c9 {
+  .c8 {
     display: block;
     width: initial;
     padding: initial;

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -21,6 +21,7 @@ import {
 } from '@bbc/gel-foundations/typography';
 import { C_EBON, C_SHADOW, C_METAL } from '@bbc/psammead-styles/colours';
 import { getSansRegular, getSerifBold } from '@bbc/psammead-styles/font-styles';
+import { grid } from '@bbc/psammead-styles/detection';
 
 const twoOfSixColumnsMaxWidthScaleable = `33.33%`;
 // (2 / 6) * 100 = 0.3333333333 = 33.33%
@@ -40,7 +41,7 @@ const fullWidthColumnsMaxScaleable = `100%`;
 const StoryPromoWrapper = styled.div`
   position: relative;
 
-  @supports (display: grid) {
+  @supports (${grid}) {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: ${GEL_GUTTER_BELOW_600PX};
@@ -101,7 +102,7 @@ const ImageGridItem = styled.div`
     width: ${fourOfTwelveColumnsMaxWidthScaleable};
   }
 
-  @supports (display: grid) {
+  @supports (${grid}) {
     display: block;
     width: initial;
 
@@ -211,7 +212,7 @@ const TextGridItem = styled.div`
     width: ${eightOfTwelveColumnsMaxScaleable};
   }
 
-  @supports (display: grid) {
+  @supports (${grid}) {
     display: block;
     width: initial;
     padding: initial;


### PR DESCRIPTION
Resolves #1364

**Overall change:** 
Use new custom `grid` detector from `@bbc/psammead-styles/detection` in `psammead-sitewide-links` and `psammead-story-promo`.

**Code changes:**
- Import and use the `grid` detector in the `StoryPromo` and `List`
- Update snaps

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval