### PR TITLE
Fix typo in link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md) (you are here)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md)
 - [Contributing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md)
 - [Contributing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md) (you are here)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md)

--- a/Code-Standards-and-Ways-of-Working.md
+++ b/Code-Standards-and-Ways-of-Working.md
@@ -3,7 +3,7 @@
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md) (you are here)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md) (you are here)
 - [Contributing and developing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Psammead packages are split into:
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md)
 - [Contributing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md) (you are here)

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,7 +5,7 @@ NB all Development Dependencies are in the top level package.json, none are in t
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md)
 - [Contributing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md)

--- a/scripts/talos/README.md
+++ b/scripts/talos/README.md
@@ -3,7 +3,7 @@
 ## Documentation index
 Please familiarise yourself with our:
 - [Code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
-- [Code Standards and Ways of Working](https://github.com/bbc/simorgh/blob/latest/Code-Standards-and-Ways-of-Working.md)
+- [Code Standards and Ways of Working](https://github.com/bbc/psammead/blob/latest/Code-Standards-and-Ways-of-Working.md)
 - [Contributing guidelines](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
 - [Primary README](https://github.com/bbc/psammead/blob/latest/README.md)


### PR DESCRIPTION
Resolves n/a

**Overall change:** fixes a typo which breaks a link in documentation index

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
