### PR TITLE
Talos - Bump @bbc/psammead-image-placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.3 | [PR#2200](https://github.com/bbc/psammead/pull/2200) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 1.8.2 | [PR#2194](https://github.com/bbc/psammead/pull/2194) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.8.1 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-assets, @bbc/psammead-locales, @bbc/psammead-test-helpers |
 | 1.8.0 | [PR#2085](https://github.com/bbc/psammead/pull/2085) Improve Talos body to show details of bumped packages |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1422,12 +1422,12 @@
       "dev": true
     },
     "@bbc/psammead-image-placeholder": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.9.tgz",
-      "integrity": "sha512-2M5DaW0QImmdsRB0i2MKZEaxiEAVrbR5zWfPb1Zp8SWxiOM/cGBaXY1fur+mnjRvQgeEH60pKz/z4x6FplrLqw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.11.tgz",
+      "integrity": "sha512-atOCO5JXBXZ/svnKCv6rJkAzvDt49IUuJ42uVQ+E0CFHz38kTELas0oSLrhfGYQfeuIPzux7j3pN1O+otVhjRQ==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.2.4",
+        "@bbc/psammead-assets": "^2.4.0",
         "@bbc/psammead-styles": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -55,7 +55,7 @@
     "@bbc/psammead-caption": "^2.2.9",
     "@bbc/psammead-copyright": "^1.2.8",
     "@bbc/psammead-image": "^1.2.2",
-    "@bbc/psammead-image-placeholder": "^1.2.9",
+    "@bbc/psammead-image-placeholder": "^1.2.11",
     "@bbc/psammead-inline-link": "^1.3.8",
     "@bbc/psammead-locales": "^2.10.0",
     "@bbc/psammead-media-indicator": "^2.5.8",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^1.2.9  →  ^1.2.11

| Version | Description |
|---------|-------------|
| 1.2.11 | [PR#2194](https://github.com/bbc/psammead/pull/2194) Talos - Bump Dependencies - @bbc/psammead-assets |
| 1.2.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/psammead-assets |
</details>

