### PR TITLE
Script Link - same style on hover and focus

### DIFF
--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0-alpha.9 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use border on hover and focus |
 | 1.0.0-alpha.8 | [PR#2569](https://github.com/bbc/psammead/pull/2569) Reduce height of Script link for 600px+ breakpoints |
 | 1.0.0-alpha.7 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.0-alpha.6 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0-alpha.9 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use border on hover and focus |
+| 1.0.0-alpha.9 | [PR#2685](https://github.com/bbc/psammead/pull/2685) Use border on hover and focus |
 | 1.0.0-alpha.8 | [PR#2569](https://github.com/bbc/psammead/pull/2569) Reduce height of Script link for 600px+ breakpoints |
 | 1.0.0-alpha.7 | [PR#2519](https://github.com/bbc/psammead/pull/2519) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.0-alpha.6 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-script-link/package-lock.json
+++ b/packages/components/psammead-script-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-script-link/package.json
+++ b/packages/components/psammead-script-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
@@ -26,13 +26,9 @@ exports[`ScriptLink should render correctly 1`] = `
   border: 0.0625rem solid #FFFFFF;
 }
 
-.c0:hover::after {
+.c0:hover::after,
+.c0:focus::after {
   border: 0.25rem solid #FFFFFF;
-}
-
-.c0:focus {
-  background-color: #FFFFFF;
-  color: #222222;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-script-link/src/index.jsx
+++ b/packages/components/psammead-script-link/src/index.jsx
@@ -7,7 +7,7 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
-import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
+import { C_WHITE } from '@bbc/psammead-styles/colours';
 import { string, shape, node } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
@@ -20,6 +20,7 @@ const StyledLink = styled.a`
   text-decoration: none;
   padding: 0 1rem;
   height: 3rem;
+
   &::after {
     content: '';
     position: absolute;
@@ -29,13 +30,12 @@ const StyledLink = styled.a`
     bottom: 0;
     border: 0.0625rem solid ${C_WHITE};
   }
-  &:hover::after {
+
+  &:hover::after,
+  &:focus::after {
     border: 0.25rem solid ${C_WHITE};
   }
-  &:focus {
-    background-color: ${C_WHITE};
-    color: ${C_EBON};
-  }
+
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     line-height: 3rem;
   }


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
In order to keep consistency with the Navigation, UX has requested to apply the same styles when hover and focus on the `Script Link`

**Code changes:**

- Apply `border: 0.25rem solid ${C_WHITE};` on hover and focus.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
