### PR TITLE
Remove alpha tag from useful links component

### DIFF
--- a/packages/components/psammead-useful-links/CHANGELOG.md
+++ b/packages/components/psammead-useful-links/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#2370](https://github.com/bbc/psammead/pull/2370) Alpha tag removed from component |
 | 1.0.0-alpha.4 | [PR#2365](https://github.com/bbc/psammead/pull/2365) Change size of column gap |
 | 1.0.0-alpha.3 | [PR#2313](https://github.com/bbc/psammead/pull/2313) Fix styling for css grid |
 | 1.0.0-alpha.2 | [PR#2308](https://github.com/bbc/psammead/pull/2308) Fix styling for Internet Explorer |

--- a/packages/components/psammead-useful-links/README.md
+++ b/packages/components/psammead-useful-links/README.md
@@ -1,7 +1,3 @@
-## ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-useful-links - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-useful-links%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-useful-links%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-useful-links)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-useful-links) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-useful-links)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-useful-links&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/useful-links--one-link) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-useful-links.svg)](https://www.npmjs.com/package/@bbc/psammead-useful-links) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-useful-links/package-lock.json
+++ b/packages/components/psammead-useful-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-useful-links/package.json
+++ b/packages/components/psammead-useful-links/package.json
@@ -33,8 +33,5 @@
     "react": "^16.9.0",
     "prop-types": "^15.6.2",
     "styled-components": "^4.3.2"
-  },
-  "publishConfig": {
-    "tag": "alpha"
   }
 }

--- a/packages/components/psammead-useful-links/package.json
+++ b/packages/components/psammead-useful-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
Resolves #2254 

**Overall change:** 
Removed an alpha tag after an a11y swarm and UX review of the component.

**Code changes:**
Removed an alpha tag.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
