### PR TITLE
Psammead Styles - Fonts - BaseUrlPath update

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.0.3 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Fix for Latha Font URL. |
+| 2.0.3 | [PR#1727](https://github.com/bbc/psammead/pull/1727) Fix for Latha Font URL. |
 | 2.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.0.1 | [PR#1597](https://github.com/bbc/psammead/pull/1597) Bump @bbc/gel-foundations, @bbc/psammead-storybook-helpers, @bbc/psammead-test-helpers |
 | 2.0.0 | [PR#1516](https://github.com/bbc/psammead/pull/1516) Add font-family and font-face declarations for World Service fonts. Changes `getSansItalic` to `getSansRegularItalic`. |

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.3 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Fix for Latha Font URL. |
 | 2.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.0.1 | [PR#1597](https://github.com/bbc/psammead/pull/1597) Bump @bbc/gel-foundations, @bbc/psammead-storybook-helpers, @bbc/psammead-test-helpers |
 | 2.0.0 | [PR#1516](https://github.com/bbc/psammead/pull/1516) Add font-family and font-face declarations for World Service fonts. Changes `getSansItalic` to `getSansRegularItalic`. |

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/fonts.js
+++ b/packages/utilities/psammead-styles/src/fonts.js
@@ -15,7 +15,7 @@ const baseUrlBBCNassimUrdu =
 const baseUrlIskoolaPotaBBC =
   'https://ws-downloads.files.bbci.co.uk/fonts/IskoolaPota/v5.91/';
 
-const baseUrlLatha = 'https://ws-downloads.files.bbci.co.uk/fonts/Latha/v5.90';
+const baseUrlLatha = 'https://ws-downloads.files.bbci.co.uk/fonts/Latha/v5.90/';
 
 const baseURlMallanna =
   'https://ws-downloads.files.bbci.co.uk/fonts/Mallanna/v1.0.4/';
@@ -53,7 +53,7 @@ export const F_REITH_SERIF_BOLD = `
     font-display: optional;
   }`;
 
-export const F_REITH_SERIF_BOLD_ITALIC = `  
+export const F_REITH_SERIF_BOLD_ITALIC = `
   @font-face {
     font-family: "ReithSerif";
     src: url("${baseFontUrl}BBCReithSerif_W_BdIt.woff2") format("woff2"), url("${baseFontUrl}BBCReithSerif_W_BdIt.woff") format("woff");


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/2888

**Overall change:** As part of using `@bbc/psammead-styles@2.0.2` in this Simorgh PR: https://github.com/bbc/simorgh/pull/3101, I noticed that there is a missing forward slash in the Latha font base url. This PR adds this in. 

**Code changes:**

- Add missing forward slash in Latha font base url path

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval