### PR TITLE
Talos - Bump @bbc/psammead-media-indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.3 | [PR#2209](https://github.com/bbc/psammead/pull/2209) Talos - Bump Dependencies - @bbc/psammead-media-indicator |
 | 1.8.2 | [PR#2194](https://github.com/bbc/psammead/pull/2194) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.8.1 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-assets, @bbc/psammead-locales, @bbc/psammead-test-helpers |
 | 1.8.0 | [PR#2085](https://github.com/bbc/psammead/pull/2085) Improve Talos body to show details of bumped packages |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1451,12 +1451,13 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.5.8.tgz",
-      "integrity": "sha512-+U4xVfr+RngLNP9ls4QP/XXe41CZ2tA6q6DwyaNENtcgPNN22Rj0/0Nt2Jq/cHcfvJFvnfh69ppATzYeedRoQQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.0.tgz",
+      "integrity": "sha512-VSA0AMhuctRMJTQi8qAK9hP04FLEyaaPafU43LyuUdUjnzok5NnkTBSMn+uKZVkhOrwNSzok3DlXtCFnfyiB5w==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^3.3.3",
+        "@bbc/gel-foundations": "^3.4.0",
+        "@bbc/psammead-assets": "^2.3.0",
         "@bbc/psammead-styles": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -58,7 +58,7 @@
     "@bbc/psammead-image-placeholder": "^1.2.9",
     "@bbc/psammead-inline-link": "^1.3.8",
     "@bbc/psammead-locales": "^2.10.0",
-    "@bbc/psammead-media-indicator": "^2.5.8",
+    "@bbc/psammead-media-indicator": "^2.6.0",
     "@bbc/psammead-paragraph": "^2.2.9",
     "@bbc/psammead-story-promo": "2.7.13",
     "@bbc/psammead-storybook-helpers": "^6.0.2",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-indicator  ^2.5.8  →  ^2.6.0

| Version | Description |
| ------- | ----------- |
| 2.6.0 | [PR#2199](https://github.com/bbc/psammead/pull/2199) Pull in media icons from @bbc/psammead-assets |
| 2.5.9 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
</details>

