### PR TITLE
Add isExternal to url link

### DIFF
--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.0.4 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Adds `isExternal` to `urlLink` |
 | 1.0.3 | [PR#2438](https://github.com/bbc/psammead/pull/2438) Fix exports resolving to `src` |
 | 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |
 | 1.0.1 | [PR#2347](https://github.com/bbc/psammead/pull/2347) Handle unsupported nodes as plain text |

--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.4 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Adds `isExternal` to `urlLink` |
+| 1.1.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Adds `isExternal` to `urlLink` |
 | 1.0.3 | [PR#2438](https://github.com/bbc/psammead/pull/2438) Fix exports resolving to `src` |
 | 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |
 | 1.0.1 | [PR#2347](https://github.com/bbc/psammead/pull/2347) Handle unsupported nodes as plain text |

--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.0.4 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Adds `isExternal` to `urlLink` |
+| 1.0.4 | [PR#2492](https://github.com/bbc/psammead/pull/2492) Adds `isExternal` to `urlLink` |
 | 1.0.3 | [PR#2438](https://github.com/bbc/psammead/pull/2438) Fix exports resolving to `src` |
 | 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |
 | 1.0.1 | [PR#2347](https://github.com/bbc/psammead/pull/2347) Handle unsupported nodes as plain text |

--- a/packages/utilities/psammead-rich-text-transforms/package-lock.json
+++ b/packages/utilities/psammead-rich-text-transforms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-rich-text-transforms/package-lock.json
+++ b/packages/utilities/psammead-rich-text-transforms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-rich-text-transforms/package.json
+++ b/packages/utilities/psammead-rich-text-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A utility library to transform to structured rich text.",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/utilities/psammead-rich-text-transforms/package.json
+++ b/packages/utilities/psammead-rich-text-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A utility library to transform to structured rich text.",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -39,7 +39,7 @@ const createUrlLink = element => {
     blocks = [fragment(text)];
   });
 
-  const isInternalRegex = /www.bbc.co(m|.uk)/;
+  const isInternalRegex = /www.bbc.(in|com|co.uk)/;
   const isExternal = !isInternalRegex.test(locator);
 
   return urlLink(text, locator, blocks, isExternal);

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -39,7 +39,10 @@ const createUrlLink = element => {
     blocks = [fragment(text)];
   });
 
-  return urlLink(text, locator, blocks);
+  const isInternalRegex = /www.bbc.co(m|.uk)/;
+  const isExternal = !isInternalRegex.test(locator);
+
+  return urlLink(text, locator, blocks, isExternal);
 };
 
 const handleSupportedNodes = (childNode, attributes, acc) => {

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -39,7 +39,7 @@ const createUrlLink = element => {
     blocks = [fragment(text)];
   });
 
-  const isInternalRegex = /bbc.(in|com|co.uk)/;
+  const isInternalRegex = /.bbc.(in|com|co.uk)/;
   const isExternal = !isInternalRegex.test(locator);
 
   return urlLink(text, locator, blocks, isExternal);

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -39,7 +39,7 @@ const createUrlLink = element => {
     blocks = [fragment(text)];
   });
 
-  const isInternalRegex = /www.bbc.(in|com|co.uk)/;
+  const isInternalRegex = /bbc.(in|com|co.uk)/;
   const isExternal = !isInternalRegex.test(locator);
 
   return urlLink(text, locator, blocks, isExternal);

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -39,7 +39,7 @@ const createUrlLink = element => {
     blocks = [fragment(text)];
   });
 
-  const isInternalRegex = /.bbc.(in|com|co.uk)/;
+  const isInternalRegex = /\.bbc\.(in|com|co\.uk)/;
   const isExternal = !isInternalRegex.test(locator);
 
   return urlLink(text, locator, blocks, isExternal);

--- a/packages/utilities/psammead-rich-text-transforms/src/models/url-link.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/models/url-link.js
@@ -1,9 +1,9 @@
 const BLOCK_NAME = 'urlLink';
 
-const urlLink = (text, locator, blocks) => {
+const urlLink = (text, locator, blocks, isExternal) => {
   return {
     type: BLOCK_NAME,
-    model: { text, locator, blocks },
+    model: { text, locator, blocks, isExternal },
   };
 };
 

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -48,6 +48,73 @@ test('can parse XML with a link', () => {
           model: {
             text: 'foo',
             locator: 'https://example.com/foo',
+            isExternal: true,
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'foo',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('can returns link with "isExternal: true" for "www.bbc.com"', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<link><caption>foo</caption><url href="https://www.bbc.com/foo"/></link>',
+    ),
+  );
+
+  expect(richText).toEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'urlLink',
+          model: {
+            text: 'foo',
+            locator: 'https://www.bbc.com/foo',
+            isExternal: false,
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'foo',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('can returns link with "isExternal: true" for "www.bbc.co.uk"', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<link><caption>foo</caption><url href="https://www.bbc.co.uk/foo"/></link>',
+    ),
+  );
+
+  expect(richText).toEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'urlLink',
+          model: {
+            text: 'foo',
+            locator: 'https://www.bbc.co.uk/foo',
+            isExternal: false,
             blocks: [
               {
                 type: 'fragment',
@@ -92,6 +159,7 @@ test('returns a plain text representation of the data', () => {
                 model: {
                   text: 'foo',
                   locator: 'https://example.com/foo',
+                  isExternal: true,
                   blocks: [
                     {
                       type: 'fragment',

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -98,6 +98,39 @@ test('can returns link with "isExternal: true" for "www.bbc.com"', () => {
   });
 });
 
+test('can returns link with "isExternal: true" for "www.bbc.in"', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<link><caption>foo</caption><url href="https://www.bbc.in/foo"/></link>',
+    ),
+  );
+
+  expect(richText).toEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'urlLink',
+          model: {
+            text: 'foo',
+            locator: 'https://www.bbc.in/foo',
+            isExternal: false,
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'foo',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
 test('can returns link with "isExternal: true" for "www.bbc.co.uk"', () => {
   const richText = candyXmlToRichText(
     createBody(

--- a/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/candy-xml.test.js
@@ -65,7 +65,7 @@ test('can parse XML with a link', () => {
   });
 });
 
-test('can returns link with "isExternal: true" for "www.bbc.com"', () => {
+test('can return a link with "isExternal: false" for "www.bbc.com"', () => {
   const richText = candyXmlToRichText(
     createBody(
       '<link><caption>foo</caption><url href="https://www.bbc.com/foo"/></link>',
@@ -98,7 +98,7 @@ test('can returns link with "isExternal: true" for "www.bbc.com"', () => {
   });
 });
 
-test('can returns link with "isExternal: true" for "www.bbc.in"', () => {
+test('can return a link with "isExternal: false" for "www.bbc.in"', () => {
   const richText = candyXmlToRichText(
     createBody(
       '<link><caption>foo</caption><url href="https://www.bbc.in/foo"/></link>',
@@ -131,7 +131,7 @@ test('can returns link with "isExternal: true" for "www.bbc.in"', () => {
   });
 });
 
-test('can returns link with "isExternal: true" for "www.bbc.co.uk"', () => {
+test('can return a link with "isExternal: false" for "www.bbc.co.uk"', () => {
   const richText = candyXmlToRichText(
     createBody(
       '<link><caption>foo</caption><url href="https://www.bbc.co.uk/foo"/></link>',
@@ -147,6 +147,39 @@ test('can returns link with "isExternal: true" for "www.bbc.co.uk"', () => {
           model: {
             text: 'foo',
             locator: 'https://www.bbc.co.uk/foo',
+            isExternal: false,
+            blocks: [
+              {
+                type: 'fragment',
+                model: {
+                  text: 'foo',
+                  attributes: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('can return a link with "isExternal: false" for "www.test.bbc.com"', () => {
+  const richText = candyXmlToRichText(
+    createBody(
+      '<link><caption>foo</caption><url href="https://www.test.bbc.com/foo"/></link>',
+    ),
+  );
+
+  expect(richText).toEqual({
+    type: 'text',
+    model: {
+      blocks: [
+        {
+          type: 'urlLink',
+          model: {
+            text: 'foo',
+            locator: 'https://www.test.bbc.com/foo',
             isExternal: false,
             blocks: [
               {

--- a/packages/utilities/psammead-rich-text-transforms/test/models/url-link.test.js
+++ b/packages/utilities/psammead-rich-text-transforms/test/models/url-link.test.js
@@ -6,14 +6,16 @@ test('returns a block from a link XML node', () => {
   const blocks = [
     { type: 'foo type', model: { text: 'foo text', attributes: [] } },
   ];
+  const isExternal = true;
 
-  const urlLinkBlock = urlLink(text, locator, blocks);
+  const urlLinkBlock = urlLink(text, locator, blocks, isExternal);
 
   expect(urlLinkBlock).toStrictEqual({
     type: 'urlLink',
     model: {
       text: 'foo text',
       locator: 'https://example.com/foo',
+      isExternal: true,
       blocks: [
         {
           type: 'foo type',


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/4405, https://github.com/bbc/simorgh/issues/4397, https://github.com/bbc/simorgh/issues/4396

**Overall change:** Adds `isExternal` to `urlLink` as it is a field that Ares appends to all `urlLink` blocks and at current is a required propType in Simorgh's `InlineLink` container. The link is considered to be internal if it is `www.bbc.com`, `www.bbc.co.uk` or `www.bbc.in`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~[ ] This PR requires manual testing~
