### PR TITLE
Correct translation for 'ago' in Punjabi timestamps

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.2.6 | [PR#2094](https://github.com/bbc/psammead/pull/2094) Fix for Punjabi (`pa-in`) locale spelling of locale |
+| 2.2.6 | [PR#2094](https://github.com/bbc/psammead/pull/2094) Fix for Punjabi (`pa-in`) locale spelling of ago |
 | 2.2.5 | [PR#2088](https://github.com/bbc/psammead/pull/2088) Another Persian locale IE11 compatibility fix |
 | 2.2.4 | [PR#2087](https://github.com/bbc/psammead/pull/2087) Bumped jalaali-js |
 | 2.2.3 | [PR#2048](https://github.com/bbc/psammead/pull/2048) Import `pa-in` locale to be updated |

--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.2.6 | [PR#2094](https://github.com/bbc/psammead/pull/2094) Fix for Punjabi (`pa-in`) locale spelling of locale |
 | 2.2.5 | [PR#2088](https://github.com/bbc/psammead/pull/2088) Another Persian locale IE11 compatibility fix |
 | 2.2.4 | [PR#2087](https://github.com/bbc/psammead/pull/2087) Bumped jalaali-js |
 | 2.2.3 | [PR#2048](https://github.com/bbc/psammead/pull/2048) Import `pa-in` locale to be updated |

--- a/packages/utilities/psammead-locales/moment/pa-in.js
+++ b/packages/utilities/psammead-locales/moment/pa-in.js
@@ -4,4 +4,7 @@ require('moment/locale/pa-in');
 
 moment.updateLocale('pa-in', {
   postformat: null,
+  relativeTime: {
+    past: '%s ਪਹਿਲਾਂ',
+  }
 });

--- a/packages/utilities/psammead-locales/moment/pa-in.test.js
+++ b/packages/utilities/psammead-locales/moment/pa-in.test.js
@@ -160,11 +160,11 @@ test('from', function () {
 
 test('suffix', function () {
   assert.equal(moment(30000).from(0), 'ਕੁਝ ਸਕਿੰਟ ਵਿੱਚ', 'prefix');
-  assert.equal(moment(0).from(30000), 'ਕੁਝ ਸਕਿੰਟ ਪਿਛਲੇ', 'suffix');
+  assert.equal(moment(0).from(30000), 'ਕੁਝ ਸਕਿੰਟ ਪਹਿਲਾਂ', 'suffix');
 });
 
 test('now from now', function () {
-  assert.equal(moment().fromNow(), 'ਕੁਝ ਸਕਿੰਟ ਪਿਛਲੇ', 'now from now should display as in the past');
+  assert.equal(moment().fromNow(), 'ਕੁਝ ਸਕਿੰਟ ਪਹਿਲਾਂ', 'now from now should display as in the past');
 });
 
 test('fromNow', function () {

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #2091

**Overall change:** _Change Punjabi translation of ago to `ਪਹਿਲਾਂ` from `ਪਿਛਲੇ`._

**Code changes:**

- Update `pa-in` locale to have past relative time of `%s ਪਹਿਲਾਂ`.
- Update unit tests to reflect above.
- Update package version number.
- Update changelog

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
