### PR TITLE
Fix storybook bug for Sitewide Links

### DIFF
--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.17 | [PR#2457](https://github.com/bbc/psammead/pull/2457) Fix storybook bug with links for services |
+| 3.1.17 | [PR#2457](https://github.com/bbc/psammead/pull/2457) Show relevant link text when selecting service in storybook |
 | 3.1.16 | [PR#2440](https://github.com/bbc/psammead/pull/2440) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.15 | [PR#2404](https://github.com/bbc/psammead/pull/2404) replace inputProvider and dirDecorator with withServicesInput |
 | 3.1.14 | [PR#2351](https://github.com/bbc/psammead/pull/2351) Fix styling for IE11 |

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.17 | [PR#2457](https://github.com/bbc/psammead/pull/2457) Fix storybook bug with links for services |
 | 3.1.16 | [PR#2440](https://github.com/bbc/psammead/pull/2440) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.15 | [PR#2404](https://github.com/bbc/psammead/pull/2404) replace inputProvider and dirDecorator with withServicesInput |
 | 3.1.14 | [PR#2351](https://github.com/bbc/psammead/pull/2351) Fix styling for IE11 |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "description": "React styled component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-sitewide-links/src/index.stories.jsx
+++ b/packages/components/psammead-sitewide-links/src/index.stories.jsx
@@ -10,10 +10,11 @@ const buildLink = text => ({
   href: 'https://www.bbc.co.uk/news',
 });
 
-const links = Array(7)
-  .fill()
-  .map((el, n) => `link ${n}`)
-  .map(buildLink);
+const links = (text, service) =>
+  Array(7)
+    .fill()
+    .map((el, n) => (service === 'news' ? `link ${n}` : `${text} ${n}`))
+    .map(buildLink);
 
 storiesOf('Components|SitewideLinks', module)
   .addDecorator(withKnobs)
@@ -22,7 +23,7 @@ storiesOf('Components|SitewideLinks', module)
     'default',
     ({ text, service }) => (
       <SitewideLinks
-        links={links}
+        links={links(text, service)}
         copyrightText={service === 'news' ? 'copyright text' : text}
         externalLink={buildLink(service === 'news' ? 'external link' : text)}
         service={service}


### PR DESCRIPTION
Resolves #2451 

**Overall change:** 
Previously in Storybook for the Sitewide Links component names of links were not updating for different services and stayed as "Link x". This was an issue since it is useful to see if the component is going to break with longer text or any other WS specific criteria. Now the text in links changes for different services.

Previously:
<img width="930" alt="Screenshot 2019-10-22 at 12 20 18" src="https://user-images.githubusercontent.com/17802955/67281155-b93d1200-f4c6-11e9-938d-2633e98a2f44.png">

Currently:
<img width="950" alt="Screenshot 2019-10-22 at 12 23 39" src="https://user-images.githubusercontent.com/17802955/67281195-cce87880-f4c6-11e9-9843-7219ac9872e3.png">

**Code changes:**
- Checked the current service before filling in an array with link's text.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
