### PR TITLE
fix storybook on ie11

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,5 +10,7 @@ module.exports = async ({ config, mode }) => {
     ),
   };
 
+  config.mode = 'production';
+
   return config;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,9 @@ module.exports = async ({ config, mode }) => {
     ),
   };
 
+  // Yes, this is a gross compromise. However, running storybook in production
+  // mode makes the HMR very s l o w, so we don't want to do that all the time.
+  // But if we don't we run into syntax issues on IE11. See #2753 for more info.
   if (process.env.FIX_STORYBOOK_IE11 === 'true') {
     config.mode = 'production';
   }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = async ({ config, mode }) => {
     ),
   };
 
-  config.mode = 'production';
+  if (process.env.FIX_STORYBOOK_IE11 === 'true') {
+    config.mode = 'production';
+  }
 
   return config;
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "preinstall": "sh scripts/enforceVersions.sh",
     "publish": "npm run build && node scripts/publish",
     "storybook": "NODE_ENV=development start-storybook -p 8180 -c .storybook",
+    "storybook:ie11": "export FIX_STORYBOOK_IE11=true && npm run storybook",
     "test": "npm run test:lint && npm run test:lint:css && npm run test:unit && npm run test:packages",
     "test:chromatic": "chromatic test run --storybook-build-dir=storybook_dist || true",
     "test:packages": "lerna run test",


### PR DESCRIPTION
Resolves #1730 

**Overall change:** Make babel transpile as if it's production mode

**Code changes:**

- Set babel to transpile as if in production mode 
- This makes HMR _very slow_, so only do it when FIX_STORYBOOK_IE11 is 'true'

---

- [x] I have assigned myself to this PR and the corresponding issues
- [-] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [-] This PR requires manual testing
