### PR TITLE
force old version of gh-pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10997,9 +10997,9 @@
       }
     },
     "gh-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.1.0.tgz",
-      "integrity": "sha512-QmV1fh/2W5GZkfoLsG4g6dRTWiNYuCetMQmm8CL6Us8JVnAufYtS0uJPD8NYogmNB4UZzdRG44uPAL+jcBzEwQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.0.1.tgz",
+      "integrity": "sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.14.3",
-    "gh-pages": "^2.0.1",
+    "gh-pages": "2.0.1",
     "glob-loader": "^0.3.0",
     "husky": "^3.0.2",
     "jest": "^24.5.0",


### PR DESCRIPTION
Resolves n/a

didn't update package-lock here: https://github.com/bbc/psammead/pull/1644

no testing required, fixes psammead build

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval