### PR TITLE
Talos - Bump @bbc/psammead-timestamp in @bbc/psammead-timestamp-container

### DIFF
--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.3 | [PR#1805](https://github.com/bbc/psammead/pull/1805) Talos - Bump Dependencies |
 | 2.4.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.4.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.4.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,12 +15,12 @@
       "integrity": "sha512-nnuMY7PxILxKaTIKcbKzTeQ+wpWRhB74+jb8c2Es802N41Tm88o/xlWMmtWFF1vic1MOvm1kWwlf/v8dh8RAzQ=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.1.tgz",
-      "integrity": "sha512-OZVWjJEUe9wj9ZR6CI8mhhrhuSPHJ80J0It4tKnYc+VqPn6GMzznok/hFZabkbE3fsdiD2zaHi8Qu7xCxydqOg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.2.tgz",
+      "integrity": "sha512-gTnfrnaY5+doInoYUJrnyMJhmMQDCb6wD5NqLoGHhyWLRMX2Xj+vnu0PU5XJXbi1XETmOAfGCMZ4waR9OCkPVA==",
       "requires": {
-        "@bbc/gel-foundations": "^3.2.2",
-        "@bbc/psammead-styles": "^2.0.3"
+        "@bbc/gel-foundations": "^3.3.1",
+        "@bbc/psammead-styles": "^2.1.1"
       }
     },
     "moment": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "^3.3.1",
-    "@bbc/psammead-timestamp": "^2.2.1",
+    "@bbc/psammead-timestamp": "^2.2.2",
     "moment-timezone": "^0.5.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/psammead-brand
@bbc/psammead-caption
@bbc/psammead-consent-banner
@bbc/psammead-copyright
@bbc/psammead-figure
@bbc/psammead-headings
@bbc/psammead-image-placeholder
@bbc/psammead-inline-link
@bbc/psammead-media-indicator
@bbc/psammead-navigation
@bbc/psammead-paragraph
@bbc/psammead-section-label
@bbc/psammead-sitewide-links
@bbc/psammead-story-promo-list
@bbc/psammead-story-promo
@bbc/psammead-timestamp
@bbc/psammead-timestamp-container
@bbc/psammead-storybook-helpers

So we need to bump them in the following packages:
@bbc/psammead-timestamp-container