### PR TITLE
Refactor input provider

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update input-provider to accept a single object rather than 4 arguments |
 | 5.1.5 | [PR#1960](https://github.com/bbc/psammead/pull/1960) Change <React.Fragment> to <> |
 | 5.1.4 | [PR#1931](https://github.com/bbc/psammead/pull/1931) Talos - Bump Dependencies |
 | 5.1.3 | [PR#1826](https://github.com/bbc/psammead/pull/1826) Talos - Bump Dependencies |

--- a/packages/utilities/psammead-storybook-helpers/README.md
+++ b/packages/utilities/psammead-storybook-helpers/README.md
@@ -59,19 +59,19 @@ storiesOf('Caption', module)
   .addDecorator(withKnobs)
   .add(
     'default',
-    inputProvider(
-      [
+    inputProvider({
+      slots: [
         { name: 'caption', defaultText: 'Students sitting an examination' },
         { name: 'offscreen text', defaultText: 'Image Caption, ' },
       ],
-      ({ slotTexts: [captionText, offscreenText], script, dir, service }) => (
+      componentFunction: ({ slotTexts: [captionText, offscreenText], script, dir, service }) => (
         <Caption script={script} dir={dir} service={service}>
           <VisuallyHiddenText>{offscreenText}</VisuallyHiddenText>
           {captionText}
         </Caption>
       ),
       ['news', 'persian', 'igbo']
-    ),
+    }),
     { knobs: { escapeHTML: false } },
   );
 ```

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.5",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "5.1.5",
+  "version": "6.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/decorators.js
+++ b/packages/utilities/psammead-storybook-helpers/src/decorators.js
@@ -5,6 +5,6 @@ export const dirDecorator = storyFn => {
   const renderFn = ({ script, dir, service }) =>
     storyFn({ script, dir, service });
 
-  const decoratedComponent = inputProvider(null, renderFn);
+  const decoratedComponent = inputProvider({ componentFunction: renderFn });
   return decoratedComponent();
 };

--- a/packages/utilities/psammead-storybook-helpers/src/index.stories.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/index.stories.jsx
@@ -8,22 +8,25 @@ storiesOf('Utilities|Input Provider', module)
   .addDecorator(withKnobs)
   .add(
     'simple',
-    inputProvider(null, () => <span>I toggle dir based on language</span>),
+    inputProvider({
+      componentFunction: () => <span>I toggle dir based on language</span>,
+    }),
     { notes, knobs: { escapeHTML: false } },
   )
   .add(
     'simple - limited services',
-    inputProvider(
-      null,
-      () => <span>Im only availible in news, pidgin & thai</span>,
-      ['news', 'pidgin', 'thai'],
-    ),
+    inputProvider({
+      componentFunction: () => (
+        <span>Im only availible in news, pidgin & thai</span>
+      ),
+      services: ['news', 'pidgin', 'thai'],
+    }),
     { notes, knobs: { escapeHTML: false } },
   )
   .add(
     'complex',
-    inputProvider(
-      [
+    inputProvider({
+      slots: [
         {
           name: 'first slot',
           defaultText:
@@ -31,7 +34,13 @@ storiesOf('Utilities|Input Provider', module)
         },
         { name: 'second slot' },
       ],
-      ({ slotTexts: [first, second], script, dir, service }) => (
+      /* eslint-disable react/prop-types */
+      componentFunction: ({
+        slotTexts: [first, second],
+        script,
+        dir,
+        service,
+      }) => (
         <ul>
           <li>{first}</li>
           <li>{second}</li>
@@ -43,7 +52,7 @@ storiesOf('Utilities|Input Provider', module)
           </li>
         </ul>
       ),
-    ),
+    }),
     { notes, knobs: { escapeHTML: false } },
   );
 

--- a/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/index.test.jsx
@@ -56,7 +56,11 @@ describe('Psammead storybook helpers', () => {
     it('always calls the render function with a script and direction', () => {
       select.mockReturnValueOnce('news');
 
-      underTest.inputProvider([], renderFn)();
+      const inputProps = {
+        componentFunction: renderFn,
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(renderFn).toHaveBeenCalledTimes(1);
       expect(renderFn).toHaveBeenCalledWith({
@@ -66,6 +70,7 @@ describe('Psammead storybook helpers', () => {
         service: 'news',
         locale: 'en',
       });
+
       expect(select).toHaveBeenCalledTimes(1);
       // Allows user to select all availible services
       expect(select.mock.calls[0][1].length).toEqual(
@@ -77,12 +82,12 @@ describe('Psammead storybook helpers', () => {
     it('filters services availible based on array provided', () => {
       select.mockReturnValueOnce('news');
 
-      underTest.inputProvider([], renderFn, [
-        'mundo',
-        'pidgin',
-        'yoruba',
-        'foobar',
-      ])();
+      const inputProps = {
+        componentFunction: renderFn,
+        services: ['mundo', 'pidgin', 'yoruba', 'foobar'],
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(renderFn).toHaveBeenCalledTimes(1);
       expect(renderFn).toHaveBeenCalledWith({
@@ -99,9 +104,13 @@ describe('Psammead storybook helpers', () => {
 
     it('allows default service to be set', () => {
       select.mockReturnValueOnce('thai');
-      underTest.inputProvider(null, renderFn, null, {
-        defaultService: 'thai',
-      })();
+
+      const inputProps = {
+        componentFunction: renderFn,
+        options: { defaultService: 'thai' },
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(select).toHaveBeenCalledTimes(1);
       expect(select.mock.calls[0][2]).toBe('thai');
@@ -110,7 +119,11 @@ describe('Psammead storybook helpers', () => {
     it('handles scenario where config is null', () => {
       select.mockReturnValueOnce('news');
 
-      underTest.inputProvider(null, renderFn)();
+      const inputProps = {
+        componentFunction: renderFn,
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(renderFn).toHaveBeenCalledTimes(1);
       expect(renderFn).toHaveBeenCalledWith({
@@ -129,10 +142,12 @@ describe('Psammead storybook helpers', () => {
         select.mockReturnValueOnce('news');
         text.mockImplementation((_, displayText) => displayText);
 
-        underTest.inputProvider(
-          [{ name: 'first', defaultText: 'Sole input' }],
-          renderFn,
-        )();
+        const inputProps = {
+          slots: [{ name: 'first', defaultText: 'Sole input' }],
+          componentFunction: renderFn,
+        };
+
+        underTest.inputProvider(inputProps)();
 
         expect(renderFn).toHaveBeenCalledTimes(1);
         expect(renderFn).toHaveBeenCalledWith({
@@ -150,13 +165,15 @@ describe('Psammead storybook helpers', () => {
         select.mockReturnValueOnce('news');
         text.mockImplementation((_, displayText) => displayText);
 
-        underTest.inputProvider(
-          [
+        const inputProps = {
+          slots: [
             { name: 'first', defaultText: 'First input' },
             { name: 'second', defaultText: 'Second input' },
           ],
-          renderFn,
-        )();
+          componentFunction: renderFn,
+        };
+
+        underTest.inputProvider(inputProps)();
 
         expect(renderFn).toHaveBeenCalledTimes(1);
         expect(renderFn).toHaveBeenCalledWith({
@@ -175,7 +192,12 @@ describe('Psammead storybook helpers', () => {
       select.mockReturnValueOnce('news');
       text.mockImplementation((_, displayText) => displayText);
 
-      underTest.inputProvider([{ name: 'first' }], renderFn)();
+      const inputProps = {
+        slots: [{ name: 'first' }],
+        componentFunction: renderFn,
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(renderFn).toHaveBeenCalledTimes(1);
       expect(renderFn).toHaveBeenCalledWith({
@@ -193,10 +215,12 @@ describe('Psammead storybook helpers', () => {
       select.mockReturnValueOnce('russian');
       text.mockImplementation((_, displayText) => displayText);
 
-      underTest.inputProvider(
-        [{ name: 'first', defaultText: 'Sole input' }],
-        renderFn,
-      )();
+      const inputProps = {
+        slots: [{ name: 'first', defaultText: 'Sole input' }],
+        componentFunction: renderFn,
+      };
+
+      underTest.inputProvider(inputProps)();
 
       expect(renderFn).toHaveBeenCalledTimes(1);
       expect(renderFn).toHaveBeenCalledWith({
@@ -215,7 +239,11 @@ describe('Psammead storybook helpers', () => {
         select.mockReturnValueOnce('russian');
         text.mockImplementation((textKnobName, displayText) => displayText);
 
-        underTest.inputProvider([], renderFn)();
+        const inputProps = {
+          componentFunction: renderFn,
+        };
+
+        underTest.inputProvider(inputProps)();
 
         expect(renderFn).toHaveBeenCalledTimes(1);
         expect(renderFn.mock.calls[0][0].dir).toBe('ltr');
@@ -225,7 +253,11 @@ describe('Psammead storybook helpers', () => {
         select.mockReturnValueOnce('arabic');
         text.mockImplementation((_, displayText) => displayText);
 
-        underTest.inputProvider([], renderFn)();
+        const inputProps = {
+          componentFunction: renderFn,
+        };
+
+        underTest.inputProvider(inputProps)();
 
         expect(renderFn).toHaveBeenCalledTimes(1);
         expect(renderFn).toHaveBeenCalledWith({

--- a/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/input-provider.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { select } from '@storybook/addon-knobs';
 import { Helmet } from 'react-helmet';
+import { arrayOf, shape, string, element } from 'prop-types';
 import * as scripts from '@bbc/gel-foundations/scripts';
 import LANGUAGE_VARIANTS from './text-variants';
 
-const inputProvider = (
+const inputProvider = ({
   slots,
   componentFunction,
   services,
   options = {},
-) => () => {
+}) => () => {
   let serviceNames = Object.keys(LANGUAGE_VARIANTS);
 
   if (services) {
@@ -51,6 +52,18 @@ const inputProvider = (
       })}
     </>
   );
+};
+
+inputProvider.propTypes = {
+  slots: arrayOf(
+    shape({
+      name: string,
+      defaultText: string,
+    }),
+  ),
+  componentFunction: element,
+  services: arrayOf(string),
+  options: shape({ defaultService: string }),
 };
 
 export default inputProvider;


### PR DESCRIPTION
related to: bbc/simorgh#3077

**Overall change:** _We currently pass in 4 arguments into inputProvider, this isn't best practice so this PR will change it to one argument of one object _

**Code changes:**

- _pass a single object into inpuProvider_

TO-DO in another PR:

a seperate PR will be required to make the changes everywhere in psammead, then simorgh after. 
will merge after this PR psammead changes are here: https://github.com/bbc/psammead/pull/1926

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
