### PR TITLE
Add Core icons (Alert and Info) to Psammead Assets

### DIFF
--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.9.0 | [PR#2641](https://github.com/bbc/psammead/pull/2641) Add Core icons group with Alert and Info icons |
 | 2.8.0 | [PR#2581](https://github.com/bbc/psammead/pull/2581) Added hamburger and cross icons for Navigation |
 | 2.7.0 | [PR#2531](https://github.com/bbc/psammead/pull/2531) Added Guidance icon |
 | 2.6.0 | [PR#2433](https://github.com/bbc/psammead/pull/2433) Add AMP js script boilerplate to psammead-assets. |

--- a/packages/utilities/psammead-assets/README.md
+++ b/packages/utilities/psammead-assets/README.md
@@ -43,6 +43,17 @@ const WrappingContainer = () => (
 );
 ```
 
+## Core Icons SVGs
+
+Core icons is an object containing styled SVG icons from GEL Iconography Core. By default Core icons are sized to work well alongside text from the `GEL BodyCopy` typography group, but can be sized differently within the component they're being used if necessary.
+
+### Usage
+```jsx
+import { coreIcons } from '@bbc/psammead-assets/svgs';
+
+<p>{coreIcons.info} Did you know, in Switzerland it's illegal to own just one guinea pig?</p>
+```
+
 ## Media Icons SVGs
 
 Media icons is an object containing styled SVG icons for video, audio and photogallery. Media icons are sized to work well alongside specific text with typography group `GEL Minion`. They are used in `psammead-media-indicator` component.

--- a/packages/utilities/psammead-assets/README.md
+++ b/packages/utilities/psammead-assets/README.md
@@ -45,7 +45,7 @@ const WrappingContainer = () => (
 
 ## Core Icons SVGs
 
-Core icons is an object containing styled SVG icons from GEL Iconography Core. By default Core icons are sized to work well alongside text from the `GEL BodyCopy` typography group, but can be sized differently within the component they're being used if necessary.
+Core icons is an object containing styled SVG icons from GEL Iconography Core. By default Core icons are sized to work well alongside text from the `GEL BodyCopy` typography group.
 
 ### Usage
 ```jsx

--- a/packages/utilities/psammead-assets/README.md
+++ b/packages/utilities/psammead-assets/README.md
@@ -35,7 +35,7 @@ This package currently has brand SVGs for the BBC News World Services as well as
 
 The width of your SVG can be calculated using your desired height multiplied by the `ratio` value provided above.
 
-## Usage
+### Usage
 
 ```jsx
 const WrappingContainer = () => (
@@ -58,7 +58,7 @@ import { coreIcons } from '@bbc/psammead-assets/svgs';
 
 Media icons is an object containing styled SVG icons for video, audio and photogallery. Media icons are sized to work well alongside specific text with typography group `GEL Minion`. They are used in `psammead-media-indicator` component.
 
-## Usage
+### Usage
 
 ```jsx
 import { mediaIcons } from '@bbc/psammead-assets/svgs';
@@ -73,7 +73,7 @@ import { mediaIcons } from '@bbc/psammead-assets/svgs';
 
 Navigation icons is an object containing styled SVG icons for hamburger and cross. They are used in `psammead-navigation` component.
 
-## Usage
+### Usage
 
 ```jsx
 import { navigationIcons } from '@bbc/psammead-assets/svgs';

--- a/packages/utilities/psammead-assets/index.test.jsx
+++ b/packages/utilities/psammead-assets/index.test.jsx
@@ -11,6 +11,7 @@ const ampBoilerplateExpectedExports = {
 
 const svgsExpectedExports = {
   BBC_BLOCKS: 'string',
+  coreIcons: 'object',
   mediaIcons: 'object',
   navigationIcons: 'object',
   afaanoromoo: 'object',

--- a/packages/utilities/psammead-assets/package-lock.json
+++ b/packages/utilities/psammead-assets/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {

--- a/packages/utilities/psammead-assets/src/svgs.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.jsx
@@ -1,4 +1,5 @@
 export BBC_BLOCKS from './svgs/bbcBlocks';
+export coreIcons from './svgs/coreIcons';
 export mediaIcons from './svgs/mediaIcons';
 export navigationIcons from './svgs/navigationIcons';
 export afaanoromoo from './svgs/afaanoromoo';

--- a/packages/utilities/psammead-assets/src/svgs.stories.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.stories.jsx
@@ -6,7 +6,7 @@ import { number as numberKnob, withKnobs } from '@storybook/addon-knobs';
 import notes from '../README.md';
 import * as allSvgs from './svgs';
 
-const { mediaIcons, navigationIcons, ...svgs } = allSvgs;
+const { coreIcons, mediaIcons, navigationIcons, ...svgs } = allSvgs;
 
 // `currentColor` has been used to address high contrast mode in Firefox.
 const Svg = styled.svg`
@@ -76,6 +76,11 @@ Object.keys(svgs)
     );
   });
 
+const coreIconStories = storiesOf(
+  'Utilities|SVGs/CoreIcons Svgs',
+  module,
+).addDecorator(withKnobs);
+
 const mediaIconStories = storiesOf(
   'Utilities|SVGs/MediaIcons Svgs',
   module,
@@ -85,6 +90,10 @@ const navigationIconsStories = storiesOf(
   'Utilities|SVGs/NavigationIcons Svgs',
   module,
 ).addDecorator(withKnobs);
+
+Object.keys(coreIcons).forEach(iconName => {
+  coreIconStories.add(iconName, () => coreIcons[iconName], { notes });
+});
 
 Object.keys(mediaIcons).forEach(iconName => {
   mediaIconStories.add(iconName, () => mediaIcons[iconName], { notes });

--- a/packages/utilities/psammead-assets/src/svgs.test.jsx
+++ b/packages/utilities/psammead-assets/src/svgs.test.jsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import * as svgs from './svgs';
 
-const svgExceptions = ['BBC_BLOCKS', 'mediaIcons', 'navigationIcons'];
+const svgExceptions = [
+  'BBC_BLOCKS',
+  'coreIcons',
+  'mediaIcons',
+  'navigationIcons',
+];
 
 Object.keys(svgs)
   .filter(svgName => !svgExceptions.includes(svgName))

--- a/packages/utilities/psammead-assets/src/svgs/coreIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/coreIcons.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { C_EBON } from '@bbc/psammead-styles/colours';
+import {
+  GEL_SPACING_HLF,
+  GEL_SPACING_DBL,
+} from '@bbc/gel-foundations/spacings';
+
+// `currentColor` has been used to better reflect user colour choices in Firefox.
+const CoreIcon = styled.svg`
+  vertical-align: middle;
+  margin: 0 ${GEL_SPACING_HLF};
+  color: ${C_EBON};
+  fill: currentColor;
+`;
+
+const AlertCoreIcon = styled(CoreIcon)`
+  height: ${GEL_SPACING_DBL};
+  width: ${GEL_SPACING_DBL};
+`;
+
+const InfoCoreIcon = styled(CoreIcon)`
+  width: ${GEL_SPACING_DBL};
+  height: ${GEL_SPACING_DBL};
+`;
+
+const CoreIcons = {
+  alert: (
+    <AlertCoreIcon
+      viewBox="0 0 32 32"
+      width="32px"
+      height="32px"
+      focusable="false"
+    >
+      <path d="M16 2L0 30h32zm2 25h-4v-4h4zm-4-6V11h4v10z" />
+    </AlertCoreIcon>
+  ),
+  info: (
+    <InfoCoreIcon
+      viewBox="0 0 32 32"
+      width="32px"
+      height="32px"
+      focusable="false"
+    >
+      <path d="M16 0a16 16 0 1 0 16 16A16 16 0 0 0 16 0zm2 25h-4V13h4zm0-14h-4V7h4z" />
+    </InfoCoreIcon>
+  ),
+};
+
+export default CoreIcons;

--- a/packages/utilities/psammead-assets/src/svgs/coreIcons.jsx
+++ b/packages/utilities/psammead-assets/src/svgs/coreIcons.jsx
@@ -6,7 +6,6 @@ import {
   GEL_SPACING_DBL,
 } from '@bbc/gel-foundations/spacings';
 
-// `currentColor` has been used to better reflect user colour choices in Firefox.
 const CoreIcon = styled.svg`
   vertical-align: middle;
   margin: 0 ${GEL_SPACING_HLF};
@@ -14,36 +13,23 @@ const CoreIcon = styled.svg`
   fill: currentColor;
 `;
 
-const AlertCoreIcon = styled(CoreIcon)`
-  height: ${GEL_SPACING_DBL};
-  width: ${GEL_SPACING_DBL};
-`;
-
-const InfoCoreIcon = styled(CoreIcon)`
-  width: ${GEL_SPACING_DBL};
-  height: ${GEL_SPACING_DBL};
-`;
+const defaultAttrs = {
+  viewBox: '0 0 32 32',
+  width: GEL_SPACING_DBL,
+  height: GEL_SPACING_DBL,
+  focusable: 'false',
+};
 
 const CoreIcons = {
   alert: (
-    <AlertCoreIcon
-      viewBox="0 0 32 32"
-      width="32px"
-      height="32px"
-      focusable="false"
-    >
+    <CoreIcon {...defaultAttrs}>
       <path d="M16 2L0 30h32zm2 25h-4v-4h4zm-4-6V11h4v10z" />
-    </AlertCoreIcon>
+    </CoreIcon>
   ),
   info: (
-    <InfoCoreIcon
-      viewBox="0 0 32 32"
-      width="32px"
-      height="32px"
-      focusable="false"
-    >
+    <CoreIcon {...defaultAttrs}>
       <path d="M16 0a16 16 0 1 0 16 16A16 16 0 0 0 16 0zm2 25h-4V13h4zm0-14h-4V7h4z" />
-    </InfoCoreIcon>
+    </CoreIcon>
   ),
 };
 


### PR DESCRIPTION
Assists https://github.com/bbc/psammead/pull/2625.

**Overall change:** Add `alert` and `info` icons from [GEL Iconography - Core](https://www.bbc.co.uk/gel/guidelines/iconography#core) to a new Core icons group within Psammead Assets.

**Code changes:**

- Add `coreIcons` group.
- Add `alert` and `info` to `coreIcons`.
- Update test coverage.
- Bump minor package version.
- Update README.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
