### PR TITLE
AV: iFrame scrollbar media player fix

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.3.3 | [PR#!!!!](https://github.com/bbc/psammead/pull/####) Added scrolling attribute to disable scrolling on canonical iframe |
 | 2.3.2 | [PR#2666](https://github.com/bbc/psammead/pull/2666) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.3.1 | [PR#2663](https://github.com/bbc/psammead/pull/2663) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 2.3.0 | [PR#2628](https://github.com/bbc/psammead/pull/2628) Add guidance message for assistive technology in Play Button and hide it in Guidance |

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 2.3.3 | [PR#2684](https://github.com/bbc/psammead/pull/2684) Added scrolling attribute to disable scrolling on canonical iframe |
+| 2.3.3 | [PR#2684](https://github.com/bbc/psammead/pull/2684) Added scrolling attribute to disable scrolling on canonical and amp iframe |
 | 2.3.2 | [PR#2666](https://github.com/bbc/psammead/pull/2666) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.3.1 | [PR#2663](https://github.com/bbc/psammead/pull/2663) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 2.3.0 | [PR#2628](https://github.com/bbc/psammead/pull/2628) Add guidance message for assistive technology in Play Button and hide it in Guidance |

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 2.3.3 | [PR#!!!!](https://github.com/bbc/psammead/pull/####) Added scrolling attribute to disable scrolling on canonical iframe |
+| 2.3.3 | [PR#2684](https://github.com/bbc/psammead/pull/2684) Added scrolling attribute to disable scrolling on canonical iframe |
 | 2.3.2 | [PR#2666](https://github.com/bbc/psammead/pull/2666) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.3.1 | [PR#2663](https://github.com/bbc/psammead/pull/2663) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 2.3.0 | [PR#2628](https://github.com/bbc/psammead/pull/2628) Add guidance message for assistive technology in Play Button and hide it in Guidance |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`Media Player: Amp should render an amp-iframe with an amp-img nested in
         frameborder="0"
         layout="fill"
         sandbox="allow-scripts allow-same-origin"
+        scrolling="no"
         src="https://foo.bar/iframe"
         title="Media player"
       >

--- a/packages/components/psammead-media-player/src/Amp/index.jsx
+++ b/packages/components/psammead-media-player/src/Amp/index.jsx
@@ -27,6 +27,7 @@ const AmpMediaPlayer = ({
       <amp-iframe
         sandbox="allow-scripts allow-same-origin"
         layout="fill"
+        scrolling="no"
         frameborder="0"
         src={src}
         title={title}

--- a/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`Media Player: Canonical should render an iframe 1`] = `
   allow="autoplay; fullscreen"
   allowfullscreen=""
   class="c0"
+  scrolling="no"
   src="https://foo.bar/iframe"
   title="Media player"
 />

--- a/packages/components/psammead-media-player/src/Canonical/index.jsx
+++ b/packages/components/psammead-media-player/src/Canonical/index.jsx
@@ -25,6 +25,7 @@ const Canonical = ({ src, title, placeholderSrc }) => {
       src={src}
       title={title}
       allow="autoplay; fullscreen"
+      scrolling="no"
       gesture="media"
       allowFullScreen
     />

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -25,6 +25,7 @@ exports[`Media Player: AMP Entry renders a landscape container with an amp-ifram
           frameborder="0"
           layout="fill"
           sandbox="allow-scripts allow-same-origin"
+          scrolling="no"
           src="http://foo.bar/iframe/amp"
           title="Media player"
         >
@@ -69,6 +70,7 @@ exports[`Media Player: AMP Entry renders a portrait container with amp-iframe an
           frameborder="0"
           layout="fill"
           sandbox="allow-scripts allow-same-origin"
+          scrolling="no"
           src="http://foo.bar/iframe/amp"
           title="Media player"
         >
@@ -113,6 +115,7 @@ exports[`Media Player: AMP Entry renders the audio skin 1`] = `
           frameborder="0"
           layout="fill"
           sandbox="allow-scripts allow-same-origin"
+          scrolling="no"
           src="https://www.test.bbc.com/ws/av-embeds/media/bbc_korean_radio/liveradio"
           title="Audio player"
         >

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -625,6 +625,7 @@ exports[`Media Player: Canonical Entry renders an iframe when showPlaceholder is
     allow="autoplay; fullscreen"
     allowfullscreen=""
     class="c1"
+    scrolling="no"
     src="http://foo.bar/iframe"
     title="Media player"
   />
@@ -655,6 +656,7 @@ exports[`Media Player: Canonical Entry renders the audio skin 1`] = `
     allow="autoplay; fullscreen"
     allowfullscreen=""
     class="c1"
+    scrolling="no"
     src="https://www.test.bbc.com/ws/av-embeds/media/bbc_korean_radio/liveradio"
     title="Audio player"
   />


### PR DESCRIPTION
Partially https://github.com/bbc/simorgh/issues/4734

**Overall change:** Fixed visual bug in some browsers that showed the scroll bar for the top iframe of the AV Media Player

**Code changes:**

- Added `scrolling="no"` to top iframe for canonical and amp to disable the visual for the iframe scrollbar.
- Updated snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing - Tested by pulling into simorgh and using Browserstack to view it locally through Chrome on Windows 7.

**Additional Info**
This will need to be bumped in Simorgh.