### PR TITLE
update article embed URL for MediaPlayer stories

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.1-alpha.2 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Update article embed URLs in MediaPLayer stories |
 | 1.1.1-alpha.1 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies |
 | 1.1.0-alpha.1 | [PR#2144](https://github.com/bbc/psammead/pull/2144) Add `skin` prop |
 | 1.0.1-alpha.4 | [PR#1960](https://github.com/bbc/psammead/pull/1960) Change <React.Fragment> to <> |

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.1-alpha.2 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Update article embed URLs in MediaPLayer stories |
+| 1.1.1-alpha.2 | [PR#2247](https://github.com/bbc/psammead/pull/2247) Update article embed URLs in MediaPLayer stories |
 | 1.1.1-alpha.1 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies |
 | 1.1.0-alpha.1 | [PR#2144](https://github.com/bbc/psammead/pull/2144) Add `skin` prop |
 | 1.0.1-alpha.4 | [PR#1960](https://github.com/bbc/psammead/pull/1960) Change <React.Fragment> to <> |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "1.1.1-alpha.1",
+  "version": "1.1.1-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "1.1.1-alpha.1",
+  "version": "1.1.1-alpha.2",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-media-player/src/index.stories.jsx
+++ b/packages/components/psammead-media-player/src/index.stories.jsx
@@ -5,7 +5,7 @@ import { ampDecorator } from '../../../../.storybook/config';
 
 storiesOf('Components|Media Player', module).add('default', () => (
   <CanonicalMediaPlayer
-    src="https://www.test.bbc.co.uk/ws/av-embeds/c3wmq4d1y3wo/p01k6msp"
+    src="https://www.test.bbc.co.uk/ws/av-embeds/articles/c3wmq4d1y3wo/p01k6msp"
     placeholderSrc="https://ichef.bbci.co.uk/news/640/cpsdevpb/4eb7/test/ba7482d0-cca8-11e8-b0bf-f33155223fc4.jpg"
   />
 ));
@@ -15,7 +15,7 @@ storiesOf('Components|Media Player', module)
   .add('AMP', () => (
     <AmpMediaPlayer
       isAmp
-      src="https://www.test.bbc.co.uk/ws/av-embeds/c3wmq4d1y3wo/p01k6msp"
+      src="https://www.test.bbc.co.uk/ws/av-embeds/articles/c3wmq4d1y3wo/p01k6msp"
       placeholderSrc="https://ichef.bbci.co.uk/news/640/cpsdevpb/4eb7/test/ba7482d0-cca8-11e8-b0bf-f33155223fc4.jpg"
     />
   ));


### PR DESCRIPTION
Resolves #2246

**Overall change:** Updates the embed URL in the MediaPlayer stories

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[] Automated jest tests added (for new features) or updated (for existing features)~
- ~[ ] This PR requires manual testing~

http://localhost:8180/?path=/story/components-media-player--default
http://localhost:8180/?path=/story/components-media-player--amp

https://bbc.github.io/psammead/?path=/story/components-media-player--amp
https://bbc.github.io/psammead/?path=/story/components-media-player--default
