### PR TITLE
revert bump on gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.14.3",
-    "gh-pages": "^2.1.0",
+    "gh-pages": "^2.0.1",
     "glob-loader": "^0.3.0",
     "husky": "^3.0.2",
     "jest": "^24.5.0",


### PR DESCRIPTION
**no testing required**

**Overall change:**: revert bump of `gh-pages` from this PR: https://github.com/bbc/psammead/pull/1592/files

because there is a current bug with the latest version: https://github.com/tschaub/gh-pages/issues/310

the error can be seen on our pipeline: https://ci.news.tools.bbc.co.uk/blue/organizations/jenkins/psammead/detail/latest/442/pipeline
 
**Code changes:**

- _revert `gh-pages` to 2.0.1_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval