### PR TITLE
Add navigation icons to psammead-assets

### DIFF
--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.8.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Added hamburger and cross icons for Navigation |
 | 2.7.0 | [PR#2531](https://github.com/bbc/psammead/pull/2531) Added Guidance icon |
 | 2.6.0 | [PR#2433](https://github.com/bbc/psammead/pull/2433) Add AMP js script boilerplate to psammead-assets. |
 | 2.5.0 | [PR#2309](https://github.com/bbc/psammead/pull/2309) Add SVGs for Weather, Cymru Fyw and Naidheachdan |

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.8.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Added hamburger and cross icons for Navigation |
+| 2.8.0 | [PR#2581](https://github.com/bbc/psammead/pull/2581) Added hamburger and cross icons for Navigation |
 | 2.7.0 | [PR#2531](https://github.com/bbc/psammead/pull/2531) Added Guidance icon |
 | 2.6.0 | [PR#2433](https://github.com/bbc/psammead/pull/2433) Add AMP js script boilerplate to psammead-assets. |
 | 2.5.0 | [PR#2309](https://github.com/bbc/psammead/pull/2309) Add SVGs for Weather, Cymru Fyw and Naidheachdan |

--- a/packages/utilities/psammead-assets/README.md
+++ b/packages/utilities/psammead-assets/README.md
@@ -58,6 +58,20 @@ import { mediaIcons } from '@bbc/psammead-assets/svgs';
 </span>
 ```
 
+## Navigation Icons SVGs
+
+Navigation icons is an object containing styled SVG icons for hamburger and cross. They are used in `psammead-navigation` component.
+
+## Usage
+
+```jsx
+import { navigationIcons } from '@bbc/psammead-assets/svgs';
+
+<span>
+  {navigationIcons.cross}
+</span>
+```
+
 ## Contributing
 
 When **adding** a new export to this utility package the [export tests](https://github.com/bbc/psammead/blob/5d7395fd60bd8d73796d5a23775b4b5b36db1445/packages/utilities/psammead-assets/index.test.jsx#L11-L18) also need to be updated. When **removing** an exisiting export from this utility package the [export tests](https://github.com/bbc/psammead/blob/5d7395fd60bd8d73796d5a23775b4b5b36db1445/packages/utilities/psammead-assets/index.test.jsx#L11-L18) need to be updated and the package version requires a major change (EG: 1.2.1 -> 2.0.0) as this would be considered a breaking change due to functionality being removed.

--- a/packages/utilities/psammead-assets/index.test.jsx
+++ b/packages/utilities/psammead-assets/index.test.jsx
@@ -12,6 +12,7 @@ const ampBoilerplateExpectedExports = {
 const svgsExpectedExports = {
   BBC_BLOCKS: 'string',
   mediaIcons: 'object',
+  navigationIcons: 'object',
   afaanoromoo: 'object',
   afrique: 'object',
   amharic: 'object',

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {

--- a/packages/utilities/psammead-assets/src/svgs.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.jsx
@@ -1,5 +1,6 @@
 export BBC_BLOCKS from './svgs/bbcBlocks';
 export mediaIcons from './svgs/mediaIcons';
+export navigationIcons from './svgs/navigationIcons';
 export afaanoromoo from './svgs/afaanoromoo';
 export afrique from './svgs/afrique';
 export amharic from './svgs/amharic';

--- a/packages/utilities/psammead-assets/src/svgs.stories.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.stories.jsx
@@ -6,7 +6,7 @@ import { number as numberKnob, withKnobs } from '@storybook/addon-knobs';
 import notes from '../README.md';
 import * as allSvgs from './svgs';
 
-const { mediaIcons, ...svgs } = allSvgs;
+const { mediaIcons, navigationIcons, ...svgs } = allSvgs;
 
 // `currentColor` has been used to address high contrast mode in Firefox.
 const Svg = styled.svg`
@@ -81,6 +81,21 @@ const mediaIconStories = storiesOf(
   module,
 ).addDecorator(withKnobs);
 
+const navigationIconsStories = storiesOf(
+  'Utilities|SVGs/NavigationIcons Svgs',
+  module,
+).addDecorator(withKnobs);
+
 Object.keys(mediaIcons).forEach(iconName => {
   mediaIconStories.add(iconName, () => mediaIcons[iconName], { notes });
+});
+
+Object.keys(navigationIcons).forEach(iconName => {
+  navigationIconsStories.add(
+    iconName,
+    () => <Container> {navigationIcons[iconName]} </Container>,
+    {
+      notes,
+    },
+  );
 });

--- a/packages/utilities/psammead-assets/src/svgs.test.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.test.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import * as svgs from './svgs';
 
+const svgExceptions = ['BBC_BLOCKS', 'mediaIcons', 'navigationIcons'];
+
 Object.keys(svgs)
-  .filter(svgName => svgName !== 'BBC_BLOCKS' && svgName !== 'mediaIcons')
+  .filter(svgName => !svgExceptions.includes(svgName))
   .forEach(svgName => {
     describe(`${svgName} SVG`, () => {
       shouldMatchSnapshot(

--- a/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
@@ -13,7 +13,7 @@ const navigationIcons = {
     </MenuIcon>
   ),
   cross: (
-    <MenuIcon width={44} height={44}>
+    <MenuIcon width="44px" height="44px">
       <path
         d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
         fillRule="evenodd"

--- a/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
@@ -1,22 +1,28 @@
 import React from 'react';
+import styled from 'styled-components';
+
+const MenuIcon = styled.svg`
+  color: #fff;
+  fill: currentColor;
+`;
 
 const navigationIcons = {
   hamburger: (
-    <svg width={44} height={44}>
+    <MenuIcon width={44} height={44}>
       <path
         d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
-        fill="#FFF"
+        fill="currentColor"
       />
-    </svg>
+    </MenuIcon>
   ),
   cross: (
-    <svg width={44} height={44}>
+    <MenuIcon width={44} height={44}>
       <path
-        fill="#FFF"
+        fill="currentColor"
         d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
         fillRule="evenodd"
       />
-    </svg>
+    </MenuIcon>
   ),
 };
 

--- a/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
@@ -9,16 +9,12 @@ const MenuIcon = styled.svg`
 const navigationIcons = {
   hamburger: (
     <MenuIcon width={44} height={44}>
-      <path
-        d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
-        fill="currentColor"
-      />
+      <path d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z" />
     </MenuIcon>
   ),
   cross: (
     <MenuIcon width={44} height={44}>
       <path
-        fill="currentColor"
         d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
         fillRule="evenodd"
       />

--- a/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const navigationIcons = {
+  hamburger: (
+    <svg width={44} height={44}>
+      <path
+        d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
+        fill="#FFF"
+      />
+    </svg>
+  ),
+  cross: (
+    <svg width={44} height={44}>
+      <path
+        fill="#FFF"
+        d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
+        fillRule="evenodd"
+      />
+    </svg>
+  ),
+};
+
+export default navigationIcons;

--- a/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/navigationIcons.jsx
@@ -8,7 +8,7 @@ const MenuIcon = styled.svg`
 
 const navigationIcons = {
   hamburger: (
-    <MenuIcon width={44} height={44}>
+    <MenuIcon width="44px" height="44px">
       <path d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z" />
     </MenuIcon>
   ),


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Added hamburger and cross icons which will be used in new Navigation Iteration.

**Code changes:**
- Added svgs for hamburger and cross icons
- Added stories for navigation icons

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
