### PR TITLE
Add Scottish colour and scotland service to fonts

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.0 | [PR#2120](https://github.com/bbc/psammead/pull/2120) Add Scottish colour and scotland service to fonts |
 | 2.2.0 | [PR#2021](https://github.com/bbc/psammead/pull/2021) Export global styles |
 | 2.1.4 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update component storybook to use latest inputProvider changes |
 | 2.1.3 | [PR#1948](https://github.com/bbc/psammead/pull/1948) Show different font types in storybook |

--- a/packages/utilities/psammead-styles/index.test.jsx
+++ b/packages/utilities/psammead-styles/index.test.jsx
@@ -70,6 +70,7 @@ const coloursExpectedExports = {
   C_CONSENT_BACKGROUND: 'string',
   C_CONSENT_ACTION: 'string',
   C_CONSENT_CONTENT: 'string',
+  C_DARK_SALTIRE: 'string',
 };
 
 const expectedExports = {

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
@@ -224,6 +224,14 @@ exports[`should render SansBold correctly for russian 1`] = `
   "
 `;
 
+exports[`should render SansBold correctly for scotland 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
+   font-style: normal;
+  "
+`;
+
 exports[`should render SansBold correctly for serbian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
@@ -572,6 +580,14 @@ exports[`should render SansBoldItalic correctly for russian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
     font-weight: 700;
+   font-style: italic;
+  "
+`;
+
+exports[`should render SansBoldItalic correctly for scotland 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
    font-style: italic;
   "
 `;
@@ -928,6 +944,14 @@ exports[`should render SansRegular correctly for russian 1`] = `
   "
 `;
 
+exports[`should render SansRegular correctly for scotland 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: normal; 
+  "
+`;
+
 exports[`should render SansRegular correctly for serbian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
@@ -1280,6 +1304,14 @@ exports[`should render SansRegularItalic correctly for russian 1`] = `
   "
 `;
 
+exports[`should render SansRegularItalic correctly for scotland 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: italic; 
+  "
+`;
+
 exports[`should render SansRegularItalic correctly for serbian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
@@ -1627,6 +1659,14 @@ exports[`should render SerifBold correctly for punjabi 1`] = `
 exports[`should render SerifBold correctly for russian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for scotland 1`] = `
+"
+    font-family: ReithSerif, Helvetica, Arial, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -1984,6 +2024,14 @@ exports[`should render SerifMedium correctly for russian 1`] = `
   "
 `;
 
+exports[`should render SerifMedium correctly for scotland 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: normal; 
+  "
+`;
+
 exports[`should render SerifMedium correctly for serbian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
@@ -2336,6 +2384,14 @@ exports[`should render SerifMediumItalic correctly for russian 1`] = `
   "
 `;
 
+exports[`should render SerifMediumItalic correctly for scotland 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: italic;
+  "
+`;
+
 exports[`should render SerifMediumItalic correctly for serbian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
@@ -2684,6 +2740,14 @@ exports[`should render SerifRegular correctly for russian 1`] = `
 "
     font-family: Helmet, Freesans, Helvetica, Arial, sans-serif;
     font-weight: 400;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifRegular correctly for scotland 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 400;
    font-style: normal;
   "
 `;

--- a/packages/utilities/psammead-styles/src/colours.js
+++ b/packages/utilities/psammead-styles/src/colours.js
@@ -22,3 +22,4 @@ export const C_CONSENT_BACKGROUND = '#323232';
 export const C_CONSENT_ACTION = '#F6A21D';
 export const C_CONSENT_CONTENT = '#BEBEBE';
 export const C_ORBIT_GREY = '#4C4C4C';
+export const C_DARK_SALTIRE = '#23104C';

--- a/packages/utilities/psammead-styles/src/font-families.js
+++ b/packages/utilities/psammead-styles/src/font-families.js
@@ -371,6 +371,7 @@ export const pidgin = helmetFontStyles;
 export const portuguese = helmetFontStyles;
 export const punjabi = punjabiStyles;
 export const russian = helmetFontStyles;
+export const scotland = latinReithFontStyles;
 export const serbian = helmetFontStyles;
 export const sinhala = sinhalaStyles;
 export const somali = helmetFontStyles;


### PR DESCRIPTION
Resolves #2121

**Overall change:**
Adds the 'scotland' service to font-families, and the dark saltire colour.

**Code changes:**

- Add the 'scotland' service to font-families
- Add the 'dark saltire' colour
- Update colour unit test

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
