### PR TITLE
Fix styling for IE for useful links

### DIFF
--- a/packages/components/psammead-useful-links/CHANGELOG.md
+++ b/packages/components/psammead-useful-links/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0-alpha.2 | [PR#2308](https://github.com/bbc/psammead/pull/2308) Fix styling for Internet Explorer |
 | 1.0.0-alpha.1 | [PR#2236](https://github.com/bbc/psammead/pull/2236) Initial creation of Useful Links component. |

--- a/packages/components/psammead-useful-links/package-lock.json
+++ b/packages/components/psammead-useful-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-useful-links/package.json
+++ b/packages/components/psammead-useful-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-useful-links/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-useful-links/src/__snapshots__/index.test.jsx.snap
@@ -46,6 +46,13 @@ exports[`Multiple useful links should render correctly 1`] = `
   }
 }
 
+@media (min-width:37.5rem) {
+  .c1 {
+    display: inline-block;
+    min-width: 50%;
+  }
+}
+
 <ul
   class="c0"
   role="list"

--- a/packages/components/psammead-useful-links/src/index.jsx
+++ b/packages/components/psammead-useful-links/src/index.jsx
@@ -41,12 +41,13 @@ export const UsefulLinksUl = styled.ul.attrs({ role: 'list' })`
 export const UsefulLinksLi = styled.li.attrs({ role: 'listitem' })`
   padding-top: ${GEL_SPACING};
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    display: inline-block;
+    min-width: 50%;
+
     @supports (${grid}) {
+      display: block;
+      min-width: initial;
       align-self: center;
-    }
-    @supports not (${grid}) {
-      display: inline-block;
-      min-width: 50%;
     }
   }
 `;


### PR DESCRIPTION
Resolves #2306 

**Overall change:** 
Fixed css so that two columns of useful links are displayed in Internet Explorer.

**Code changes:**
- Removed `@supports not (${grid})` since it is not supported by IE.
- Updated snapshot.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing

**Screenshots:**
Here are the screenshots of how the columns work in Internet Explorer now (taken from BrowserStack):

<img width="499" alt="Screenshot 2019-10-04 at 10 52 34" src="https://user-images.githubusercontent.com/17802955/66199675-19dee900-e697-11e9-9efc-28da02423a97.png">
<img width="959" alt="Screenshot 2019-10-04 at 10 52 52" src="https://user-images.githubusercontent.com/17802955/66199687-1e0b0680-e697-11e9-8258-e26fd563d7f0.png">

