### PR TITLE
Talos - Bump @bbc/psammead-image-placeholder, @bbc/psammead-media-player, @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.5.8 | [PR#1964](https://github.com/bbc/psammead/pull/1964) Talos - Bump Dependencies |
 | 1.5.7 | [PR#1961](https://github.com/bbc/psammead/pull/1961) Talos - Bump Dependencies |
 | 1.5.6 | [PR#1942](https://github.com/bbc/psammead/pull/1942) Talos - Bump react, react-dom & react-test-renderer |
 | 1.5.5 | [PR#1935](https://github.com/bbc/psammead/pull/1935) Talos - Bump Dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1487,12 +1487,12 @@
       "dev": true
     },
     "@bbc/psammead-image-placeholder": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.5.tgz",
-      "integrity": "sha512-xeW4uLSAyVsFQznyBTkkpDloFqWNCnHdKuzn71Cef3bQrWcRIXvef2xRaBleQeD1rt9CWKP37CA58hVZR3qfjA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.6.tgz",
+      "integrity": "sha512-dbI0nyTYJ3HvfHWvCv45D7pzHO4uFntslBHFFSffzVcoUqWsT6BaQyKhvH5iHRUTJ8FbvmX8dxg4GK3PwAJPgA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.2.3",
+        "@bbc/psammead-assets": "^2.2.4",
         "@bbc/psammead-styles": "^2.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -63,7 +63,7 @@
     "@bbc/psammead-caption": "^2.2.5",
     "@bbc/psammead-copyright": "^1.2.4",
     "@bbc/psammead-image": "^1.2.2",
-    "@bbc/psammead-image-placeholder": "^1.2.5",
+    "@bbc/psammead-image-placeholder": "^1.2.6",
     "@bbc/psammead-inline-link": "^1.3.3",
     "@bbc/psammead-locales": "^2.0.0",
     "@bbc/psammead-media-indicator": "^2.5.5",


### PR DESCRIPTION
👋 The following packages have been published:
@bbc/psammead-image-placeholder
@bbc/psammead-media-player
@bbc/psammead-timestamp-container

So we need to bump them in the following packages:
psammead