### PR TITLE
use xmldoc instead of xml-js, with refactor to accomadate new package

### DIFF
--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,5 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |
 | 1.0.1 | [PR#2347](https://github.com/bbc/psammead/pull/2347) Handle unsupported nodes as plain text |
 | 1.0.0 | [PR#2304](https://github.com/bbc/psammead/pull/2304) Add inital `rich-text-transforms` utility package |

--- a/packages/utilities/psammead-rich-text-transforms/package-lock.json
+++ b/packages/utilities/psammead-rich-text-transforms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-rich-text-transforms/package-lock.json
+++ b/packages/utilities/psammead-rich-text-transforms/package-lock.json
@@ -4919,19 +4919,19 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "requires": {
-        "sax": "^1.2.4"
-      }
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xmldoc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.2.tgz",
+      "integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
+      "requires": {
+        "sax": "^1.2.1"
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/utilities/psammead-rich-text-transforms/package.json
+++ b/packages/utilities/psammead-rich-text-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A utility library to transform to structured rich text.",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/utilities/psammead-rich-text-transforms/package.json
+++ b/packages/utilities/psammead-rich-text-transforms/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "ramda": "^0.26.1",
-    "xml-js": "^1.6.11"
+    "xmldoc": "^1.1.2"
   },
   "devDependencies": {
     "jest": "^24.8.0"

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -9,7 +9,7 @@ const attributeTags = ['bold', 'italic'];
 const supportedXmlNodeNames = ['paragraph', 'link', 'url', ...attributeTags];
 
 const isXmlNodeSupported = node => {
-  if (node.constructor.name === 'XmlTextNode') {
+  if (path(['constructor', 'name'], node) === 'XmlTextNode') {
     return true;
   }
 

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define */
-const { xml2json } = require('xml-js');
+const xmldoc = require('xmldoc');
 const path = require('ramda/src/path');
 const pathOr = require('ramda/src/pathOr');
 const is = require('ramda/src/is');
@@ -9,8 +9,8 @@ const attributeTags = ['bold', 'italic'];
 const supportedXmlNodeNames = ['paragraph', 'link', 'url', ...attributeTags];
 
 const isXmlNodeSupported = node => {
-  if (path(['type'], node) === 'text') {
-    return Boolean(pathOr('', ['text'], node).trim());
+  if (node.constructor.name === 'XmlTextNode') {
+    return true;
   }
 
   return supportedXmlNodeNames.includes(path(['name'], node));
@@ -22,24 +22,22 @@ const getTextFromChildBlocks = childBlocks => {
   return childBlocks.map(({ model }) => pathOr('', ['text'], model)).join('');
 };
 
-const findEl = (element, name, key) => {
-  const elements = path(['elements'], element);
-
-  if (!is(Array, elements)) return undefined;
-
-  return elements.find(el => path([key], el) === name);
-};
-
-const findAtr = (element, name) => path(['attributes', name], element);
-
 const createUrlLink = element => {
-  const captionTextNode = findEl(element, 'caption', 'name');
+  let text;
+  let locator;
+  let blocks;
 
-  const locator = findAtr(findEl(element, 'url', 'name'), 'href');
+  path(['children'], element).forEach(childNode => {
+    if (childNode.name === 'caption') {
+      text = path(['children', 0, 'text'], childNode);
+    }
 
-  const text = path(['text'], findEl(captionTextNode, 'text', 'type'));
+    if (childNode.name === 'url') {
+      locator = path(['attr', 'href'], childNode);
+    }
 
-  const blocks = [fragment(text)];
+    blocks = [fragment(text)];
+  });
 
   return urlLink(text, locator, blocks);
 };
@@ -51,12 +49,12 @@ const handleSupportedNodes = (childNode, attributes, acc) => {
 };
 
 const convertToBlocks = (node, attributes = []) =>
-  pathOr([], ['elements'], node).reduce((acc, childNode) => {
+  pathOr([], ['children'], node).reduce((acc, childNode) => {
     if (isXmlNodeSupported(childNode, attributes)) {
       return handleSupportedNodes(childNode, attributes, acc);
     }
 
-    if (childNode.elements) {
+    if (childNode.children && childNode.children.length !== 0) {
       // ignore the unsupported node and try to render it's children
       return convertToBlocks(childNode, attributes);
     }
@@ -67,7 +65,7 @@ const convertToBlocks = (node, attributes = []) =>
 const xmlNodeToBlock = (node, attributes) => {
   if (!is(Object, node)) return undefined;
 
-  if (node.type === 'text') {
+  if (node.constructor.name === 'XmlTextNode') {
     return fragment(node.text, attributes);
   }
 
@@ -95,11 +93,8 @@ const xmlNodeToBlock = (node, attributes) => {
 
 const candyXmlToRichText = xml => {
   try {
-    const parsedXml = JSON.parse(xml2json(xml));
-
-    const bodyXmlNode = path(['elements', 0], parsedXml);
-
-    const blocks = convertToBlocks(bodyXmlNode);
+    const parsedXml = new xmldoc.XmlDocument(xml);
+    const blocks = convertToBlocks(parsedXml);
 
     return {
       type: 'text',

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -452,7 +452,7 @@ test('can handle an empty XML tag', () => {
 test('can handle chaos', () => {
   const richText = candyXmlToRichText(
     createBody(
-      '<paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage></carnage></bold></is></this></italic>.</paragraph>',
+      '<paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage> stuff</carnage></bold></is></this></italic>.</paragraph>',
     ),
   );
 
@@ -464,7 +464,7 @@ test('can handle chaos', () => {
           type: 'paragraph',
           model: {
             text:
-              'Bold text in unsupported nodes followed by normal text then some carnage.',
+              'Bold text in unsupported nodes followed by normal text then some carnage stuff.',
             blocks: [
               {
                 type: 'fragment',
@@ -491,6 +491,13 @@ test('can handle chaos', () => {
                 type: 'fragment',
                 model: {
                   text: 'carnage',
+                  attributes: ['italic', 'bold'],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: ' stuff',
                   attributes: ['italic', 'bold'],
                 },
               },

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -411,6 +411,44 @@ test('returns plain text if wrapped in an unsupport xml node', () => {
   });
 });
 
+test('can handle an empty XML tag', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<paragraph>Some text content with <foo></foo>an empty XML tag.</paragraph>',
+    ),
+  );
+
+  expect(richText).toStrictEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'paragraph',
+          model: {
+            text: 'Some text content with an empty XML tag.',
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'Some text content with ',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: 'an empty XML tag.',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
 test('can handle chaos', () => {
   const richText = candyXmlToRichText(
     createBody(

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -449,76 +449,10 @@ test('can handle an empty XML tag', () => {
   });
 });
 
-test('can handle horrible nesting', () => {
-  const richText = candyXmlToRichText(
-    createBody(
-      '<paragraph>Some <foo>text <bar>content with<meh> </meh>many nested</bar></foo> tags</paragraph>',
-    ),
-  );
-
-  expect(richText).toStrictEqual({
-    type: 'text',
-    model: {
-      blocks: [
-        {
-          type: 'paragraph',
-          model: {
-            text: 'Some text content with many nested tags',
-            blocks: [
-              {
-                type: 'fragment',
-                model: {
-                  text: 'Some ',
-                  attributes: [],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: 'text ',
-                  attributes: [],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: 'content with',
-                  attributes: [],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: ' ',
-                  attributes: [],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: 'many nested',
-                  attributes: [],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: ' tags',
-                  attributes: [],
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  });
-});
-
 test('can handle chaos', () => {
   const richText = candyXmlToRichText(
     createBody(
-      '<paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage> stuff</carnage></bold></is></this></italic>.</paragraph>',
+      '<paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage></carnage></bold></is></this></italic>.</paragraph>',
     ),
   );
 
@@ -530,7 +464,7 @@ test('can handle chaos', () => {
           type: 'paragraph',
           model: {
             text:
-              'Bold text in unsupported nodes followed by normal text then some carnage stuff.',
+              'Bold text in unsupported nodes followed by normal text then some carnage.',
             blocks: [
               {
                 type: 'fragment',
@@ -557,13 +491,6 @@ test('can handle chaos', () => {
                 type: 'fragment',
                 model: {
                   text: 'carnage',
-                  attributes: ['italic', 'bold'],
-                },
-              },
-              {
-                type: 'fragment',
-                model: {
-                  text: ' stuff',
                   attributes: ['italic', 'bold'],
                 },
               },

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -34,12 +34,9 @@ test('can parse XML with a paragraph', () => {
 
 test('can parse XML with a link', () => {
   const richText = candyXmlToRichText(
-    createBody(`
-      <link>
-        <caption>foo</caption>
-        <url href="https://example.com/foo"/>
-      </link>
-    `),
+    createBody(
+      '<link><caption>foo</caption><url href="https://example.com/foo"/></link>',
+    ),
   );
 
   expect(richText).toEqual({
@@ -69,9 +66,9 @@ test('can parse XML with a link', () => {
 
 test('returns a plain text representation of the data', () => {
   const richText = candyXmlToRichText(
-    createBody(`
-      <paragraph>Read more: <link><caption>foo</caption><url href="https://example.com/foo"/></link> bar <bold>baz</bold></paragraph>
-    `),
+    createBody(
+      '<paragraph>Read more: <link><caption>foo</caption><url href="https://example.com/foo"/></link> bar <bold>baz</bold></paragraph>',
+    ),
   );
 
   expect(richText).toEqual({
@@ -130,11 +127,9 @@ test('returns a plain text representation of the data', () => {
 
 test('can parse XML with multiple paragraphs', () => {
   const richText = candyXmlToRichText(
-    createBody(`
-      <paragraph>foo</paragraph>
-      <paragraph>bar</paragraph>
-      <paragraph>baz</paragraph>
-    `),
+    createBody(
+      '<paragraph>foo</paragraph><paragraph>bar</paragraph><paragraph>baz</paragraph>',
+    ),
   );
 
   expect(richText).toStrictEqual({
@@ -380,9 +375,9 @@ test('returns null when given invalid xml', () => {
 
 test('returns plain text if wrapped in an unsupport xml node', () => {
   const richText = candyXmlToRichText(
-    createBody(`
-      <paragraph><foobar>Struck through text</foobar> followed by normal text</paragraph>
-    `),
+    createBody(
+      '<paragraph><foobar>Struck through text</foobar> followed by normal text</paragraph>',
+    ),
   );
 
   expect(richText).toStrictEqual({
@@ -418,9 +413,9 @@ test('returns plain text if wrapped in an unsupport xml node', () => {
 
 test('can handle chaos', () => {
   const richText = candyXmlToRichText(
-    createBody(`
-      <paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage> </carnage></bold></is></this></italic>.</paragraph>
-    `),
+    createBody(
+      '<paragraph><foo><bar><bold><meh>Bold text in unsupported nodes</meh></bold></bar></foo> followed by normal text then <italic><this><is>some <bold>carnage<carnage></carnage></bold></is></this></italic>.</paragraph>',
+    ),
   );
 
   expect(richText).toStrictEqual({

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -449,6 +449,72 @@ test('can handle an empty XML tag', () => {
   });
 });
 
+test('can handle horrible nesting', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<paragraph>Some <foo>text <bar>content with<meh> </meh>many nested</bar></foo> tags</paragraph>',
+    ),
+  );
+
+  expect(richText).toStrictEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'paragraph',
+          model: {
+            text: 'Some text content with many nested tags',
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'Some ',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: 'text ',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: 'content with',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: ' ',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: 'many nested',
+                  attributes: [],
+                },
+              },
+              {
+                type: 'fragment',
+                model: {
+                  text: ' tags',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
 test('can handle chaos', () => {
   const richText = candyXmlToRichText(
     createBody(


### PR DESCRIPTION
Resolves #2363

**Overall change:** Swaps out `xml-js` to `xmldoc` as the dependency of this package and updates the code based on the new packages format.

**Code changes:**

- Swaps the checking the `node.type as text` to `node.constructor.name === 'XmlTextNode`
- Removes `findEl` and `findAtr` as the new format is less nested
- Has to loop over each child of the urlLink to build out the `text`, `locator` and `blocks`
- Swaps `elements` for `children` due to the new format 
- Checks if the array is empty with (`childNode.children.length !== 0`) before recursively calling `convertToBlocks()`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~[ ] This PR requires manual testing~
