### PR TITLE
Talos - Bump react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.5.3 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 1.5.3 | [PR#1849](https://github.com/bbc/psammead/pull/1849) Bump @bbc/psammead-test-helpers `^1.1.1` to `^1.3.0`  |
 | 1.5.2 | [PR#1751](https://github.com/bbc/psammead/pull/1751) Bump storybook-readme to 5.0.8 from 5.0.6 to fix vulnerability |
 | 1.5.1 | [PR#1687](https://github.com/bbc/psammead/pull/1686) Bump psammead package dependencies |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.5.3 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
+| 1.5.3 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump React |
 | 1.5.3 | [PR#1849](https://github.com/bbc/psammead/pull/1849) Bump @bbc/psammead-test-helpers `^1.1.1` to `^1.3.0`  |
 | 1.5.2 | [PR#1751](https://github.com/bbc/psammead/pull/1751) Bump storybook-readme to 5.0.8 from 5.0.6 to fix vulnerability |
 | 1.5.1 | [PR#1687](https://github.com/bbc/psammead/pull/1686) Bump psammead package dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -106,7 +106,7 @@
     "lint-staged": "^9.2.2",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
     "react-test-renderer": "^16.8.6",

--- a/packages/components/psammead-amp-geo/CHANGELOG.md
+++ b/packages/components/psammead-amp-geo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.2 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 1.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.0.1 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/components/psammead-amp-geo/package-lock.json
+++ b/packages/components/psammead-amp-geo/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-amp-geo",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1
 }

--- a/packages/components/psammead-amp-geo/package.json
+++ b/packages/components/psammead-amp-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-amp-geo",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-amp-geo/README.md",
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.6"
+    "react": "^16.9.0"
   },
   "keywords": [
     "bbc",

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.3.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 4.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 4.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 4.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.3.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.3.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 1.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 1.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.2 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.2.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |
 | 1.1.3 | [PR#1682](https://github.com/bbc/psammead/pull/1682) Move all dev dependencies to top level package.json |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1
 }

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image/README.md",
   "peerDependencies": {
     "prop-types": "^15.6.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.5.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.5.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.5.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.5.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "keywords": [

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.1 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 1.0.1-alpha.1 | [PR#1920](https://github.com/bbc/psammead/pull/1920) Use @testing-library-react |
 | 1.0.1-alpha.0 | [PR#1842](https://github.com/bbc/psammead/pull/1842) Fix fullscreen for Firefox, Internet Explorer and Safari |
 | 1.0.0-alpha.0 | [PR#1831](https://github.com/bbc/psammead/pull/1831) Create `psammead-media-player` component |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1",
   "publishConfig": {
     "tag": "alpha"
   },
@@ -28,7 +28,7 @@
     "embed"
   ],
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   },
   "dependencies": {

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.2.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.2.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
     "@bbc/psammead-visually-hidden-text": "^1.2.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
   },

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.8 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.3.7 | [PR#1922](https://github.com/bbc/psammead/pull/1922) Revert "Revert "Hide section labels for all breakpoints"" |
 | 2.3.6 | [PR#1860](https://github.com/bbc/psammead/pull/1860) Make flexbox section labels work on IE11 |
 | 2.3.5 | [PR#1918](https://github.com/bbc/psammead/pull/1918) Revert "Hide section labels for all breakpoints" |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   }
 }

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 3.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 3.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 3.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   }
 }

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.1.2 | [PR#1804](https://github.com/bbc/psammead/pull/1804) Talos - Bump Dependencies |
 | 2.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
   },

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.7.1 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.7.0 | [PR#1835](https://github.com/bbc/psammead/pull/1835) Add desktop width top story and show indexAlsos |
 | 2.6.2 | [PR#1923](https://github.com/bbc/psammead/pull/1923) Add support for RTL to Index Alsos |
 | 2.6.1 | [PR#1845](https://github.com/bbc/psammead/pull/1845) Remove padding-bottom from Index Alsos Wrapper |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-styles": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
   },

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.6 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.4.5 | [PR#1827](https://github.com/bbc/psammead/pull/1827) Talos - Bump Dependencies |
 | 2.4.4 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |
 | 2.4.3 | [PR#1805](https://github.com/bbc/psammead/pull/1805) Talos - Bump Dependencies |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -30,6 +30,6 @@
     "moment-timezone": "^0.5.26"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": "^16.9.0"
   }
 }

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.4 | [PR#1932](https://github.com/bbc/psammead/pull/1932) Talos - Bump Dependencies |
 | 2.2.3 | [PR#1847](https://github.com/bbc/psammead/pull/1847) Fixed Telugu typos |
 | 2.2.2 | [PR#1806](https://github.com/bbc/psammead/pull/1806/) Change strings to booleans |
 | 2.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {
@@ -24,7 +24,7 @@
     "amp"
   ],
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "styled-components": "^4.3.2"
   }
 }


### PR DESCRIPTION
👋 The following packages have been published:
react

So we need to bump them in the following packages:
psammead
@bbc/psammead-image-placeholder
@bbc/psammead-media-indicator
@bbc/psammead-amp-geo
@bbc/psammead-section-label
@bbc/psammead-image
@bbc/psammead-consent-banner
@bbc/psammead-sitewide-links
@bbc/psammead-brand
@bbc/psammead-media-player
@bbc/psammead-timestamp-container
@bbc/psammead-navigation
@bbc/psammead-story-promo
@bbc/psammead-story-promo-list
@bbc/psammead-assets