### PR TITLE
revert styling, remove alpha, bump version

### DIFF
--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.2.1 | [PR#1413](https://github.com/bbc/psammead/pull/1413) Revert alpha changes while they undergo external accesibility review |
+| 1.2.1 | [PR#1413](https://github.com/bbc/psammead/pull/1413) Revert alpha changes while they undergo external accessibility review |
 | 1.2.0-alpha.3 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.2.0-alpha.2 | [PR#1405](https://github.com/bbc/psammead/pull/1405) Fix pre-wrap hover bug |
 | 1.2.0-alpha.1 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.1 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Revert alpha changes while they undergo external accesibility review |
 | 1.2.0-alpha.3 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.2.0-alpha.2 | [PR#1405](https://github.com/bbc/psammead/pull/1405) Fix pre-wrap hover bug |
 | 1.2.0-alpha.1 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.2.1 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Revert alpha changes while they undergo external accesibility review |
+| 1.2.1 | [PR#1413](https://github.com/bbc/psammead/pull/1413) Revert alpha changes while they undergo external accesibility review |
 | 1.2.0-alpha.3 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.2.0-alpha.2 | [PR#1405](https://github.com/bbc/psammead/pull/1405) Fix pre-wrap hover bug |
 | 1.2.0-alpha.1 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.2.0-alpha.3",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.2.0-alpha.3",
+  "version": "1.2.1",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -35,8 +35,5 @@
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"
-  },
-  "publishConfig": {
-    "tag": "alpha"
   }
 }

--- a/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-inline-link/src/__snapshots__/index.test.jsx.snap
@@ -4,8 +4,6 @@ exports[`InlineLink should render correctly 1`] = `
 .c0 {
   color: #222222;
   border-bottom: 1px solid #B80000;
-  margin: 0 -0.125rem;
-  padding: 0 0.125rem;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -17,9 +15,8 @@ exports[`InlineLink should render correctly 1`] = `
 
 .c0:focus,
 .c0:hover {
-  background-color: #B80000;
   border-bottom: 2px solid #B80000;
-  color: #FFFFFF;
+  color: #B80000;
 }
 
 <a

--- a/packages/components/psammead-inline-link/src/index.jsx
+++ b/packages/components/psammead-inline-link/src/index.jsx
@@ -1,16 +1,9 @@
 import styled from 'styled-components';
-import {
-  C_POSTBOX,
-  C_METAL,
-  C_EBON,
-  C_WHITE,
-} from '@bbc/psammead-styles/colours';
+import { C_POSTBOX, C_METAL, C_EBON } from '@bbc/psammead-styles/colours';
 
 const InlineLink = styled.a`
   color: ${C_EBON};
   border-bottom: 1px solid ${C_POSTBOX};
-  margin: 0 -0.125rem;
-  padding: 0 0.125rem;
   text-decoration: none;
 
   &:visited {
@@ -20,9 +13,8 @@ const InlineLink = styled.a`
 
   &:focus,
   &:hover {
-    background-color: ${C_POSTBOX};
     border-bottom: 2px solid ${C_POSTBOX};
-    color: ${C_WHITE};
+    color: ${C_POSTBOX};
   }
 `;
 


### PR DESCRIPTION
Resolves #1411

**Overall change:** Removes the new inline-link styling and removes alpha tag from the package.

**Code changes:**

- removes alpha tag
- removes new styling updates

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval