### PR TITLE
Remove template literals from Jalaali helper for IE11 compat

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.2.4 | [PR#2088](https://github.com/bbc/psammead/pull/2088) Another Persian locale IE11 compatibility fix |
 | 2.2.3 | [PR#2048](https://github.com/bbc/psammead/pull/2048) Import `pa-in` locale to be updated |
 | 2.2.2 | [PR#2044](https://github.com/bbc/psammead/pull/2044) Fix for Persian (`fa`) locale not working on client |
 | 2.2.1 | [PR#2020](https://github.com/bbc/psammead/pull/2020) IE11 fixes |

--- a/packages/utilities/psammead-locales/moment/helpers/jalaali.js
+++ b/packages/utilities/psammead-locales/moment/helpers/jalaali.js
@@ -8,9 +8,9 @@ function getJalaaliDatetime(gregorianMoment, jalaliMonths) {
     gregorianMoment.month() + 1,
     gregorianMoment.date()
   );
-  const output = `${jalaliDate.jd} ${jalaliMonths[jalaliDate.jm - 1]} ${
-    jalaliDate.jy
-  }`;
+  const output =
+    // eslint-disable-next-line prefer-template
+    jalaliDate.jd + ' ' + jalaliMonths[jalaliDate.jm - 1] + ' ' + jalaliDate.jy;
   return output;
 }
 
@@ -20,9 +20,15 @@ function addJalaliDate(locale, jalaliMonths, jalaliFormats, gregorianString) {
   // gregorianString must be in one of jalaliFormats, and return an isValid moment for
   // Jalali calendar to be applied to - e.g this will exclude timeago timestamps
   if (gregorianMoment.isValid() && jalaliMonths.length === 12) {
-    return `${stringHelper.useEasternNumerals(
-      getJalaaliDatetime(gregorianMoment, jalaliMonths)
-    )} - ${stringHelper.useEasternNumerals(gregorianString)}`;
+    // eslint-disable-next-line prefer-template
+    return (
+      // eslint-disable-next-line prefer-template
+      stringHelper.useEasternNumerals(
+        getJalaaliDatetime(gregorianMoment, jalaliMonths)
+      ) +
+      ' - ' +
+      stringHelper.useEasternNumerals(gregorianString)
+    );
   }
   return gregorianString;
 }

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/bbc/psammead/issues/1732

**Overall change:** _Remove template literals in Jalaali calendar helper causing breakage in IE11._

More sustainable solution will arrive soon in the form of https://github.com/bbc/psammead/issues/2025

Related:
- https://github.com/bbc/psammead/pull/2044
- https://github.com/bbc/psammead/pull/2020

**Code changes:**

- Replace template literals with string concatenation
- Hide concatenation from prettier

---

- [x] I have assigned myself to this PR and the corresponding issues
- [no - no change to behaviour] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] This PR requires manual testing
