### PR TITLE
use the correct build result param

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ node {
 
           // send slack notification if building branch: latest
           if (env.BRANCH_NAME == 'latest') {
-            switch (currentBuild.result) {
+            switch (currentBuild.currentResult) {
               case 'SUCCESS':
                 notifySlack('good', 'Success', gitCommitAuthor, 'Successfully Deployed', gitCommitHash, gitCommitMessage, slackChannel)
                 break

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,6 +93,7 @@ node {
                 notifySlack('danger', 'Aborted', gitCommitAuthor, 'Pipeline was aborted', gitCommitHash, gitCommitMessage, slackChannel)
                 break
               default:
+                echo "Build Result: ${currentBuild.currentResult}"
                 notifySlack('danger', 'Unknown', gitCommitAuthor, 'Pipeline has failed', gitCommitHash, gitCommitMessage, slackChannel)
                 break
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,9 @@ node {
         } finally {
           cleanUp()
 
+          echo "currentBuild.currentResult: ${currentBuild.currentResult}"
+          echo "currentBuild.result: ${currentBuild.result}"
+
           // send slack notification if building branch: latest
           if (env.BRANCH_NAME == 'latest') {
             switch (currentBuild.currentResult) {
@@ -93,7 +96,6 @@ node {
                 notifySlack('danger', 'Aborted', gitCommitAuthor, 'Pipeline was aborted', gitCommitHash, gitCommitMessage, slackChannel)
                 break
               default:
-                echo "Build Result: ${currentBuild.currentResult}"
                 notifySlack('danger', 'Unknown', gitCommitAuthor, 'Pipeline has failed', gitCommitHash, gitCommitMessage, slackChannel)
                 break
             }


### PR DESCRIPTION
Resolves #NUMBER

Overall change:

When using currentBuild.result you have to set the build result yourself.

Code changes:

Switches to using currentBuild.currentResult which is automatically set and should never be null
---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval