### PR TITLE
Talos - Bump @bbc/psammead-amp-geo, @bbc/psammead-brand, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-figure, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-image, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-story-promo-list, @bbc/psammead-story-promo, @bbc/psammead-timestamp, @bbc/psammead-visually-hidden-text, @bbc/psammead-timestamp-container, @bbc/gel-foundations, @bbc/moment-timezone-include, @bbc/psammead-assets, @bbc/psammead-locales, @bbc/psammead-storybook-helpers, @bbc/psammead-styles, @bbc/psammead-test-helpers

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 4.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 4.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 4.2.6 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.1.2.tgz",
-      "integrity": "sha512-Sa7s/Rj1josf1wgqJv4ZDKshTQb0JwE95eV+NA//nYf8LOfXGev38SxAy64KNqHJfAki5Ce1oXrKijgwxCDHGg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.2.1.tgz",
+      "integrity": "sha512-lff3oX8H1RAcYcm7ld+A4Jnfab398xK0/JpCyYnW0UjVBxOa1y+Cmr5gz+MDTMJvbHjS4hQrACIVjgoG5n5b2Q=="
     }
   }
 }

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3",
-    "@bbc/psammead-visually-hidden-text": "^1.1.2"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1",
+    "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.2.3 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.1.4   | [PR#1685](https://github.com/bbc/psammead/pull/1685) Bump dependencies |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     }
   }
 }

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-figure/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1"
+    "@bbc/gel-foundations": "^3.3.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 3.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 3.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 3.0.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.1.6 | [PR#1781](https://github.com/bbc/psammead/pull/1781) Talos - Bump Dependencies |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-assets": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.1.0.tgz",
-      "integrity": "sha512-WbucCwS5JO576bAPPiK2PdCyZu8vGTSG/+6aQTrbBK+7kZ8f8ZVaEqZwBD+u69zWw8Y7C2uvb7gryedkGmb8Nw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.2.1.tgz",
+      "integrity": "sha512-BzOiqxIuQbqxcTuT7TAEvAVKRiKHbrfvaYccg2fNaDkPiPPdt7dMW2uR9kauvm31ouCSeYtz3gV2aHkstGLvpQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
-    "@bbc/psammead-assets": "^2.1.0",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/psammead-assets": "^2.2.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.2.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.5.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.5.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.4.2 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     },
     "@bbc/psammead-visually-hidden-text": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.1.2.tgz",
-      "integrity": "sha512-Sa7s/Rj1josf1wgqJv4ZDKshTQb0JwE95eV+NA//nYf8LOfXGev38SxAy64KNqHJfAki5Ce1oXrKijgwxCDHGg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.2.1.tgz",
+      "integrity": "sha512-lff3oX8H1RAcYcm7ld+A4Jnfab398xK0/JpCyYnW0UjVBxOa1y+Cmr5gz+MDTMJvbHjS4hQrACIVjgoG5n5b2Q=="
     }
   }
 }

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3",
-    "@bbc/psammead-visually-hidden-text": "^1.1.2"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1",
+    "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.2.0 | [PR#1534](https://github.com/bbc/psammead/pull/1534) Add linking variant of section label |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 3.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 3.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 3.0.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.0.2 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.5.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.5.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.4.0   | [PR#1567](https://github.com/bbc/psammead/pull/1567) Add Index Alsos |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.1.5 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     }
   }
 }

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
-    "@bbc/psammead-styles": "^2.0.3"
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.4.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.4.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 2.3.6 | [PR#1762](https://github.com/bbc/psammead/pull/1762) Talos - Bump Dependencies |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,33 +1,26 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.1.tgz",
-      "integrity": "sha512-8Gd1BcvYPU6qbPNsfDHxxJO0bbqGw0l5f/dYyhTtd0exYw/IqUiiiQ/+thGd7Rrpx8RvqmG050/8Fji52FPlNg=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.0.3.tgz",
-      "integrity": "sha512-FBKI+StXEc8Bo31jtjDF2Oex+pqPR9zN26cUHpADEG8po7uCmHXfks8lWsoJt3+oa79YV1LNRNqNi5sdxQ0kvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.1.1.tgz",
+      "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.1.5.tgz",
-      "integrity": "sha512-y62dqpu7zZLI8YmygjaS4d98UbK4PthgB9ksGqnOD/T73ssMt6a6sQlMyYosS33vK97HFKlBLqoAFb6mOWVuAg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.1.tgz",
+      "integrity": "sha512-OZVWjJEUe9wj9ZR6CI8mhhrhuSPHJ80J0It4tKnYc+VqPn6GMzznok/hFZabkbE3fsdiD2zaHi8Qu7xCxydqOg==",
       "requires": {
         "@bbc/gel-foundations": "^3.2.2",
         "@bbc/psammead-styles": "^2.0.3"
-      },
-      "dependencies": {
-        "@bbc/gel-foundations": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-          "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
-        }
       }
     },
     "moment": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -25,8 +25,8 @@
     "moment-timezone"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.1",
-    "@bbc/psammead-timestamp": "^2.1.5",
+    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/psammead-timestamp": "^2.2.1",
     "moment-timezone": "^0.5.26"
   },
   "peerDependencies": {

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 5.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 5.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 5.0.1 | [PR#1734](https://github.com/bbc/psammead/pull/1734) Talos - Bump Dependencies |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.2.2.tgz",
-      "integrity": "sha512-P67ZFA22BmREVcRlJ/tDfuKmS9mrYDyUbow8/XkbOHu7Dc45xI+8ZokQ2KsG71/ucSpDNTlQtHk1IwHvfyLAVA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
+      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
     },
     "exenv": {
       "version": "1.2.2",

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
     "knobs"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.2.2",
+    "@bbc/gel-foundations": "^3.3.1",
     "react-helmet": "^5.2.1"
   }
 }


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/psammead-amp-geo
@bbc/psammead-brand
@bbc/psammead-caption
@bbc/psammead-consent-banner
@bbc/psammead-copyright
@bbc/psammead-figure
@bbc/psammead-headings
@bbc/psammead-image-placeholder
@bbc/psammead-image
@bbc/psammead-inline-link
@bbc/psammead-media-indicator
@bbc/psammead-navigation
@bbc/psammead-paragraph
@bbc/psammead-section-label
@bbc/psammead-sitewide-links
@bbc/psammead-story-promo-list
@bbc/psammead-story-promo
@bbc/psammead-timestamp
@bbc/psammead-visually-hidden-text
@bbc/psammead-timestamp-container
@bbc/gel-foundations
@bbc/moment-timezone-include
@bbc/psammead-assets
@bbc/psammead-locales
@bbc/psammead-storybook-helpers
@bbc/psammead-styles
@bbc/psammead-test-helpers

So we need to bump them in the following packages:
@bbc/psammead-timestamp
@bbc/psammead-timestamp-container
@bbc/psammead-storybook-helpers
@bbc/psammead-consent-banner
@bbc/psammead-section-label
@bbc/psammead-navigation
@bbc/psammead-media-indicator
@bbc/psammead-image-placeholder
@bbc/psammead-inline-link
@bbc/psammead-copyright
@bbc/psammead-story-promo-list
@bbc/psammead-sitewide-links
@bbc/psammead-brand
@bbc/psammead-figure
@bbc/psammead-headings
@bbc/psammead-caption
@bbc/psammead-story-promo
@bbc/psammead-paragraph