### PR TITLE
Talos - Bump @bbc/psammead-test-helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.8.23 | [PR#2426](https://github.com/bbc/psammead/pull/2426) Talos - Bump Dependencies - @bbc/psammead-test-helpers |
 | 1.8.22 | [PR#2413](https://github.com/bbc/psammead/pull/2413) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 1.8.21 | [PR#2303](https://github.com/bbc/psammead/pull/2303) Added psammead-calendars as a dependency |
 | 1.8.20 | [PR#2401](https://github.com/bbc/psammead/pull/2401) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-storybook-helpers |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.22",
+  "version": "1.8.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1496,9 +1496,9 @@
       "dev": true
     },
     "@bbc/psammead-test-helpers": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-3.0.2.tgz",
-      "integrity": "sha512-ZXy6HGtsLx67AGlB8hUcpYv3VGgvEqoqLvw4mIX1uMzVTzToiPF7T+aeI2mKFhIUjoEQFqSQ3bn5/lJPjVI0TQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-3.1.1.tgz",
+      "integrity": "sha512-1i9r+vPp1lYvnkI+u2lEZaLJEl+zWAP6pRiLCLNG9/pXFAJXK0tBjdWsaxWxfx/JdWfjVRyOJHRvb1n1gD0sHQ==",
       "dev": true,
       "requires": {
         "jest-styled-components": "^6.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "1.8.22",
+  "version": "1.8.23",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -64,7 +64,7 @@
     "@bbc/psammead-story-promo": "2.8.0-alpha.1",
     "@bbc/psammead-storybook-helpers": "^6.0.4",
     "@bbc/psammead-styles": "^4.0.1",
-    "@bbc/psammead-test-helpers": "^3.0.2",
+    "@bbc/psammead-test-helpers": "^3.1.1",
     "@bbc/psammead-timestamp": "^2.2.12",
     "@bbc/psammead-visually-hidden-text": "^1.2.2",
     "@storybook/addon-a11y": "^5.2.2",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-test-helpers  ^3.0.2  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#2421](https://github.com/bbc/psammead/pull/2421) Removes done from `matchSnapshotAsync` and minor refactors |
| 3.1.0 | [PR#2416](https://github.com/bbc/psammead/pull/2416) Adds `matchSnapshotAsync` export |
</details>

