### PR TITLE
Talos - Bump @bbc/psammead-locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.13 | [PR#2298](https://github.com/bbc/psammead/pull/2298) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.12 | [PR#2289](https://github.com/bbc/psammead/pull/2289) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-caption, @bbc/psammead-copyright, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-paragraph, @bbc/psammead-story-promo, @bbc/psammead-styles, @bbc/psammead-timestamp |
 | 1.8.12 | [PR#2273](https://github.com/bbc/psammead/pull/2273) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.8.11 | [PR#2277](https://github.com/bbc/psammead/pull/2277) Fix changelog formatting |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1441,9 +1441,9 @@
       }
     },
     "@bbc/psammead-locales": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.21.0.tgz",
-      "integrity": "sha512-1nBoAEQ8cNoYcg+MvRn9+dj555X8VzbuIUMI4xnLNrefuA8aKnEyHzrZF7IPiHGxHrZ1ynMxjiJGsxAxjHJ6yw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.22.0.tgz",
+      "integrity": "sha512-4vX0AKZSRKB3iyZ5JWQXpijHk+rqrMC1W36rCG9Sd01NIGBoYpR4qrMoOgtaEaSpsocbxHihHNGRXrDBAljVAw==",
       "dev": true,
       "requires": {
         "jalaali-js": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -57,7 +57,7 @@
     "@bbc/psammead-image": "^1.2.2",
     "@bbc/psammead-image-placeholder": "^1.2.14",
     "@bbc/psammead-inline-link": "^1.3.10",
-    "@bbc/psammead-locales": "^2.21.0",
+    "@bbc/psammead-locales": "^2.22.0",
     "@bbc/psammead-media-indicator": "^2.6.3",
     "@bbc/psammead-paragraph": "^2.2.12",
     "@bbc/psammead-story-promo": "2.7.17",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-locales  ^2.21.0  →  ^2.22.0

| Version | Description |
| ------- | ----------- |
| 2.22.0 | [PR#2290](https://github.com/bbc/psammead/pull/2290) Add `en-gb` (English) locale. |
| 2.21.1 | [PR#2288](https://github.com/bbc/psammead/pull/2288) Remove `de` from `es` (Mundo) locale long date format. Add `pt-br` (Brasil) locale month override |
</details>

