### PR TITLE
remove async keyword from test helpers

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.0 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator plugin error |
 | 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2125) Removes use of async/await |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |
 | 2.0.2 | [PR#1994](https://github.com/bbc/psammead/pull/1994) Add comment to clarify new shouldMatchSnapshot logic |

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator runtime plugin error |
+| 3.0.2 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator runtime plugin error |
 | 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2125) Removes use of async/await |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |
 | 2.0.2 | [PR#1994](https://github.com/bbc/psammead/pull/1994) Add comment to clarify new shouldMatchSnapshot logic |

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator plugin error |
+| 3.1.0 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator runtime plugin error |
 | 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2125) Removes use of async/await |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |
 | 2.0.2 | [PR#1994](https://github.com/bbc/psammead/pull/1994) Add comment to clarify new shouldMatchSnapshot logic |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.0",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.0",
+  "version": "3.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/renderWithHelmet.js
+++ b/packages/utilities/psammead-test-helpers/src/renderWithHelmet.js
@@ -1,6 +1,6 @@
 import { render, waitForDomChange } from '@testing-library/react';
 
-export default async component => {
+export default component => {
   /*
    * Similar to this problem https://github.com/testing-library/react-testing-library/issues/402
    * This helper was created to solve the problem of rendering helmet/head contents in snapshots.


### PR DESCRIPTION
**Overall change:** Removes the `async` keyword from test helper which removes regenerator runtime reference from the transpiled code.

**Code changes:**

- Removes `async` keyword because `await` is not being used and the function uses a promise instead.

---

**Testing notes**
No testing is required.

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
