### PR TITLE
Talos - Bump @bbc/gel-foundations, @bbc/psammead-assets, @bbc/psammead-locales

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 4.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 4.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 4.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-brand/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1",
     "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-figure/CHANGELOG.md
+++ b/packages/components/psammead-figure/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-figure/package-lock.json
+++ b/packages/components/psammead-figure/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     }
   }
 }

--- a/packages/components/psammead-figure/package.json
+++ b/packages/components/psammead-figure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-figure",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-figure/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1"
+    "@bbc/gel-foundations": "^3.3.2"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 3.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 3.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 3.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-assets": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.2.1.tgz",
-      "integrity": "sha512-BzOiqxIuQbqxcTuT7TAEvAVKRiKHbrfvaYccg2fNaDkPiPPdt7dMW2uR9kauvm31ouCSeYtz3gV2aHkstGLvpQ=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.2.2.tgz",
+      "integrity": "sha512-uMM5GvGGAklUD+prUay0zuSiZ5Cr6yClvoFcwNQ7QBcv2J54RCUce1bZqhkH+S9gnH16kAQoiX+fYDRZB+3/PQ=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
-    "@bbc/psammead-assets": "^2.2.1",
+    "@bbc/psammead-assets": "^2.2.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.5.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.5.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1",
     "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.3.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 3.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 3.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 3.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.5.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.5.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 2.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.4 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.4.3 | [PR#1805](https://github.com/bbc/psammead/pull/1805) Talos - Bump Dependencies |
 | 2.4.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.4.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "@bbc/psammead-styles": {
       "version": "2.1.1",

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -25,7 +25,7 @@
     "moment-timezone"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "@bbc/psammead-timestamp": "^2.2.2",
     "moment-timezone": "^0.5.26"
   },

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 5.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 5.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 5.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.1.tgz",
-      "integrity": "sha512-1XHJcI8jTq2mS3hqGfDVIJ/PO651lf/HzUsehP/q0ayeKnLa1EtrsF/uAg1d/6zPLX5Wt4trvGo++BWlOC/IYw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.3.2.tgz",
+      "integrity": "sha512-6/NBXwU7rrHyc1TWlrML89lRaDeU94PSUzYiIIoj7hAHD6qOlyL7hEiQI5zpVCooIaelqxLMcJuz7SsSaYZGBA=="
     },
     "exenv": {
       "version": "1.2.2",

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
     "knobs"
   ],
   "dependencies": {
-    "@bbc/gel-foundations": "^3.3.1",
+    "@bbc/gel-foundations": "^3.3.2",
     "react-helmet": "^5.2.1"
   }
 }


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/gel-foundations
@bbc/psammead-assets
@bbc/psammead-locales

So we need to bump them in the following packages:
@bbc/psammead-brand
@bbc/psammead-copyright
@bbc/psammead-section-label
@bbc/psammead-image-placeholder
@bbc/psammead-timestamp
@bbc/psammead-headings
@bbc/psammead-consent-banner
@bbc/psammead-sitewide-links
@bbc/psammead-paragraph
@bbc/psammead-story-promo-list
@bbc/psammead-caption
@bbc/psammead-figure
@bbc/psammead-story-promo
@bbc/psammead-storybook-helpers
@bbc/psammead-timestamp-container
@bbc/psammead-media-indicator
@bbc/psammead-navigation