### PR TITLE
Talos - Bump @bbc/psammead-locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.3 | [PR#2228](https://github.com/bbc/psammead/pull/2228) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.2 | [PR#2194](https://github.com/bbc/psammead/pull/2194) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.8.1 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-assets, @bbc/psammead-locales, @bbc/psammead-test-helpers |
 | 1.8.0 | [PR#2085](https://github.com/bbc/psammead/pull/2085) Improve Talos body to show details of bumped packages |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1441,9 +1441,9 @@
       }
     },
     "@bbc/psammead-locales": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.10.0.tgz",
-      "integrity": "sha512-/aLUsutdFm8Q6bHZP+HiJCKHPkMEKAqC5/yyGhr48jsBKZsXIX6tHc7QylgfMwax38KkWFSbjNE6xiPUpjfyPw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.17.0.tgz",
+      "integrity": "sha512-Zkjv9eIpLKg9uHYHpZo2ERFppJjfPk9ViOSbqF1dhp4qLYSpikVG1hjq8Bh9VUIE9DC+H15Ab2BR9JqOOvwanA==",
       "dev": true,
       "requires": {
         "jalaali-js": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -57,7 +57,7 @@
     "@bbc/psammead-image": "^1.2.2",
     "@bbc/psammead-image-placeholder": "^1.2.9",
     "@bbc/psammead-inline-link": "^1.3.8",
-    "@bbc/psammead-locales": "^2.10.0",
+    "@bbc/psammead-locales": "^2.17.0",
     "@bbc/psammead-media-indicator": "^2.5.8",
     "@bbc/psammead-paragraph": "^2.2.9",
     "@bbc/psammead-story-promo": "2.7.13",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-locales  ^2.10.0  →  ^2.17.0

| Version | Description |
| ------- | ----------- |
| 2.17.0 | [PR#2210](https://github.com/bbc/psammead/pull/2210) Add moment relative timestamp overrides for `ne` (Nepali), `sr` and `sr-cyrl` (Serbian) locales |
| 2.16.0 | [PR#2176](https://github.com/bbc/psammead/pull/2176)  Add `es` (Spanish) locale and update `ar` (Arabic) and `pt-br` (Brasil) locales |
| 2.15.0 | [PR#2184](https://github.com/bbc/psammead/pull/2184) Add `uz` (Uzbek) locale |
| 2.14.0 | [PR#2178](https://github.com/bbc/psammead/pull/2178)  Update `ps` (Pashto) locale to add relative time support |
| 2.13.0 | [PR#2193](https://github.com/bbc/psammead/pull/2193) Create `rw` (Gahuza) and `ti` (Tigrinya) locales |
| 2.12.0 | [PR#2179](https://github.com/bbc/psammead/pull/2179) Create `om` (Afaan Oromoo) and `am` (Amharic) locales |
| 2.11.0 | [PR#2196](https://github.com/bbc/psammead/pull/2196) Create `ha` (Hausa) and `so` (Somali) locales |
</details>

