### PR TITLE
Index Alsos - Remove padding bottom

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.6.1 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Remove padding-bottom from Index Alsos Wrapper |
 | 2.6.0 | [PR#1832](https://github.com/bbc/psammead/pull/1832) Export IndexAlsos from `src/index.jsx` |
 | 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.6.1 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Remove padding-bottom from Index Alsos Wrapper |
+| 2.6.1 | [PR#3216](https://github.com/bbc/psammead/pull/3216) Remove padding-bottom from Index Alsos Wrapper |
 | 2.6.0 | [PR#1832](https://github.com/bbc/psammead/pull/1832) Export IndexAlsos from `src/index.jsx` |
 | 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.6.1 | [PR#3216](https://github.com/bbc/psammead/pull/3216) Remove padding-bottom from Index Alsos Wrapper |
+| 2.6.1 | [PR#1845](https://github.com/bbc/psammead/pull/1845) Remove padding-bottom from Index Alsos Wrapper |
 | 2.6.0 | [PR#1832](https://github.com/bbc/psammead/pull/1832) Export IndexAlsos from `src/index.jsx` |
 | 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
 .c0 {
   position: relative;
   z-index: 2;
-  padding: 1rem 0 0.5rem;
+  padding: 1rem 0 0;
 }
 
 .c3 {
@@ -200,7 +200,7 @@ exports[`Index Alsos should render one correctly 1`] = `
 .c0 {
   position: relative;
   z-index: 2;
-  padding: 1rem 0 0.5rem;
+  padding: 1rem 0 0;
 }
 
 .c2 {

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -12,7 +12,7 @@ import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 const StyledIndexAlsos = styled.div`
   position: relative;
   z-index: 2;
-  padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};
+  padding: ${GEL_SPACING_DBL} 0 0;
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     display: none;
     visibility: hidden;

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -624,7 +624,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
 .c7 {
   position: relative;
   z-index: 2;
-  padding: 1rem 0 0.5rem;
+  padding: 1rem 0 0;
 }
 
 .c10 {
@@ -1012,7 +1012,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
 .c7 {
   position: relative;
   z-index: 2;
-  padding: 1rem 0 0.5rem;
+  padding: 1rem 0 0;
 }
 
 .c9 {

--- a/packages/components/psammead-story-promo/testHelpers/IndexAlsosContainer.jsx
+++ b/packages/components/psammead-story-promo/testHelpers/IndexAlsosContainer.jsx
@@ -40,6 +40,12 @@ const IndexAlsosContainer = ({ alsoItems, script, service }) => {
             const { id, cpsType, mediaType } = item;
             const { headline } = item.headlines;
             const url = item.locators.assetUri;
+            const indexAlsoMediaIndicator = IndexAlsosMediaIndicator(
+              cpsType,
+              mediaType,
+              service,
+            );
+            const indexAlsoMediaType = getMediaType(cpsType, mediaType);
 
             return (
               <IndexAlsosLi
@@ -47,12 +53,8 @@ const IndexAlsosContainer = ({ alsoItems, script, service }) => {
                 script={script}
                 service={service}
                 url={url}
-                mediaIndicator={IndexAlsosMediaIndicator(
-                  cpsType,
-                  mediaType,
-                  service,
-                )}
-                mediaType={getMediaType(cpsType, mediaType)}
+                mediaIndicator={indexAlsoMediaIndicator}
+                mediaType={indexAlsoMediaType}
               >
                 {headline}
               </IndexAlsosLi>
@@ -65,18 +67,20 @@ const IndexAlsosContainer = ({ alsoItems, script, service }) => {
           const { cpsType, mediaType } = alsoItems;
           const { headline } = alsoItems.headlines;
           const url = alsoItems.locators.assetUri;
+          const indexAlsoMediaIndicator = IndexAlsosMediaIndicator(
+            cpsType,
+            mediaType,
+            service,
+          );
+          const indexAlsoMediaType = getMediaType(cpsType, mediaType);
 
           return (
             <IndexAlso
               script={script}
               service={service}
               url={url}
-              mediaIndicator={IndexAlsosMediaIndicator(
-                cpsType,
-                mediaType,
-                service,
-              )}
-              mediaType={getMediaType(cpsType, mediaType)}
+              mediaIndicator={indexAlsoMediaIndicator}
+              mediaType={indexAlsoMediaType}
             >
               {headline}
             </IndexAlso>


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
When pulling in the Index Alsos into Simorgh, we realized that there was a lot of spacing beneath top stories with index alsos and the following story, a total of `32px` when it should be a `24px`.

**Code changes:**
- Remove `padding-bottom 8px` from the Index Alsos container

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
