### PR TITLE
Talos - Bump @bbc/psammead-timestamp in @bbc/psammead-timestamp-container

### DIFF
--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.6 | [PR#1762](https://github.com/bbc/psammead/pull/1762) Talos - Bump Dependencies |
 | 2.3.5 | [PR#1686](https://github.com/bbc/psammead/pull/1686) Bump dependencies |
 | 2.3.4 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |
 | 2.3.3 | [PR#1641](https://github.com/bbc/psammead/pull/1641) Bump dependencies |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,17 +10,24 @@
       "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.2.tgz",
-      "integrity": "sha512-Fpazc8Q0/ishOhn2X/Z5yZnzAnLDcK9G4fUDwojALYwAIs1qi3o47U5gY14bhTa+MKxI0nLQyQJ69IYR0nsoxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
+      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.1.4.tgz",
-      "integrity": "sha512-L4o17RoULKYxJYrIHwKBWuPl+8pkpDzHfmsHLZFfjuuDQn4/L4Vy98AIBt88COltuM8lRNpwKXrPTQqzd0z2mA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.1.5.tgz",
+      "integrity": "sha512-y62dqpu7zZLI8YmygjaS4d98UbK4PthgB9ksGqnOD/T73ssMt6a6sQlMyYosS33vK97HFKlBLqoAFb6mOWVuAg==",
       "requires": {
-        "@bbc/gel-foundations": "^3.2.1",
-        "@bbc/psammead-styles": "^2.0.2"
+        "@bbc/gel-foundations": "^3.2.2",
+        "@bbc/psammead-styles": "^2.0.3"
+      },
+      "dependencies": {
+        "@bbc/gel-foundations": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
+          "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+        }
       }
     },
     "moment": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-timestamp": "^2.1.4",
+    "@bbc/psammead-timestamp": "^2.1.5",
     "moment-timezone": "^0.5.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/psammead-brand
@bbc/psammead-caption
@bbc/psammead-consent-banner
@bbc/psammead-copyright
@bbc/psammead-headings
@bbc/psammead-image-placeholder
@bbc/psammead-inline-link
@bbc/psammead-media-indicator
@bbc/psammead-navigation
@bbc/psammead-paragraph
@bbc/psammead-section-label
@bbc/psammead-sitewide-links
@bbc/psammead-story-promo-list
@bbc/psammead-story-promo
@bbc/psammead-timestamp
@bbc/psammead-storybook-helpers

So we need to bump them in the following packages:
@bbc/psammead-timestamp-container