### PR TITLE
Add a notice to Media Player for browsers with JavaScript disabled

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.3.0 | [PR#2623](https://github.com/bbc/psammead/pull/2623) Add a no-JS fallback to CanonicalMediaPlayer |
 | 2.2.4 | [PR#2615](https://github.com/bbc/psammead/pull/2615) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-image |
 | 2.2.3 | [PR#2578](https://github.com/bbc/psammead/pull/2578) Fix HCM for guidance background colour on windows |
 | 2.2.2 | [PR#2493](https://github.com/bbc/psammead/pull/2493) Show media player placeholder while loading on canonical |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
**Overall change:** Add a notice to Media Player indicating to users that JavaScript is required for playback.

**Code changes:**

- 

**No-JS development approach:**
- Move Psammead Media Player into Simorgh.
- Update MediaPlayerContainer to import the local component.
- Use `npm run dev` (within Simorgh), with JS in the browser disabled.
- When component is ready, move it back into Psammead.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
