### PR TITLE
Make height and width optional

### DIFF
--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.2.4 | [PR#]() Make `<AmpImg />` height and width props optional |
+| 1.2.4 | [PR#2523](https://github.com/bbc/psammead/pull/2523) Make `<AmpImg />` height and width props optional |
 | 1.2.3 | [PR#2460](https://github.com/bbc/psammead/pull/2460) Fix Storybook console errors |
 | 1.2.2 | [PR#1942](https://github.com/bbc/psammead/pull/1942) Talos - Bump React to 16.9.0 |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.4 | [PR#]() Make `<AmpImg />` height and width props optional |
 | 1.2.3 | [PR#2460](https://github.com/bbc/psammead/pull/2460) Fix Storybook console errors |
 | 1.2.2 | [PR#1942](https://github.com/bbc/psammead/pull/1942) Talos - Bump React to 16.9.0 |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-image/package-lock.json
+++ b/packages/components/psammead-image/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1
 }

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-image/src/index.amp.jsx
+++ b/packages/components/psammead-image/src/index.amp.jsx
@@ -10,18 +10,20 @@ const AmpImg = props => {
 AmpImg.propTypes = {
   alt: string.isRequired,
   attribution: string,
-  height: number.isRequired,
+  height: number,
   layout: string.isRequired,
   sizes: string,
   src: string.isRequired,
   srcset: string,
-  width: number.isRequired,
+  width: number,
 };
 
 AmpImg.defaultProps = {
   attribution: '',
   sizes: null,
   srcset: null,
+  height: null,
+  width: null,
 };
 
 export default AmpImg;


### PR DESCRIPTION
Related to #2516 

**Overall change:** _Make `<AmpImg />` height and width props optional to resolve storybook and console prop-type warnings._

**Code changes:**

- _Make height and width props optional._
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
