### PR TITLE
Storybook helpers v5

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Renamed `indonesian` to `indonesia` and `afaanOromoo` to `afaanoromoo`.  Input provider now has an optional 4th argument that allows the default service to be configured |
+| 5.0.0 | [PR#1714](https://github.com/bbc/psammead/pull/1714) Renamed `indonesian` to `indonesia` and `afaanOromoo` to `afaanoromoo`.  Input provider now has an optional 4th argument that allows the default service to be configured |
 | 4.0.0 | [PR#1679](https://github.com/bbc/psammead/pull/1679) Remove text knob from input-provider |
 | 3.3.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 3.3.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Renamed `indonesian` to `indonesia` and `afaanOromoo` to `afaanoromoo`.  Input provider now has an optional 4th argument that allows the default service to be configured |
 | 4.0.0 | [PR#1679](https://github.com/bbc/psammead/pull/1679) Remove text knob from input-provider |
 | 3.3.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 3.3.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
@@ -97,6 +97,14 @@ describe('Psammead storybook helpers', () => {
       expect(text).toHaveBeenCalledTimes(0);
     });
 
+    it('allows default service to be set', () => {
+      select.mockReturnValueOnce('thai');
+      underTest.inputProvider(null, renderFn, null, { defaultService: 'thai' })();
+
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(select.mock.calls[0][2]).toBe('thai');
+    });
+
     it('handles scenario where config is null', () => {
       select.mockReturnValueOnce('news');
 

--- a/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
@@ -99,7 +99,9 @@ describe('Psammead storybook helpers', () => {
 
     it('allows default service to be set', () => {
       select.mockReturnValueOnce('thai');
-      underTest.inputProvider(null, renderFn, null, { defaultService: 'thai' })();
+      underTest.inputProvider(null, renderFn, null, {
+        defaultService: 'thai',
+      })();
 
       expect(select).toHaveBeenCalledTimes(1);
       expect(select.mock.calls[0][2]).toBe('thai');

--- a/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
@@ -4,14 +4,23 @@ import { Helmet } from 'react-helmet';
 import * as scripts from '@bbc/gel-foundations/scripts';
 import LANGUAGE_VARIANTS from './text-variants';
 
-const inputProvider = (slots, componentFunction, services) => () => {
+const inputProvider = (
+  slots,
+  componentFunction,
+  services,
+  options = {},
+) => () => {
   let serviceNames = Object.keys(LANGUAGE_VARIANTS);
 
   if (services) {
     serviceNames = serviceNames.filter(service => services.includes(service));
   }
 
-  const serviceName = select('Select a service', serviceNames, 'news');
+  const serviceName = select(
+    'Select a service',
+    serviceNames,
+    options.defaultService || 'news',
+  );
 
   const service = LANGUAGE_VARIANTS[serviceName];
   const isNews = serviceName === 'news';

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -1,5 +1,5 @@
 const LANGUAGE_VARIANTS = {
-  afaanOromoo: {
+  afaanoromoo: {
     text:
       "Gammadoo ta'uun akkanumaan hin dhufu, waan shaakalamuudha jetti saantoos.",
     script: 'latin',
@@ -83,7 +83,7 @@ const LANGUAGE_VARIANTS = {
     script: 'latinDiacritics',
     locale: 'ig',
   },
-  indonesian: {
+  indonesia: {
     text:
       '"Apa yang terjadi di Selandia Baru adalah kekerasan yang dibawa oleh seseorang yang tumbuh dan belajar ideologinya di tempat lain,\' kata Jacinda Ardern.',
     script: 'latin',


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/1668

**Overall change:** _Update service names for parity with Simorgh, and add option to set default service._

**Code changes:**

- _Renamed `indonesian` to `indonesia`._
- _Renamed `afaanOromoo` to `afaanoromoo`._
- _`inputProvider` now allows a default service to be configured, rather than always using `news`_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval