### PR TITLE
Talos - Bump @bbc/psammead-play-button

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.1.3 | [PR#2542](https://github.com/bbc/psammead/pull/2542) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.1.2 | [PR#2467](https://github.com/bbc/psammead/pull/2476) Update image `alt` to be empty for Media Player placeholder |
 | 2.1.1 | [PR#2532](https://github.com/bbc/psammead/pull/2532) Rename "Media Player" story to "MediaPlayer"
 | 2.1.0 | [PR#2424](https://github.com/bbc/psammead/pull/2424) Add srcset to placeholder image

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.4.0.tgz",
-      "integrity": "sha512-WuewciWzvSb/WKhUGSvIoighqCdXGN2PsVQbZbUo5/eWi5+o3O8uoojUpeQeRZMYWLsLVELPHr6qJDuqKghXKA=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.4.1.tgz",
+      "integrity": "sha512-twwL0UcFrvq9w3O92PvkJRo+wThLqWLrxgFxxn8kwR1pni1wS6lhr3IwUPym4juS2hlTy/5C0/QiycB05IQhLg=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.4.1.tgz",
-      "integrity": "sha512-ARJodaVdDkRUTf5FmK34J/FbpstPiQl6innPsaUKxQ6YiLWm9uzhywJNpH6yRYAPkjpG0bfkXLNfVftr/S9Zew=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.7.0.tgz",
+      "integrity": "sha512-6LLWU6uCqEDPrjlXZzqFFxx9wIDfkMQ8KddNub/OqHcEISi34jcD3T1PQIfSTUFbH/lHIQWx/eI/ZPntGBnzSQ=="
     },
     "@bbc/psammead-image": {
       "version": "1.2.3",
@@ -20,19 +20,19 @@
       "integrity": "sha512-gGkkAarnDBvm2j2aI9QRhU+b5tqx8F539LqGlogA6PlKI6jyqxG2OYViv1VHEw2DvXILccBgzfiU3OFn/R1foQ=="
     },
     "@bbc/psammead-play-button": {
-      "version": "1.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-play-button/-/psammead-play-button-1.0.0-alpha.0.tgz",
-      "integrity": "sha512-G1gy1hwnVyinGnO5Z6KjCRjT/8N6zqJVciDeFsqX8CoR9M4zVS6qfNacacCXo5y/BHP3rfH19do3ObKdQ0bX4w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-play-button/-/psammead-play-button-1.0.0.tgz",
+      "integrity": "sha512-xoBr+l/fijNKE0cZK4TFsbyJmwq2N9o1zy/qOqgx+V+KR59HUbPfmEaBPzoFbgufYSC5mHWeyYf6IHezOoNh8w==",
       "requires": {
-        "@bbc/gel-foundations": "^3.4.0",
-        "@bbc/psammead-assets": "^2.4.1",
-        "@bbc/psammead-styles": "^2.3.0"
+        "@bbc/gel-foundations": "^3.4.1",
+        "@bbc/psammead-assets": "^2.7.0",
+        "@bbc/psammead-styles": "^4.1.0"
       }
     },
     "@bbc/psammead-styles": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-2.3.0.tgz",
-      "integrity": "sha512-m8BwXTRDTVOZ0pO1KDSJ5mXOn+0rgkx6eNbLsspLX2u/UX8xAlTGLn61ua9HRDKTZ/yHnxIQnD8PKghStH3aPA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.1.0.tgz",
+      "integrity": "sha512-i9fAfK8zRubcOoMMU5o/WuY5dvtIuSEjr6VxlhGfb9OFII1FjVjj+4eW/iL2Kl5a0DqbM0ob5sBTum3pQ/Uc6w=="
     }
   }
 }

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@bbc/psammead-image": "^1.2.3",
-    "@bbc/psammead-play-button": "^1.0.0-alpha.0"
+    "@bbc/psammead-play-button": "^1.0.0"
   }
 }


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead-media-player

<details>
<summary>Details</summary>
@bbc/psammead-play-button  ^1.0.0-alpha.0  →  ^1.0.0

| Version | Description |
| ------------- | ----------- |
| 1.0.0 | [PR#2522](https://github.com/bbc/psammead/issues/2522) Remove alpha tag. |
| 1.0.0-alpha.10 | [PR#2533](https://github.com/bbc/psammead/pull/2533) Talos - Bump Dependencies - @bbc/psammead-assets |
| 1.0.0-alpha.9 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
| 1.0.0-alpha.8 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |
| 1.0.0-alpha.7 | [PR#2486](https://github.com/bbc/psammead/pull/2486) Talos - Bump Dependencies - @bbc/psammead-assets |
| 1.0.0-alpha.6 | [PR#2477](https://github.com/bbc/psammead/pull/2477) Talos - Bump Dependencies - @bbc/psammead-styles |
| 1.0.0-alpha.5 | [PR#2440](https://github.com/bbc/psammead/pull/2440) Talos - Bump Dependencies - @bbc/psammead-styles |
| 1.0.0-alpha.4 | [PR#2404](https://github.com/bbc/psammead/pull/2404) replace inputProvider and dirDecorator with withServicesInput |
| 1.0.0-alpha.3 | [PR#2401](https://github.com/bbc/psammead/pull/2401) Talos - Bump Dependencies - @bbc/psammead-assets |
| 1.0.0-alpha.2 | [PR#2380](https://github.com/bbc/psammead/pull/2380) Talos - Bump Dependencies - @bbc/psammead-styles |
| 1.0.0-alpha.1 | [PR#2318](https://github.com/bbc/psammead/pull/2318) Update snapshot. |
</details>

