### PR TITLE
Talos - Bump @bbc/psammead-styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1608,9 +1608,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA==",
       "dev": true
     },
     "@bbc/psammead-assets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10452,7 +10452,7 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
@@ -10466,14 +10466,14 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -10491,7 +10491,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -10502,7 +10502,7 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
@@ -10530,14 +10530,14 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -10547,28 +10547,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -10578,14 +10578,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -10602,7 +10602,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -10617,14 +10617,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -10634,7 +10634,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -10644,7 +10644,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -10662,14 +10662,14 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -10679,14 +10679,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -10703,7 +10703,7 @@
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -10714,7 +10714,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -10724,7 +10724,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -10734,14 +10734,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -10753,7 +10753,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -10772,7 +10772,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -10783,14 +10783,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -10801,7 +10801,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -10821,14 +10821,14 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -10838,21 +10838,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -10863,21 +10863,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -10890,7 +10890,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -10899,7 +10899,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -10915,7 +10915,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -10932,42 +10932,42 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -10979,7 +10979,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -10989,7 +10989,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -10999,14 +10999,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -11022,14 +11022,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-assets": "^2.0.1",
     "@bbc/psammead-brand": "^4.2.5",
     "@bbc/psammead-caption": "^2.1.4",

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.2.6 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 4.2.5   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 4.2.4 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 4.2.3   | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "1.1.2",

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3",
     "@bbc/psammead-visually-hidden-text": "^1.1.2"
   },

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2",
+    "@bbc/psammead-styles": "^2.0.3",
     "@bbc/psammead-visually-hidden-text": "^1.1.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.1.2 | [PR#1667](https://github.com/bbc/psammead/pull/1667) Bump dependencies |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.3 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.2.1   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.2.1 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.2.0 | [PR#1594](https://github.com/bbc/psammead/pull/1594) Update layout to flip correctly for right-to-left services |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 1.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 1.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 1.1.2   | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 3.0.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 3.0.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 3.0.2 | [PR#1672](https://github.com/bbc/psammead/pull/1672) Bump dependencies |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 1.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 1.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 1.1.2  | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-0qxksewaHU+n0PhRXG213m7/OxtF3HAszPOvug4abbvwdSWqI2fYSI8uzPcMHCUY7CNf50zEjnQzow/umTjp1w=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
     "@bbc/psammead-assets": "^2.0.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 1.2.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 1.2.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 1.2.2 | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.4.2 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.4.1   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.4.0 | [PR#1669](https://github.com/bbc/psammead/pull/1669) Add `Index Alsos` support |
 | 2.3.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.1.2 | [PR#1641](https://github.com/bbc/psammead/pull/1641) Bump dependencies |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "1.1.2",

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2",
+    "@bbc/psammead-styles": "^2.0.3",
     "@bbc/psammead-visually-hidden-text": "^1.1.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3",
     "@bbc/psammead-visually-hidden-text": "^1.1.2"
   },

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.1.2 | [PR#1641](https://github.com/bbc/psammead/pull/1641) Bump dependencies |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.6 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.1.5   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.1.4 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.1.3 | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.4 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
+| 3.0.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
+| 3.0.4   | [PR#1731](https://github.com/bbc/psammead/pull/1731) Add space after copyright text |
 | 3.0.3   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 3.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 3.0.1 | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.4 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 3.0.3   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 3.0.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 3.0.1 | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-sitewide-links/src/__snapshots__/index.test.jsx.snap
@@ -266,6 +266,7 @@ exports[`SitewideLinks should render correctly 1`] = `
       <span>
         Text here.
       </span>
+       
       <a
         class="c4 c8"
         href="https://www.bbc.co.uk/news"

--- a/packages/components/psammead-sitewide-links/src/index.jsx
+++ b/packages/components/psammead-sitewide-links/src/index.jsx
@@ -49,7 +49,7 @@ const SitewideLinks = ({ links, copyrightText, externalLink, service }) => (
     <ConstrainedWrapper>
       <List links={links} />
       <StyledParagraph>
-        {copyrightText}
+        {copyrightText}{' '}
         <Link text={externalLink.text} href={externalLink.href} inline />
       </StyledParagraph>
     </ConstrainedWrapper>

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.0.2 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.0.1   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.0.0 | [PR#1643](https://github.com/bbc/psammead/pull/1643) Move vertical rhythm out of psammead |
 | 1.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.3.4 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.3.5   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.3.2 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.3.1 | [PR#1641](https://github.com/bbc/psammead/pull/1641) Bump dependencies |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 2.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |
 | 2.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.1.2 | [PR#1599](https://github.com/bbc/psammead/pull/1599) Bump dependencies |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     }
   }
 }

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.0.3",

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-styles": "^2.0.2"
+    "@bbc/psammead-styles": "^2.0.3"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.1 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |
 | 5.0.0 | [PR#1714](https://github.com/bbc/psammead/pull/1714) Renamed `indonesian` to `indonesia` and `afaanOromoo` to `afaanoromoo`.  Input provider now has an optional 4th argument that allows the default service to be configured |
 | 4.0.0 | [PR#1679](https://github.com/bbc/psammead/pull/1679) Remove text knob from input-provider |
 | 3.3.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
     },
     "exenv": {
       "version": "1.2.2",

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -26,7 +26,7 @@
     "knobs"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
+    "@bbc/gel-foundations": "^3.2.2",
     "react-helmet": "^5.2.1"
   }
 }

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/psammead-styles

So we need to bump them in the following packages:
@bbc/psammead-consent-banner
@bbc/psammead-copyright
@bbc/psammead-image-placeholder
@bbc/psammead-headings
@bbc/psammead-navigation
@bbc/psammead-sitewide-links
@bbc/psammead-brand
@bbc/psammead-paragraph
@bbc/psammead-caption
@bbc/psammead-story-promo-list
@bbc/psammead-inline-link
@bbc/psammead-story-promo
@bbc/psammead-media-indicator
@bbc/psammead-timestamp
@bbc/psammead-section-label

___
Testing note added by @sareh: `@bbc/psammead-styles@2.0.3` fixed the font base url for Latha (used by the Tamil service) and so it should be bumped up through all of these packages, so that in our consuming application Simorgh, we don't have multiple versions of psammead-styles. 

Also updated to include bumps to these packages:
The following package has been published:
@bbc/gel-foundations

So we need to bump them in the following packages:
psammead-brand
psammead-caption
psammead-consent-banner
psammead-copyright
psammead-headings
psammead-media-indicator
psammead-navigation
psammead-paragraph
psammead-section-label
psammead-sitewide-links
psammead-story-promo-list
psammead-story-promo
psammead-timestamp
psammead-storybook-helpers