### PR TITLE
Add entry file for '/font-families'

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.3 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Add top-level entry file for font-families. |
 | 2.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.0.1 | [PR#1597](https://github.com/bbc/psammead/pull/1597) Bump @bbc/gel-foundations, @bbc/psammead-storybook-helpers, @bbc/psammead-test-helpers |
 | 2.0.0 | [PR#1516](https://github.com/bbc/psammead/pull/1516) Add font-family and font-face declarations for World Service fonts. Changes `getSansItalic` to `getSansRegularItalic`. |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.0.3 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Add top-level entry file for font-families. |
+| 2.0.3 | [PR#1717](https://github.com/bbc/psammead/pull/1717) Add top-level entry file for font-families. |
 | 2.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.0.1 | [PR#1597](https://github.com/bbc/psammead/pull/1597) Bump @bbc/gel-foundations, @bbc/psammead-storybook-helpers, @bbc/psammead-test-helpers |
 | 2.0.0 | [PR#1516](https://github.com/bbc/psammead/pull/1516) Add font-family and font-face declarations for World Service fonts. Changes `getSansItalic` to `getSansRegularItalic`. |

--- a/packages/utilities/psammead-styles/font-families.js
+++ b/packages/utilities/psammead-styles/font-families.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/font-families'); // eslint-disable-line import/no-unresolved

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bug fix raised as part of this Simorgh PR https://github.com/bbc/simorgh/pull/3030

**Overall change:** Ensure `font-families` file has a top-level export

**Code changes:**

- Ensure `font-families` file has a top-level export

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval