### PR TITLE
Talos - Bump @bbc/psammead-styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.8 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.8.7 | [PR#2243](https://github.com/bbc/psammead/pull/2243) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.6 | [PR#2237](https://github.com/bbc/psammead/pull/2237) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.5 | [PR#2238](https://github.com/bbc/psammead/pull/2238) Bumping dependencies - @storybook/theming, @storybook/react, @storybook/addon-notes, @storybook/knobs, @storybook/addon-a11y, @storybook/addon-actions, @storybook/addon-viewport, eslint-plugin-prettier, enquirer, lint-staged |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1403,6 +1403,14 @@
       "requires": {
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-copyright": {
@@ -1413,6 +1421,14 @@
       "requires": {
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-image": {
@@ -1429,6 +1445,14 @@
       "requires": {
         "@bbc/psammead-assets": "^2.4.1",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-inline-link": {
@@ -1438,6 +1462,14 @@
       "dev": true,
       "requires": {
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-locales": {
@@ -1459,6 +1491,14 @@
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-assets": "^2.4.1",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-paragraph": {
@@ -1469,6 +1509,14 @@
       "requires": {
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-story-promo": {
@@ -1479,6 +1527,14 @@
       "requires": {
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-storybook-helpers": {
@@ -1492,9 +1548,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA==",
       "dev": true
     },
     "@bbc/psammead-test-helpers": {
@@ -1514,6 +1570,14 @@
       "requires": {
         "@bbc/gel-foundations": "^3.4.0",
         "@bbc/psammead-styles": "^2.3.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
+          "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+          "dev": true
+        }
       }
     },
     "@bbc/psammead-visually-hidden-text": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -62,7 +62,7 @@
     "@bbc/psammead-paragraph": "^2.2.10",
     "@bbc/psammead-story-promo": "2.7.15",
     "@bbc/psammead-storybook-helpers": "^6.0.3",
-    "@bbc/psammead-styles": "^2.3.0",
+    "@bbc/psammead-styles": "^3.0.0",
     "@bbc/psammead-test-helpers": "^3.0.2",
     "@bbc/psammead-timestamp": "^2.2.9",
     "@bbc/psammead-visually-hidden-text": "^1.2.2",

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 5.0.3 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.2 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 5.0.1 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.0 | [PR#2127](https://github.com/bbc/psammead/pull/2127) Remove default colours. Add required props backgroundColour & logoColour |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA==",
       "dev": true
     },
     "@bbc/psammead-visually-hidden-text": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-visually-hidden-text": "^1.2.2"
   },
   "devDependencies": {
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.11 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.9 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.8 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.12 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.3.11 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.3.10 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.3.9 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.10 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.2.9 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.2.8 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.2.7 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.11 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 3.1.9 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.8 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.13 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.2.12 | [PR#2230](https://github.com/bbc/psammead/pull/2230) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.2.11 | [PR#2194](https://github.com/bbc/psammead/pull/2194) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.2.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-ARJodaVdDkRUTf5FmK34J/FbpstPiQl6innPsaUKxQ6YiLWm9uzhywJNpH6yRYAPkjpG0bfkXLNfVftr/S9Zew=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
     "@bbc/psammead-assets": "^2.4.1",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.3.9 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.3.8 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.3.7 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.3.6 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update component storybook to use latest inputProvider changes |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "React styled component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.6.2 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.6.1 | [PR#2230](https://github.com/bbc/psammead/pull/2230) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 2.6.0 | [PR#2199](https://github.com/bbc/psammead/pull/2199) Pull in media icons from @bbc/psammead-assets |
 | 2.5.9 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-ARJodaVdDkRUTf5FmK34J/FbpstPiQl6innPsaUKxQ6YiLWm9uzhywJNpH6yRYAPkjpG0bfkXLNfVftr/S9Zew=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0",
+    "@bbc/psammead-styles": "^3.0.0",
     "@bbc/psammead-assets": "^2.4.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.3 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.3.2 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.3.1 | [PR#2147](https://github.com/bbc/psammead/pull/2147) Add props for Storybook story withBrand. |
 | 2.3.0 | [PR#2117](https://github.com/bbc/psammead/pull/2117) Pass `dir` prop to `Navigation` component instead of `NavigationLi` |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "1.2.2",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0",
+    "@bbc/psammead-styles": "^3.0.0",
     "@bbc/psammead-visually-hidden-text": "^1.2.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.11 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.9 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.8 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.15 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.3.14 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.3.13 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.3.12 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.11 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.10 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 3.1.9 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.8 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.13 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.1.12 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.1.11 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.1.10 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.7.16 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.7.15 | [PR#2181](https://github.com/bbc/psammead/pull/2181) Remove `Timestamp` in StoryPromo story |
 | 2.7.14 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.7.13 | [PR#2119](https://github.com/bbc/psammead/pull/2119) Add visuallyHiddenText for media types in storybook |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.10 | [PR#2251](https://github.com/bbc/psammead/pull/2251) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.9 | [PR#2191](https://github.com/bbc/psammead/pull/2191) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.8 | [PR#2145](https://github.com/bbc/psammead/pull/2145) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.7 | [PR#2081](https://github.com/bbc/psammead/pull/2081) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+      "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
     }
   }
 }

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^3.4.0",
-    "@bbc/psammead-styles": "^2.3.0"
+    "@bbc/psammead-styles": "^3.0.0"
   },
   "peerDependencies": {
     "styled-components": "^4.3.2"


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-consent-banner

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-media-indicator

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-caption

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-timestamp

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-sitewide-links

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-inline-link

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-section-label

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-headings

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-brand

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-image-placeholder

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-paragraph

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-story-promo-list

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-story-promo

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-navigation

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>


@bbc/psammead-copyright

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^2.3.0  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#2250](https://github.com/bbc/psammead/pull/2250) Update Mundo, Brasil and Turkish fonts from Helmet to Reith |
</details>

