### PR TITLE
Fix change scanner scope

### DIFF
--- a/.yeoman/index.test.js
+++ b/.yeoman/index.test.js
@@ -23,7 +23,7 @@ const tempFiles = [
 
 describe('pacakge generator', () => {
   beforeEach(() => {
-    jest.setTimeout(12000);
+    jest.setTimeout(15000);
 
     return helpers
       .run(path.join(__dirname, '.'))

--- a/scripts/changeScanner/getChanges.js
+++ b/scripts/changeScanner/getChanges.js
@@ -3,7 +3,9 @@ const { exec } = require('shelljs');
 const getChanges = () => {
   exec(`git fetch --all;`, { silent: true });
 
-  const execute = exec(`git diff --name-only origin/latest ./packages`, {
+  // Use ./packages/*/*/* to ensure you only capture
+  // changes in package folders, not readmes outside them
+  const execute = exec(`git diff --name-only origin/latest ./packages/*/*/*`, {
     silent: true,
   }).stdout;
 

--- a/scripts/changeScanner/getChanges.test.js
+++ b/scripts/changeScanner/getChanges.test.js
@@ -35,7 +35,7 @@ describe(`changeScanner - getChanges`, () => {
 
     expect(exec).toHaveBeenCalledWith('git fetch --all;', { silent: true });
     expect(exec).toHaveBeenCalledWith(
-      'git diff --name-only origin/latest ./packages',
+      'git diff --name-only origin/latest ./packages/*/*/*',
       { silent: true },
     );
   });


### PR DESCRIPTION
**Overall change:** The current changeScanner gets confused by changes to the readmes inside the `packages` folder or the `components`, `containers` or `utilities` folders.

This ensures that changes are only detected inside package folders

**Code changes:**

- Restrict git diff scope

Ignore - `packages/README.md`
Ignore - `packages/components/README.md`
Dont Ignore - `packages/components/psammead-copyright/README.md`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
