### PR TITLE
Fix TopStoryPromo Image and Summary width

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 3.0.0-alpha.7 | [PR#2626](https://github.com/bbc/psammead/pull/2626) Increase image and summary width of top story at 1008px+ |
+| 3.0.0-alpha.7 | [PR#2626](https://github.com/bbc/psammead/pull/2626) Increase image and summary width of top story at 1008px+ for grid fallbacks |
 | 3.0.0-alpha.6 | [PR#2397](https://github.com/bbc/psammead/pull/2397) Add a `displayImage` prop to render story promo without an image |
 | 3.0.0-alpha.5 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0-alpha.4 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 3.0.0-alpha.7 | [PR#]() Increase image and summary width of top story at 1008px+ |
 | 3.0.0-alpha.6 | [PR#2397](https://github.com/bbc/psammead/pull/2397) Add a `displayImage` prop to render story promo without an image |
 | 3.0.0-alpha.5 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0-alpha.4 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 3.0.0-alpha.7 | [PR#]() Increase image and summary width of top story at 1008px+ |
+| 3.0.0-alpha.7 | [PR#2626](https://github.com/bbc/psammead/pull/2626) Increase image and summary width of top story at 1008px+ |
 | 3.0.0-alpha.6 | [PR#2397](https://github.com/bbc/psammead/pull/2397) Add a `displayImage` prop to render story promo without an image |
 | 3.0.0-alpha.5 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0-alpha.4 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -88,9 +88,9 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c1 {
-    width: 33.33%;
+    width: 50%;
   }
 }
 
@@ -109,9 +109,9 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c3 {
-    width: 66.67%;
+    width: 50%;
   }
 }
 
@@ -600,9 +600,9 @@ exports[`StoryPromo - Top Story should render with Media Indicator correctly 1`]
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c1 {
-    width: 33.33%;
+    width: 50%;
   }
 }
 
@@ -621,9 +621,9 @@ exports[`StoryPromo - Top Story should render with Media Indicator correctly 1`]
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c8 {
-    width: 66.67%;
+    width: 50%;
   }
 }
 
@@ -908,9 +908,9 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c1 {
-    width: 33.33%;
+    width: 50%;
   }
 }
 
@@ -929,9 +929,9 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c3 {
-    width: 66.67%;
+    width: 50%;
   }
 }
 
@@ -1271,9 +1271,9 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c1 {
-    width: 33.33%;
+    width: 50%;
   }
 }
 
@@ -1292,9 +1292,9 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
   }
 }
 
-@media (min-width:80rem) {
+@media (min-width:63rem) {
   .c3 {
-    width: 66.67%;
+    width: 50%;
   }
 }
 

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -83,14 +83,14 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width:63rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
   }
 }
 
@@ -595,14 +595,14 @@ exports[`StoryPromo - Top Story should render with Media Indicator correctly 1`]
 
 @media (min-width:37.5rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width:63rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
   }
 }
 
@@ -903,14 +903,14 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
 
 @media (min-width:37.5rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width:63rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
   }
 }
 
@@ -1266,14 +1266,14 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
 
 @media (min-width:37.5rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width:63rem) {
   .c1 {
-    width: 50%;
+    width: calc(50% - 0.5rem);
   }
 }
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -45,6 +45,10 @@ const fullWidthColumnsMaxScaleable = `100%`;
 
 const halfWidthColumnsMaxScaleable = `50%`;
 
+const gridFallbackImageWidth = css`
+  width: calc(${halfWidthColumnsMaxScaleable} - ${GEL_SPACING});
+`;
+
 const StoryPromoWrapper = styled.div`
   position: relative;
 
@@ -89,12 +93,12 @@ const ImageGridFallbackTopStory = css`
   width: ${fullWidthColumnsMaxScaleable};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    width: calc(${halfWidthColumnsMaxScaleable} - ${GEL_SPACING});
+    ${gridFallbackImageWidth};
     margin-bottom: 0;
   }
 
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    width: calc(${halfWidthColumnsMaxScaleable} - ${GEL_SPACING});
+    ${gridFallbackImageWidth};
   }
 `;
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -89,12 +89,12 @@ const ImageGridFallbackTopStory = css`
   width: ${fullWidthColumnsMaxScaleable};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    width: ${halfWidthColumnsMaxScaleable};
+    width: calc(${halfWidthColumnsMaxScaleable} - ${GEL_SPACING});
     margin-bottom: 0;
   }
 
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    width: ${halfWidthColumnsMaxScaleable};
+    width: calc(${halfWidthColumnsMaxScaleable} - ${GEL_SPACING});
   }
 `;
 

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -37,14 +37,8 @@ import { grid } from '@bbc/psammead-styles/detection';
 const twoOfSixColumnsMaxWidthScaleable = `33.33%`;
 // (2 / 6) * 100 = 0.3333333333 = 33.33%
 
-// const fourOfTwelveColumnsMaxWidthScaleable = `33.33%`;
-// (4 / 12) * 100 = 0.3333333333 = 33.33%
-
 const fourOfSixColumnsMaxWidthScaleable = `66.67%`;
 // (4 / 6) * 100 = 66.6666666667 = 66.67%
-
-// const eightOfTwelveColumnsMaxScaleable = `66.67%`;
-// (8 / 12) * 100 = 66.6666666667 = 66.67%
 
 const fullWidthColumnsMaxScaleable = `100%`;
 // (12 / 12) * 100 = 100 = 100%

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -37,13 +37,13 @@ import { grid } from '@bbc/psammead-styles/detection';
 const twoOfSixColumnsMaxWidthScaleable = `33.33%`;
 // (2 / 6) * 100 = 0.3333333333 = 33.33%
 
-const fourOfTwelveColumnsMaxWidthScaleable = `33.33%`;
+// const fourOfTwelveColumnsMaxWidthScaleable = `33.33%`;
 // (4 / 12) * 100 = 0.3333333333 = 33.33%
 
 const fourOfSixColumnsMaxWidthScaleable = `66.67%`;
 // (4 / 6) * 100 = 66.6666666667 = 66.67%
 
-const eightOfTwelveColumnsMaxScaleable = `66.67%`;
+// const eightOfTwelveColumnsMaxScaleable = `66.67%`;
 // (8 / 12) * 100 = 66.6666666667 = 66.67%
 
 const fullWidthColumnsMaxScaleable = `100%`;
@@ -99,8 +99,8 @@ const ImageGridFallbackTopStory = css`
     margin-bottom: 0;
   }
 
-  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    width: ${fourOfTwelveColumnsMaxWidthScaleable};
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    width: ${halfWidthColumnsMaxScaleable};
   }
 `;
 
@@ -177,8 +177,8 @@ const TextGridFallbackTopStory = css`
     padding: 0 ${GEL_SPACING_DBL};
   }
 
-  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    width: ${eightOfTwelveColumnsMaxScaleable};
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    width: ${halfWidthColumnsMaxScaleable};
   }
 `;
 


### PR DESCRIPTION
Resolves #2605

**Overall change:** _Fix TopStoryPromo Image and Summary width in IE11._

**Code changes:**

- _Increase width TopStoryPromo image and summary in fallback styling._
- _Update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
