### PR TITLE
Revert "Visually hide section label on desktop"

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.3.4 | [PR#1829](https://github.com/bbc/psammead/pull/1829) Hide section labels for all breakpoints |
 | 2.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.5 | [PR#1918](https://github.com/bbc/psammead/pull/1918) Revert "Hide section labels for all breakpoints" |
+| 2.3.4 | [PR#1829](https://github.com/bbc/psammead/pull/1829) Hide section labels for all breakpoints |
 | 2.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-section-label/README.md
+++ b/packages/components/psammead-section-label/README.md
@@ -68,7 +68,7 @@ const WrappingComponent = () => (
 );
 ```
 
-You can also visually hide the SectionLabel for all breakpoints by adding the `visuallyHidden` prop:
+You can also visually hide the SectionLabel at widths below 600px by adding the `visuallyHidden` prop:
 
 ```jsx
 import SectionLabel from '@bbc/psammead-section-label';
@@ -124,7 +124,7 @@ Although this component has the appearance of a horizontal rule, it does not use
 
 This component wraps the title string in an `<h2>` element. The `labelId` prop will be applied to the `<h2>` as an `id` attribute, allowing the content of the element to be referenced by an `aria-labelledby` attribute. See the [examples](#usage) above.
 
-Setting the `visuallyHidden` prop to true visually hides this component for all breakpoints, however it will still be available to screen-readers and other assistive technology.
+Setting the `visuallyHidden` prop to true visually hides this component at widths <600px, however; it will still be available to screen-readers and other assistive technology.
 
 When supplied with an `href` and the `linkText`, the section label contains an `<a>` link, which is `aria-labelledby` the `labelId` described above. The `linkText` is only expected to be useful to visual users, so is marked as `aria-hidden="true"` to prevent announcement to screen readers. This `aria-hidden="true"` isn't strictly required - setting the `aria-labelledby` attribute should prevent screen readers from reading out the `linkText`. However, it adding it makes clear to screen readers and other developers that the `linkText` is designed to be ignored by screen readers.
 

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.4",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.3",
+  "version": "2.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.3",
+  "version": "2.3.5",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.4",
+  "version": "2.3.3",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SectionLabel When hideSectionHeader is true should add styling to hide SectionLabel for all breakpoints 1`] = `
+exports[`SectionLabel When hideSectionHeader is true should add styling to hide SectionLabel when width of screen is less than 600 px 1`] = `
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -43,14 +43,6 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 .c0 {
   position: relative;
   margin-top: 2rem;
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
 }
 
 .c1 {
@@ -96,6 +88,19 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%);
+    -webkit-clip: rect(1px,1px,1px,1px);
+    clip: rect(1px,1px,1px,1px);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    width: 1px;
   }
 }
 

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { bool, oneOf, shape, string } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
-import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MAX,
+  MEDIA_QUERY_TYPOGRAPHY,
+} from '@bbc/gel-foundations/breakpoints';
 import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -41,13 +44,15 @@ const SectionLabelWrapper = styled.div`
   ${({ visuallyHidden }) =>
     visuallyHidden &&
     css`
-      // Hide for all breakpoints
-      clip-path: inset(100%);
-      clip: rect(1px, 1px, 1px, 1px);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      width: 1px;
+      // Hide when under 600px
+      @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+        clip-path: inset(100%);
+        clip: rect(1px, 1px, 1px, 1px);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        width: 1px;
+      }
     `}
 `;
 

--- a/packages/components/psammead-section-label/src/index.stories.jsx
+++ b/packages/components/psammead-section-label/src/index.stories.jsx
@@ -17,7 +17,7 @@ storiesOf('Components|SectionLabel', module)
           dir={dir}
           bar={boolean('show bar?', true)}
           visuallyHidden={boolean(
-            'visually hide component for all breakpoints?',
+            'visually hide component when width less than 600px?',
             false,
           )}
           labelId="example-section-label"
@@ -39,7 +39,7 @@ storiesOf('Components|SectionLabel', module)
           dir={dir}
           bar={boolean('show bar?', true)}
           visuallyHidden={boolean(
-            'visually hide component for all breakpoints?',
+            'visually hide component when width less than 600px?',
             false,
           )}
           labelId="example-section-label"

--- a/packages/components/psammead-section-label/src/index.test.jsx
+++ b/packages/components/psammead-section-label/src/index.test.jsx
@@ -202,7 +202,7 @@ describe('SectionLabel', () => {
 
   describe('When hideSectionHeader is true', () => {
     shouldMatchSnapshot(
-      'should add styling to hide SectionLabel for all breakpoints',
+      'should add styling to hide SectionLabel when width of screen is less than 600 px',
       <SectionLabel
         script={latin}
         bar={false}


### PR DESCRIPTION
Reverts bbc/psammead#1829

Temporarily reverting so https://github.com/bbc/psammead/pull/1860 can go on top

Will unrevert after #1860 gets merged :)

This does not need manual testing