### PR TITLE
Refactor async/await use into promise

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -34,7 +34,6 @@ module.exports = {
       },
     ],
     '@babel/plugin-proposal-export-default-from',
-    '@babel/plugin-transform-runtime',
   ],
   presets,
   env: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -34,6 +34,7 @@ module.exports = {
       },
     ],
     '@babel/plugin-proposal-export-default-from',
+    '@babel/plugin-transform-runtime',
   ],
   presets,
   env: {

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2123) Adds regenerator runtime plugin to babel config |
+| 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2123) Removes use of async/await |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |
 | 2.0.2 | [PR#1994](https://github.com/bbc/psammead/pull/1994) Add comment to clarify new shouldMatchSnapshot logic |
 | 2.0.1 | [PR#1958](https://github.com/bbc/psammead/pull/1958) Update `shouldMatchSnapshot` to add firstChild logic |

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2123) Adds regenerator runtime plugin to babel config |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |
 | 2.0.2 | [PR#1994](https://github.com/bbc/psammead/pull/1994) Add comment to clarify new shouldMatchSnapshot logic |
 | 2.0.1 | [PR#1958](https://github.com/bbc/psammead/pull/1958) Update `shouldMatchSnapshot` to add firstChild logic |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -4,19 +4,22 @@ import deepClone from 'ramda/src/clone';
 import renderWithHelmet from './renderWithHelmet';
 
 export const shouldMatchSnapshot = (title, component) => {
-  it(title, async () => {
+  it(title, done => {
     // select the first child to remove the pointless wrapping div from snapshots
     const removeWrappingDiv = container => container.firstChild;
-    const { container } = await renderWithHelmet(component);
-    const hasOneChild = container.children.length === 1;
-    /*
-     * if the container has more than one child then it's a component that uses a
-     * fragment at the top level so we should not select the first child because it
-     * wouldn't snapshot the whole component
-     */
-    expect(
-      hasOneChild ? removeWrappingDiv(container) : container,
-    ).toMatchSnapshot();
+    renderWithHelmet(component).then(({ container }) => {
+      const hasOneChild = container.children.length === 1;
+      /*
+       * if the container has more than one child then it's a component that uses a
+       * fragment at the top level so we should not select the first child because it
+       * wouldn't snapshot the whole component
+       */
+      expect(
+        hasOneChild ? removeWrappingDiv(container) : container,
+      ).toMatchSnapshot();
+
+      done();
+    });
   });
 };
 


### PR DESCRIPTION
**Overall change:** Fixes broken `psammead-test-helpers` version 3.0.0. This is because of the use of async/await without the regenerator runtime babel plugin. It is included for the jest test environment which is why the issue was not discovered.

**Code changes:**

- Refactors async await in `psammead-test-helpers/src/index.js` in `shouldMatchSnapshot`
- Bumps `psammead-test-helpers` to 3.0.1

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
