### PR TITLE
Remove done from matchSnapshotAsync

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#2416](https://github.com/bbc/psammead/pull/2416) Adds matchSnapshotAsync export |
+| 3.1.1 | [PR#2421](https://github.com/bbc/psammead/pull/2421) Removes done from `matchSnapshotAsync` and minor refactors |
+| 3.1.0 | [PR#2416](https://github.com/bbc/psammead/pull/2416) Adds `matchSnapshotAsync` export |
 | 3.0.2 | [PR#2166](https://github.com/bbc/psammead/pull/2166) remove async keyword from test helper to fix regenerator runtime plugin error |
 | 3.0.1 | [PR#2123](https://github.com/bbc/psammead/pull/2125) Removes use of async/await |
 | 3.0.0 | [PR#2104](https://github.com/bbc/psammead/pull/2104) add function to detect and render helmet for use in snapshots |

--- a/packages/utilities/psammead-test-helpers/__snapshots__/index.test.jsx.snap
+++ b/packages/utilities/psammead-test-helpers/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Psammead test helpers should create a snapshot from an async it() block with component and done props 1`] = `
+exports[`Psammead test helpers should create a snapshot from an async it() block 1`] = `
 <div>
   <p>
     Foobar

--- a/packages/utilities/psammead-test-helpers/index.test.jsx
+++ b/packages/utilities/psammead-test-helpers/index.test.jsx
@@ -234,13 +234,12 @@ describe('Psammead test helpers', () => {
     <HelmetWithContent />,
   );
 
-  it('should create a snapshot from an async it() block with component and done props', async done => {
-    const data = Promise.resolve('Foobar');
-    const component = (
+  it('should create a snapshot from an async it() block', async () => {
+    const data = await Promise.resolve('Foobar');
+    await testHelpers.matchSnapshotAsync(
       <div>
-        <p>{await data}</p>
-      </div>
+        <p>{data}</p>
+      </div>,
     );
-    testHelpers.matchSnapshotAsync(component, done);
   });
 });

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -6,18 +6,22 @@ import renderWithHelmet from './renderWithHelmet';
 // select the first child to remove the pointless wrapping div from snapshots
 const removeWrappingDiv = container => container.firstChild;
 
+const createSnapshot = container => {
+  const hasOneChild = container.children.length === 1;
+  /*
+   * if the container has more than one child then it's a component that uses a
+   * fragment at the top level so we should not select the first child because it
+   * wouldn't snapshot the whole component
+   */
+  expect(
+    hasOneChild ? removeWrappingDiv(container) : container,
+  ).toMatchSnapshot();
+};
+
 export const shouldMatchSnapshot = (title, component) => {
   it(title, done => {
     renderWithHelmet(component).then(({ container }) => {
-      const hasOneChild = container.children.length === 1;
-      /*
-       * if the container has more than one child then it's a component that uses a
-       * fragment at the top level so we should not select the first child because it
-       * wouldn't snapshot the whole component
-       */
-      expect(
-        hasOneChild ? removeWrappingDiv(container) : container,
-      ).toMatchSnapshot();
+      createSnapshot(container);
       done();
     });
   });
@@ -25,15 +29,7 @@ export const shouldMatchSnapshot = (title, component) => {
 
 export const matchSnapshotAsync = component => {
   return renderWithHelmet(component).then(({ container }) => {
-    const hasOneChild = container.children.length === 1;
-    /*
-     * if the container has more than one child then it's a component that uses a
-     * fragment at the top level so we should not select the first child because it
-     * wouldn't snapshot the whole component
-     */
-    expect(
-      hasOneChild ? removeWrappingDiv(container) : container,
-    ).toMatchSnapshot();
+    createSnapshot(container);
   });
 };
 

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -3,10 +3,29 @@ import 'jest-styled-components';
 import deepClone from 'ramda/src/clone';
 import renderWithHelmet from './renderWithHelmet';
 
-const createSnapshot = (component, done) => {
-  // select the first child to remove the pointless wrapping div from snapshots
+export const shouldMatchSnapshot = (title, component) => {
+  it(title, done => {
+    // select the first child to remove the pointless wrapping div from snapshots
+    const removeWrappingDiv = container => container.firstChild;
+    renderWithHelmet(component).then(({ container }) => {
+      const hasOneChild = container.children.length === 1;
+      /*
+       * if the container has more than one child then it's a component that uses a
+       * fragment at the top level so we should not select the first child because it
+       * wouldn't snapshot the whole component
+       */
+      expect(
+        hasOneChild ? removeWrappingDiv(container) : container,
+      ).toMatchSnapshot();
+      done();
+    });
+  });
+};
+
+export const matchSnapshotAsync = component => {
   const removeWrappingDiv = container => container.firstChild;
-  renderWithHelmet(component).then(({ container }) => {
+  return renderWithHelmet(component).then(({ container }) => {
+    // select the first child to remove the pointless wrapping div from snapshots
     const hasOneChild = container.children.length === 1;
     /*
      * if the container has more than one child then it's a component that uses a
@@ -16,19 +35,7 @@ const createSnapshot = (component, done) => {
     expect(
       hasOneChild ? removeWrappingDiv(container) : container,
     ).toMatchSnapshot();
-
-    done();
   });
-};
-
-export const shouldMatchSnapshot = (title, component) => {
-  it(title, done => {
-    createSnapshot(component, done);
-  });
-};
-
-export const matchSnapshotAsync = (component, done) => {
-  createSnapshot(component, done);
 };
 
 export const isNull = (title, component) => {

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -3,10 +3,11 @@ import 'jest-styled-components';
 import deepClone from 'ramda/src/clone';
 import renderWithHelmet from './renderWithHelmet';
 
+// select the first child to remove the pointless wrapping div from snapshots
+const removeWrappingDiv = container => container.firstChild;
+
 export const shouldMatchSnapshot = (title, component) => {
   it(title, done => {
-    // select the first child to remove the pointless wrapping div from snapshots
-    const removeWrappingDiv = container => container.firstChild;
     renderWithHelmet(component).then(({ container }) => {
       const hasOneChild = container.children.length === 1;
       /*
@@ -23,9 +24,7 @@ export const shouldMatchSnapshot = (title, component) => {
 };
 
 export const matchSnapshotAsync = component => {
-  const removeWrappingDiv = container => container.firstChild;
   return renderWithHelmet(component).then(({ container }) => {
-    // select the first child to remove the pointless wrapping div from snapshots
     const hasOneChild = container.children.length === 1;
     /*
      * if the container has more than one child then it's a component that uses a


### PR DESCRIPTION
Follows up https://github.com/bbc/psammead/pull/2416 with changes based on the comments in https://github.com/bbc/simorgh/pull/4240#discussion_r335853599

**Overall change:** Removes `done` from `matchSnapshotAsync` and explicitly returns the contents of the function. 

**Code changes:**

- Splits out `createSnapshot` as it isn't reuse-able if `done` removed, also the `matchSnapshotAsnyc` has to be explicitly returned
- Tidies up the `matchSnapshotAsnyc` test to be more readable

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~[ ] This PR requires manual testing~
