### PR TITLE
Add exports for scripts

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.4.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Add generic script exports - cyrillicAndLatin, devanagariAndGurmukhi & noAscendersOrDescenders |
+| 3.4.0 | [PR#2169](https://github.com/bbc/psammead/pull/2169) Add generic script exports - cyrillicAndLatin, devanagariAndGurmukhi & noAscendersOrDescenders |
 | 3.3.3 | [PR#1847](https://github.com/bbc/psammead/pull/1847) Fixed Telugu typos |
 | 3.3.2 | [PR#1806](https://github.com/bbc/psammead/pull/1806/) Change strings to booleans |
 | 3.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.4.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Add generic script exports - cyrillicAndLatin, devanagariAndGurmukhi & noAscendersOrDescenders |
 | 3.3.3 | [PR#1847](https://github.com/bbc/psammead/pull/1847) Fixed Telugu typos |
 | 3.3.2 | [PR#1806](https://github.com/bbc/psammead/pull/1806/) Change strings to booleans |
 | 3.3.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/utilities/gel-foundations/index.test.jsx
+++ b/packages/utilities/gel-foundations/index.test.jsx
@@ -72,21 +72,24 @@ const typographyExpectedExports = {
 };
 
 const scriptsExpectedExports = {
-  latin: 'object',
-  cyrillic: 'object',
-  latinDiacritics: 'object',
   arabic: 'object',
   arabicPashto: 'object',
   bengali: 'object',
   burmese: 'object',
+  chinese: 'object',
+  cyrillic: 'object',
+  cyrillicAndLatin: 'object',
+  devanagariAndGurmukhi: 'object',
+  ethiopic: 'object',
   hindi: 'object',
+  korean: 'object',
+  latin: 'object',
+  latinDiacritics: 'object',
   nepali: 'object',
+  noAscendersOrDescenders: 'object',
   sinhalese: 'object',
   tamil: 'object',
   thai: 'object',
-  chinese: 'object',
-  korean: 'object',
-  ethiopic: 'object',
 };
 
 const expectedExports = {

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "sideEffects": false,
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {

--- a/packages/utilities/gel-foundations/src/scripts.js
+++ b/packages/utilities/gel-foundations/src/scripts.js
@@ -1,15 +1,28 @@
-export latin from './scripts/latin-and-cyrillic';
-export cyrillic from './scripts/latin-and-cyrillic';
-export latinDiacritics from './scripts/latin-with-diacritics';
 export arabic from './scripts/arabic';
+
 export arabicPashto from './scripts/arabic-pashto';
+
 export bengali from './scripts/bengali';
+
 export burmese from './scripts/burmese';
+
+export devanagariAndGurmukhi from './scripts/devanagari-and-gurmukhi';
 export hindi from './scripts/devanagari-and-gurmukhi';
 export nepali from './scripts/devanagari-and-gurmukhi';
-export sinhalese from './scripts/sinhalese';
-export tamil from './scripts/tamil';
-export thai from './scripts/thai';
+
+export cyrillic from './scripts/latin-and-cyrillic';
+export cyrillicAndLatin from './scripts/latin-and-cyrillic';
+export latin from './scripts/latin-and-cyrillic';
+
+export latinDiacritics from './scripts/latin-with-diacritics';
+
 export chinese from './scripts/no-ascenders-or-descenders';
-export korean from './scripts/no-ascenders-or-descenders';
 export ethiopic from './scripts/no-ascenders-or-descenders';
+export korean from './scripts/no-ascenders-or-descenders';
+export noAscendersOrDescenders from './scripts/no-ascenders-or-descenders';
+
+export sinhalese from './scripts/sinhalese';
+
+export tamil from './scripts/tamil';
+
+export thai from './scripts/thai';


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/3837

**Overall change:** Add exports for scripts devanagariAndGurmukhi, noAscendersOrDescenders & cyrillicAndLatin

**Code changes:**

-  Adding exports to `@bbc/gel-foundations/scripts`: `devanagariAndGurmukhi`, `noAscendersOrDescenders` & `cyrillicAndLatin`


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
