### PR TITLE
BumperBot: Bump @bbc/psammead-assets, @bbc/gel-foundations

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.2.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 4.2.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 4.2.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 4.1.12 | [PR#1181](https://github.com/bbc/psammead/pull/1181) Bump dependencies |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,14 +138,14 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-assets": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.0.6.tgz",
-      "integrity": "sha512-lc0q33HfEK17hV+eKInWG/v4sGrLkVlcU90N5EC6hn2BX+0Td7ue+6wQMpKjw2ngL+j5xv2zKzsBLDwn1k0mUQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.1.1.tgz",
+      "integrity": "sha512-hzZbvhudaNXiVC7xXqy6YbeF7tVSpxe7q8xpGU4b8fbCgtxIWZuKrw6AXOC6BHfCyAli1fT4Gedqf7hrYWXXvQ==",
       "dev": true
     },
     "@bbc/psammead-storybook-helpers": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,12 +19,12 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0",
     "@bbc/psammead-visually-hidden-text": "^1.0.7"
   },
   "devDependencies": {
-    "@bbc/psammead-assets": "^1.0.6",
+    "@bbc/psammead-assets": "^1.1.1",
     "@bbc/psammead-storybook-helpers": "^3.1.3",
     "@bbc/psammead-test-helpers": "^1.0.2",
     "react": "^16.8.6",

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.3   | [PR#1203](https://github.com/bbc/psammead/pull/1203) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3` and bump devDependencies |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-inline-link": {
       "version": "1.1.10",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.3 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.2 | [PR#1366](https://github.com/bbc/psammead/pull/1366) Add Storybook entries for all services |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.3.0",

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 1.0.6   | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3`, `psammead-test-helpers@1.0.2`, `psammead-visually-hidden-text@1.0.7` |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-styles": {
       "version": "1.2.0",

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.1 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 1.0.8   | [PR#1205](https://github.com/bbc/psammead/pull/1205) Bump dependencies |
 | 1.0.7   | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-assets": {
       "version": "1.0.6",

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-figure/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3"
+    "@bbc/gel-foundations": "^3.1.0"
   },
   "devDependencies": {
     "@bbc/psammead-caption": "^2.0.3",

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 3.0.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 3.0.0   | [PR#1241](https://github.com/bbc/psammead/pull/1241) Apply font based on service |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.1.3",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 1.0.5 | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `psammead-assets@1.0.6`, `psammead-styles@1.1.3`, `psammead-test-helpers@1.0.2`|

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/psammead-assets": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.0.6.tgz",
-      "integrity": "sha512-lc0q33HfEK17hV+eKInWG/v4sGrLkVlcU90N5EC6hn2BX+0Td7ue+6wQMpKjw2ngL+j5xv2zKzsBLDwn1k0mUQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.1.1.tgz",
+      "integrity": "sha512-hzZbvhudaNXiVC7xXqy6YbeF7tVSpxe7q8xpGU4b8fbCgtxIWZuKrw6AXOC6BHfCyAli1fT4Gedqf7hrYWXXvQ=="
     },
     "@bbc/psammead-styles": {
       "version": "1.2.0",

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
-    "@bbc/psammead-assets": "^1.0.6",
+    "@bbc/psammead-assets": "^1.1.1",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.1 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 1.0.6 | [PR#1180](https://github.com/bbc/psammead/pull/1180) use `psammead-assets@1.0.6` and `psammead-test-helpers@1.0.2`|
 | 1.0.5 | [PR#1082](https://github.com/bbc/psammead/pull/1082) Bump lodash security vulnerability |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/psammead-assets": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.0.6.tgz",
-      "integrity": "sha512-lc0q33HfEK17hV+eKInWG/v4sGrLkVlcU90N5EC6hn2BX+0Td7ue+6wQMpKjw2ngL+j5xv2zKzsBLDwn1k0mUQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.1.1.tgz",
+      "integrity": "sha512-hzZbvhudaNXiVC7xXqy6YbeF7tVSpxe7q8xpGU4b8fbCgtxIWZuKrw6AXOC6BHfCyAli1fT4Gedqf7hrYWXXvQ==",
       "dev": true
     },
     "@bbc/psammead-test-helpers": {

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image/README.md",
   "devDependencies": {
-    "@bbc/psammead-assets": "^1.0.6",
+    "@bbc/psammead-assets": "^1.1.1",
     "@bbc/psammead-test-helpers": "^1.0.2",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.3.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.3.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.3.0 | [PR#1240](https://github.com/bbc/psammead/pull/1240) Remove unused offscreen text |
 | 2.2.0 | [PR#1243](https://github.com/bbc/psammead/pull/1243) Add photogallery media icon |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.1.3",

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.1   | [PR#1182](https://github.com/bbc/psammead/pull/1182) Bump dependencies |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,14 +138,14 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-assets": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.0.6.tgz",
-      "integrity": "sha512-lc0q33HfEK17hV+eKInWG/v4sGrLkVlcU90N5EC6hn2BX+0Td7ue+6wQMpKjw2ngL+j5xv2zKzsBLDwn1k0mUQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-1.1.1.tgz",
+      "integrity": "sha512-hzZbvhudaNXiVC7xXqy6YbeF7tVSpxe7q8xpGU4b8fbCgtxIWZuKrw6AXOC6BHfCyAli1fT4Gedqf7hrYWXXvQ==",
       "dev": true
     },
     "@bbc/psammead-brand": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -19,12 +19,12 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0",
     "@bbc/psammead-visually-hidden-text": "^1.0.7"
   },
   "devDependencies": {
-    "@bbc/psammead-assets": "^1.0.6",
+    "@bbc/psammead-assets": "^1.1.1",
     "@bbc/psammead-brand": "^4.1.12",
     "@bbc/psammead-storybook-helpers": "^3.1.3",
     "@bbc/psammead-test-helpers": "^1.0.2",

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.5   | [PR#1182](https://github.com/bbc/psammead/pull/1182) Bump dependencies |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-inline-link": {
       "version": "1.1.10",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.0 | [PR#974](https://github.com/bbc/psammead/pull/974) Apply font based on service prop |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.1.3",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.3 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.2 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.1 | [PR#1362](https://github.com/bbc/psammead/pull/1362) Use `text-decoration` styling instead of border-bottom |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.1.3",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 1.0.7   | [PR#1203](https://github.com/bbc/psammead/pull/1203) use `gel-foundations@3.0.3`, `psammead-styles@1.1.3`, bump devDependencies and pass `service` prop to required components in test. |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-image": {
       "version": "1.0.6",

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.2 | [PR#1409](https://github.com/bbc/psammead/pull/1409) Bump media-indicator to v2.3.0 |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-image": {
       "version": "1.0.6",

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.1.1 | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 2.0.4   | [PR#1181](https://github.com/bbc/psammead/pull/1181) use `psammead-styles@1.1.3`, `gel-foundations@3.0.3`, `psammead-storybook-helpers@3.1.3`, `psammead-test-helpers@1.0.2`  |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.1.3",

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
     "@bbc/psammead-styles": "^1.2.0",
-    "@bbc/gel-foundations": "^3.0.3"
+    "@bbc/gel-foundations": "^3.1.0"
   },
   "devDependencies": {
     "@bbc/psammead-storybook-helpers": "^3.1.3",

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.2 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 2.2.1 | [PR#1352](https://github.com/bbc/psammead/pull/1352) Update default timestamp format |
 | 2.2.0   | [PR#1245](https://github.com/bbc/psammead/pull/1245) The storybook stories now include the ability to change the service |
 | 2.1.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-storybook-helpers": {
       "version": "3.3.0",

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -25,7 +25,7 @@
     "moment-timezone"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-timestamp": "^2.0.4",
     "moment-timezone": "^0.5.26"
   },

--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description                                                                                                       |
 | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| 1.0.3 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.0.2   | [PR#1365](https://github.com/bbc/psammead/pull/1365) Bump psammead-styles to 1.2.0 |
 | 1.0.1   | [PR#1181](https://github.com/BBC-News/psammead/pull/1181) use `gel-foundations@3.0.3` and `psammead-styles@1.1.3` |
 | 1.0.0   | [PR#638](https://github.com/BBC-News/psammead/pull/638) Initial creation of package                               |

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg==",
       "dev": true
     },
     "@bbc/psammead-styles": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-styles": "^1.2.0",
     "moment": "^2.24.0"
   }

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.3.1 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 3.3.0 | [PR#1233](https://github.com/bbc/psammead/pull/1233) Add ESM modules entry |
 | 3.2.0 | [PR#1244](https://github.com/bbc/psammead/pull/1244) `dirDecorator` now includes service `locale` in the object passed to the callback |
 | 3.1.3 | [PR#1179](https://github.com/bbc/psammead/pull/1179) use `gel-foundations@3.0.3` and `psammead-test-helpers@1.0.2`|

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg=="
     },
     "@bbc/psammead-test-helpers": {
       "version": "1.0.2",

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
     "knobs"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "react-helmet": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.1 | [PR#1466](https://github.com/bbc/psammead/pull/1466) Bump Dependancies |
 | 1.2.0 | [PR#1234](https://github.com/bbc/psammead/pull/1234) Add custom CSS Grid feature detector |
 | 1.1.5 | [PR#1215](https://github.com/bbc/psammead/pull/1215) Fix `sans serif` typo |
 | 1.1.4 | [PR#1066](https://github.com/bbc/psammead/pull/1066) Fix Serif Medium font. |

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.3.tgz",
-      "integrity": "sha512-sWqC6vvs6XjzHcRvE0nmjb3JYr+XlCZ66mmNRVlXe1gnBmIcnSuYOPx0WjK2VFd+EHF9TuQVuAD1L4u2fDU4Bg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.1.0.tgz",
+      "integrity": "sha512-akyOCP4wdn18By7HHz8ostOUJadbZXF8wfFQIJyoXiALU7rdKCH3yLHVsas4LYjYxc1lhmN8hUeVSGHmR7Lnqg==",
       "dev": true
     },
     "@bbc/psammead-storybook-helpers": {

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "fonts"
   ],
   "devDependencies": {
-    "@bbc/gel-foundations": "^3.0.3",
+    "@bbc/gel-foundations": "^3.1.0",
     "@bbc/psammead-storybook-helpers": "^3.1.3",
     "@bbc/psammead-test-helpers": "^1.0.2"
   }


### PR DESCRIPTION
👋
The following packages have been published:
@bbc/psammead-assets
@bbc/gel-foundations

So we need to bump them in the following packages:
@bbc/psammead-brand
@bbc/psammead-styles
@bbc/psammead-media-indicator
@bbc/psammead-figure
@bbc/psammead-paragraph
@bbc/psammead-timestamp-container
@bbc/psammead-story-promo-list
@bbc/psammead-sitewide-links
@bbc/psammead-image-placeholder
@bbc/psammead-locales
@bbc/psammead-section-label
@bbc/psammead-consent-banner
@bbc/psammead-storybook-helpers
@bbc/psammead-timestamp
@bbc/psammead-caption
@bbc/psammead-story-promo
@bbc/psammead-headings
@bbc/psammead-copyright
@bbc/psammead-image
@bbc/psammead-navigation