### PR TITLE
Talos - Bump @bbc/psammead-locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.22 | [PR#2413](https://github.com/bbc/psammead/pull/2413) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.21 | [PR#2303](https://github.com/bbc/psammead/pull/2303) Added psammead-calendars as a dependency |
 | 1.8.20 | [PR#2401](https://github.com/bbc/psammead/pull/2401) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-storybook-helpers |
 | 1.8.19 | [PR#2356](https://github.com/bbc/psammead/pull/2356) Bump @bbc/psammead-story-promo |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1379,6 +1379,18 @@
       "requires": {
         "@bbc/psammead-locales": "^2.23.0",
         "jalaali-js": "1.1.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-locales": {
+          "version": "2.23.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.23.0.tgz",
+          "integrity": "sha512-6QTbLtaXAPbg0Z2su0w6hnxyn9vRHFHx9ilqwhSS9gyoJaXyPQRDjCoyEoON0oviqmMt00KPqJ40hXPI2bql/g==",
+          "dev": true,
+          "requires": {
+            "jalaali-js": "1.1.0",
+            "moment": "^2.24.0"
+          }
+        }
       }
     },
     "@bbc/psammead-caption": {
@@ -1427,9 +1439,9 @@
       }
     },
     "@bbc/psammead-locales": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.23.0.tgz",
-      "integrity": "sha512-6QTbLtaXAPbg0Z2su0w6hnxyn9vRHFHx9ilqwhSS9gyoJaXyPQRDjCoyEoON0oviqmMt00KPqJ40hXPI2bql/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-3.0.0.tgz",
+      "integrity": "sha512-A5UKwdWjl2yhMUYoGrk8DseOffKrEe7Vo8gTOd+Q0Goo8JM+2qrPNDzMHSknZ0YLV4eVBOeIw5y4cB7P2PiGrA==",
       "dev": true,
       "requires": {
         "jalaali-js": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -58,7 +58,7 @@
     "@bbc/psammead-image": "^1.2.2",
     "@bbc/psammead-image-placeholder": "^1.2.15",
     "@bbc/psammead-inline-link": "^1.3.11",
-    "@bbc/psammead-locales": "^2.23.0",
+    "@bbc/psammead-locales": "^3.0.0",
     "@bbc/psammead-media-indicator": "^2.6.4",
     "@bbc/psammead-paragraph": "^2.2.13",
     "@bbc/psammead-story-promo": "2.8.0-alpha.1",

--- a/packages/utilities/psammead-calendars/CHANGELOG.md
+++ b/packages/utilities/psammead-calendars/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
+| 2.0.1 | [PR#2413](https://github.com/bbc/psammead/pull/2413) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.0 | [PR#2360](https://github.com/bbc/psammead/pull/2360) Use Eastern Arabic numerals for Jalaali dates |
 | 1.0.0 | [PR#2190](https://github.com/bbc/psammead/pull/2190) Initial creation of package. |

--- a/packages/utilities/psammead-calendars/package-lock.json
+++ b/packages/utilities/psammead-calendars/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-calendars",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-locales": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.23.0.tgz",
-      "integrity": "sha512-6QTbLtaXAPbg0Z2su0w6hnxyn9vRHFHx9ilqwhSS9gyoJaXyPQRDjCoyEoON0oviqmMt00KPqJ40hXPI2bql/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-3.0.0.tgz",
+      "integrity": "sha512-A5UKwdWjl2yhMUYoGrk8DseOffKrEe7Vo8gTOd+Q0Goo8JM+2qrPNDzMHSknZ0YLV4eVBOeIw5y4cB7P2PiGrA==",
       "requires": {
         "jalaali-js": "1.1.0",
         "moment": "^2.24.0"

--- a/packages/utilities/psammead-calendars/package.json
+++ b/packages/utilities/psammead-calendars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-calendars",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-calendars/README.md",
   "dependencies": {
-    "@bbc/psammead-locales": "^2.23.0",
+    "@bbc/psammead-locales": "^3.0.0",
     "jalaali-js": "1.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-locales  ^2.23.0  →  ^3.0.0

| Version | Description |
| ------- | ----------- |
| 3.0.0 | [PR#2375](https://github.com/bbc/psammead/pull/2375) Removed `fa` locale override and jalaali calendar helper  |
</details>


@bbc/psammead-calendars

<details>
<summary>Details</summary>
@bbc/psammead-locales  ^2.23.0  →  ^3.0.0

| Version | Description |
| ------- | ----------- |
| 3.0.0 | [PR#2375](https://github.com/bbc/psammead/pull/2375) Removed `fa` locale override and jalaali calendar helper  |
</details>

