### PR TITLE
Add AMP_BIND, AMP_ACCESS, AMP_LIST, AMP_MUSTACHE scripts to amp-boilerplate exports

### DIFF
--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.9.0 | [PR#2631](https://github.com/bbc/psammead/pull/2631) Add AMP_BIND, AMP_LIST, AMP_MUSTACHE scripts to amp-boilerplate exports |
+| 2.10.0 | [PR#2631](https://github.com/bbc/psammead/pull/2631) Add AMP_BIND, AMP_LIST, AMP_MUSTACHE scripts to amp-boilerplate exports |
 | 2.8.0 | [PR#2581](https://github.com/bbc/psammead/pull/2581) Added hamburger and cross icons for Navigation |
 | 2.7.0 | [PR#2531](https://github.com/bbc/psammead/pull/2531) Added Guidance icon |
 | 2.6.0 | [PR#2433](https://github.com/bbc/psammead/pull/2433) Add AMP js script boilerplate to psammead-assets. |

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.9.0 | [PR#2631](https://github.com/bbc/psammead/pull/2631) Add AMP_BIND, AMP_LIST, AMP_MUSTACHE scripts to amp-boilerplate exports |
 | 2.8.0 | [PR#2581](https://github.com/bbc/psammead/pull/2581) Added hamburger and cross icons for Navigation |
 | 2.7.0 | [PR#2531](https://github.com/bbc/psammead/pull/2531) Added Guidance icon |
 | 2.6.0 | [PR#2433](https://github.com/bbc/psammead/pull/2433) Add AMP js script boilerplate to psammead-assets. |

--- a/packages/utilities/psammead-assets/index.test.jsx
+++ b/packages/utilities/psammead-assets/index.test.jsx
@@ -7,6 +7,9 @@ const ampBoilerplateExpectedExports = {
   AMP_GEO_JS: 'object',
   AMP_CONSENT_JS: 'object',
   AMP_ANALYTICS_JS: 'object',
+  AMP_BIND: 'object',
+  AMP_LIST: 'object',
+  AMP_MUSTACHE: 'object',
 };
 
 const svgsExpectedExports = {

--- a/packages/utilities/psammead-assets/index.test.jsx
+++ b/packages/utilities/psammead-assets/index.test.jsx
@@ -3,13 +3,14 @@ import { testUtilityPackages } from '@bbc/psammead-test-helpers';
 const ampBoilerplateExpectedExports = {
   AMP_SCRIPT: 'string',
   AMP_NO_SCRIPT: 'string',
-  AMP_JS: 'object',
-  AMP_GEO_JS: 'object',
-  AMP_CONSENT_JS: 'object',
+  AMP_ACCESS_JS: 'object',
   AMP_ANALYTICS_JS: 'object',
-  AMP_BIND: 'object',
-  AMP_LIST: 'object',
-  AMP_MUSTACHE: 'object',
+  AMP_BIND_JS: 'object',
+  AMP_CONSENT_JS: 'object',
+  AMP_GEO_JS: 'object',
+  AMP_JS: 'object',
+  AMP_LIST_JS: 'object',
+  AMP_MUSTACHE_JS: 'object',
 };
 
 const svgsExpectedExports = {

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {

--- a/packages/utilities/psammead-assets/src/__snapshots__/amp-boilerplate.test.jsx.snap
+++ b/packages/utilities/psammead-assets/src/__snapshots__/amp-boilerplate.test.jsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AMP Boilerplate JavaScript should render AMP Access JS 1`] = `
+<script
+  async=""
+  custom-element="amp-access"
+  src="https://cdn.ampproject.org/v0/amp-access-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP Analytics JS 1`] = `
+<script
+  async=""
+  custom-element="amp-analytics"
+  src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP Bind JS 1`] = `
+<script
+  async=""
+  custom-element="amp-bind"
+  src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP Consent JS 1`] = `
+<script
+  async=""
+  custom-element="amp-consent"
+  src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP Geo JS 1`] = `
+<script
+  async=""
+  custom-element="amp-geo"
+  src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP JS 1`] = `
+<script
+  async=""
+  src="https://cdn.ampproject.org/v0.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP List JS 1`] = `
+<script
+  async=""
+  custom-element="amp-list"
+  src="https://cdn.ampproject.org/v0/amp-list-0.1.js"
+/>
+`;
+
+exports[`AMP Boilerplate JavaScript should render AMP Mustache JS 1`] = `
+<script
+  async=""
+  custom-template="amp-mustache"
+  src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"
+/>
+`;
+
+exports[`AMP Boilerplate styles should render AMP NoScript 1`] = `
+<div>
+  body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}
+</div>
+`;
+
+exports[`AMP Boilerplate styles should render AMP Script 1`] = `
+<div>
+  body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}
+</div>
+`;

--- a/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
+++ b/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
@@ -7,18 +7,12 @@ export const AMP_SCRIPT = `body{-webkit-animation:-amp-start 8s steps(1,end) 0s 
 export const AMP_NO_SCRIPT = `body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}`;
 
 export const AMP_JS = <script async src="https://cdn.ampproject.org/v0.js" />;
-export const AMP_GEO_JS = (
+
+export const AMP_ACCESS_JS = (
   <script
     async
-    custom-element="amp-geo"
-    src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"
-  />
-);
-export const AMP_CONSENT_JS = (
-  <script
-    async
-    custom-element="amp-consent"
-    src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"
+    custom-element="amp-access"
+    src="https://cdn.ampproject.org/v0/amp-access-0.1.js"
   />
 );
 export const AMP_ANALYTICS_JS = (
@@ -28,21 +22,35 @@ export const AMP_ANALYTICS_JS = (
     src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
   />
 );
-export const AMP_BIND = (
+export const AMP_BIND_JS = (
   <script
     async
     custom-element="amp-bind"
     src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
   />
 );
-export const AMP_LIST = (
+export const AMP_CONSENT_JS = (
+  <script
+    async
+    custom-element="amp-consent"
+    src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"
+  />
+);
+export const AMP_GEO_JS = (
+  <script
+    async
+    custom-element="amp-geo"
+    src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"
+  />
+);
+export const AMP_LIST_JS = (
   <script
     async
     custom-element="amp-list"
     src="https://cdn.ampproject.org/v0/amp-list-0.1.js"
   />
 );
-export const AMP_MUSTACHE = (
+export const AMP_MUSTACHE_JS = (
   <script
     async
     custom-template="amp-mustache"

--- a/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
+++ b/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
@@ -28,3 +28,24 @@ export const AMP_ANALYTICS_JS = (
     src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
   />
 );
+export const AMP_BIND = (
+  <script
+    async
+    custom-element="amp-bind"
+    src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
+  />
+);
+export const AMP_LIST = (
+  <script
+    async
+    custom-element="amp-list"
+    src="https://cdn.ampproject.org/v0/amp-list-0.1.js"
+  />
+);
+export const AMP_MUSTACHE = (
+  <script
+    async
+    custom-template="amp-mustache"
+    src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"
+  />
+);

--- a/packages/utilities/psammead-assets/src/amp-boilerplate.test.jsx
+++ b/packages/utilities/psammead-assets/src/amp-boilerplate.test.jsx
@@ -1,0 +1,34 @@
+import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import * as boilerplate from './amp-boilerplate';
+
+describe('AMP Boilerplate', () => {
+  describe('styles', () => {
+    shouldMatchSnapshot('should render AMP Script', boilerplate.AMP_SCRIPT);
+    shouldMatchSnapshot(
+      'should render AMP NoScript',
+      boilerplate.AMP_NO_SCRIPT,
+    );
+  });
+  describe('JavaScript', () => {
+    shouldMatchSnapshot(
+      'should render AMP Access JS',
+      boilerplate.AMP_ACCESS_JS,
+    );
+    shouldMatchSnapshot(
+      'should render AMP Analytics JS',
+      boilerplate.AMP_ANALYTICS_JS,
+    );
+    shouldMatchSnapshot('should render AMP Bind JS', boilerplate.AMP_BIND_JS);
+    shouldMatchSnapshot(
+      'should render AMP Consent JS',
+      boilerplate.AMP_CONSENT_JS,
+    );
+    shouldMatchSnapshot('should render AMP Geo JS', boilerplate.AMP_GEO_JS);
+    shouldMatchSnapshot('should render AMP JS', boilerplate.AMP_JS);
+    shouldMatchSnapshot('should render AMP List JS', boilerplate.AMP_LIST_JS);
+    shouldMatchSnapshot(
+      'should render AMP Mustache JS',
+      boilerplate.AMP_MUSTACHE_JS,
+    );
+  });
+});


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/4586

**Overall change:** Adds three new AMP scripts so they're available to be used for containers within Simorgh. The AMP Access, Bind, List and Mustache scripts will be needed for data fetching at the container level within AMP pages. 

**Code changes:**

- Add scripts from 
https://amp.dev/documentation/components/amp-access/ 
https://amp.dev/documentation/components/amp-bind/ 
https://amp.dev/documentation/components/amp-list/ 
https://amp.dev/documentation/components/amp-mustache/
- Added unit tests (snapshots) for all amp-boilerplate exports. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
