### PR TITLE
Persian client bundle timestamp format fix

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.2.2 | [PR#2044](https://github.com/bbc/psammead/pull/2044) Fix for Persian (`fa`) locale not working on client |
 | 2.2.1 | [PR#2020](https://github.com/bbc/psammead/pull/2020) IE11 fixes |
 | 2.2.0 | [PR#2001](https://github.com/bbc/psammead/pull/2001) Add `pa-in` (Punjabi) locale |
 | 2.1.5 | [PR#2000](https://github.com/bbc/psammead/pull/2000) Add Persian and Pashto locales to Storybook |

--- a/packages/utilities/psammead-locales/moment/fa.js
+++ b/packages/utilities/psammead-locales/moment/fa.js
@@ -22,7 +22,6 @@ const persianJalaliMonths = [
 // Moment formats that should have the Jalali date added
 const jalaliFormats = ['D MMMM YYYY', 'LL'];
 
-moment().locale('fa');
 moment.updateLocale('fa', {
   // eslint-disable-next-line object-shorthand
   postformat: function(string) {

--- a/packages/utilities/psammead-locales/moment/fa.js
+++ b/packages/utilities/psammead-locales/moment/fa.js
@@ -2,6 +2,7 @@
 const moment = require('moment');
 const jalaaliHelper = require('./helpers/jalaali');
 const stringHelper = require('./helpers/stringHelper');
+require('moment/locale/fa');
 
 const persianJalaliMonths = [
   'فروردین',

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to https://github.com/bbc/psammead/issues/1732

**Overall change:** _Prevents Persian timestamps from changing format when they are rendered client-side due to a missing require_

The Persian locale in `psammead-locales` was not explicitly requiring the base Moment locale as other overrides (e.g. `yo`) do. @dr3 spotted the base locale was not being added to the client bundle and this was causing a discrepancy between Persian timestamps on client and server render.

**Code changes:**

- Ensure the base Persian moment locale is available in the client bundles
- Avoid changing global moment locale unnecessarily (unrelated fix)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] This PR requires manual testing
