### PR TITLE
Swap out constructor name from if block

### DIFF
--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.1.1 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Replaces `node.constructor.name` logic as it caused a bug on client-side code execution |
 | 1.1.0 | [PR#2492](https://github.com/bbc/psammead/pull/2492) Adds `isExternal` to `urlLink` |
 | 1.0.3 | [PR#2438](https://github.com/bbc/psammead/pull/2438) Fix exports resolving to `src` |
 | 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |

--- a/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
+++ b/packages/utilities/psammead-rich-text-transforms/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.1.1 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Replaces `node.constructor.name` logic as it caused a bug on client-side code execution |
+| 1.1.1 | [PR#2495](https://github.com/bbc/psammead/pull/2495) Replaces `node.constructor.name` logic as it caused a bug on client-side code execution |
 | 1.1.0 | [PR#2492](https://github.com/bbc/psammead/pull/2492) Adds `isExternal` to `urlLink` |
 | 1.0.3 | [PR#2438](https://github.com/bbc/psammead/pull/2438) Fix exports resolving to `src` |
 | 1.0.2 | [PR#2364](https://github.com/bbc/psammead/pull/2364) Swaps `xml-js` to `xmldoc` in the hopes it reduces the install size |

--- a/packages/utilities/psammead-rich-text-transforms/package-lock.json
+++ b/packages/utilities/psammead-rich-text-transforms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-rich-text-transforms/package.json
+++ b/packages/utilities/psammead-rich-text-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-rich-text-transforms",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A utility library to transform to structured rich text.",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -65,7 +65,7 @@ const convertToBlocks = (node, attributes = []) =>
 const xmlNodeToBlock = (node, attributes) => {
   if (!is(Object, node)) return undefined;
 
-  if (node.constructor.name === 'XmlTextNode') {
+  if (path(node.text)) {
     return fragment(node.text, attributes);
   }
 
@@ -80,7 +80,7 @@ const xmlNodeToBlock = (node, attributes) => {
     return convertToBlocks(node, [...attributes, styleAttribute]);
   }
 
-  const childBlocks = convertToBlocks(node);
+  const childBlocks = convertToBlocks(node); // why isn't this 'convertToBlocks(node, attributes);' ???
 
   return {
     type: node.name,

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -9,7 +9,7 @@ const attributeTags = ['bold', 'italic'];
 const supportedXmlNodeNames = ['paragraph', 'link', 'url', ...attributeTags];
 
 const isXmlNodeSupported = node => {
-  if (path(['text'], node)) {
+  if (path(['type'], node) === 'text') {
     return true;
   }
 
@@ -68,7 +68,7 @@ const convertToBlocks = (node, attributes = []) =>
 const xmlNodeToBlock = (node, attributes) => {
   if (!is(Object, node)) return undefined;
 
-  if (path(['text'], node)) {
+  if (node.type === 'text') {
     return fragment(node.text, attributes);
   }
 

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -83,7 +83,7 @@ const xmlNodeToBlock = (node, attributes) => {
     return convertToBlocks(node, [...attributes, styleAttribute]);
   }
 
-  const childBlocks = convertToBlocks(node); // why isn't this 'convertToBlocks(node, attributes);' ???
+  const childBlocks = convertToBlocks(node);
 
   return {
     type: node.name,

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -9,7 +9,7 @@ const attributeTags = ['bold', 'italic'];
 const supportedXmlNodeNames = ['paragraph', 'link', 'url', ...attributeTags];
 
 const isXmlNodeSupported = node => {
-  if (path(['constructor', 'name'], node) === 'XmlTextNode') {
+  if (path(['text'], node)) {
     return true;
   }
 

--- a/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
+++ b/packages/utilities/psammead-rich-text-transforms/src/candy-xml.js
@@ -65,7 +65,7 @@ const convertToBlocks = (node, attributes = []) =>
 const xmlNodeToBlock = (node, attributes) => {
   if (!is(Object, node)) return undefined;
 
-  if (path(node.text)) {
+  if (path(['text'], node)) {
     return fragment(node.text, attributes);
   }
 


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/4408

**Overall change:** Swaps out the use of `node.constructor.name` for logic that checks if `node.text` exists. This is required because the constructor was being changed in the minification of out code meaning the `if()` block failed after the bundles were built, further info in the issue. 

**Code changes:**

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Automated jest tests added (for new features) or updated (for existing features)~
- ~[ ] This PR requires manual testing~ Testing will be handled in Simorgh 

# Client side render bug prior to PR 

![Client side parsing failing](https://user-images.githubusercontent.com/7791726/67566081-d0763c80-f71e-11e9-87b6-7e50ac87a691.gif)

# Client side render following this PR
![Client side parsing working](https://user-images.githubusercontent.com/7791726/67566502-d7517f00-f71f-11e9-8d6f-84872b67925f.gif)

