### PR TITLE
Add data-cy attribute for Index Alsos E2Es

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.7.11 | [PR#2040](https://github.com/bbc/psammead/pull/2040) Add `data-cy` attribute for testing Index Alsos in Cypress |
 | 2.7.10 | [PR#2040](https://github.com/bbc/psammead/pull/2040) Fix summary visibility for breakpoints below 1008px |
 | 2.7.9 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.7.8 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update component storybook to use latest inputProvider changes |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -89,6 +89,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
 
 <div
   class="c0"
+  data-cy="index-alsos"
 >
   <h4
     class="c1"
@@ -248,6 +249,7 @@ exports[`Index Alsos should render one correctly 1`] = `
 
 <div
   class="c0"
+  data-cy="index-alsos"
 >
   <h4
     class="c1"

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -10,7 +10,9 @@ import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 
 const paddingDir = ({ dir }) => `padding-${dir === 'rtl' ? 'left' : 'right'}`;
 
-const StyledIndexAlsos = styled.div`
+const StyledIndexAlsos = styled.div.attrs(() => ({
+  'data-cy': 'index-alsos',
+}))`
   position: relative;
   z-index: 2;
   padding: ${GEL_SPACING_DBL} 0 0;

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -798,6 +798,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
     </time>
     <div
       class="c7"
+      data-cy="index-alsos"
     >
       <h4
         class="c8"
@@ -1165,6 +1166,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
     </time>
     <div
       class="c7"
+      data-cy="index-alsos"
     >
       <h4
         class="c8"


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/3586
Related to https://github.com/bbc/simorgh/pull/3587

**Overall change:** Add a `data-cy` attribute so the Index Alsos can be easily targeted without having to check for the structure of story promo which can make the test very flakey

**Code changes:**

- Add `data-cy` to Index Alsos
- Bump version + CHANGELOG update

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- ~~This PR requires manual testing~~
