### PR TITLE
Update text examples

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 8.1.1 | [PR#2668](https://github.com/bbc/psammead/pull/2668) Remove `chineseTrad` & `chineseSimp` example as Zhongwen example covers it.  |
 | 8.1.0 | [PR#2668](https://github.com/bbc/psammead/pull/2668) Add variant prop to `storyProps` and update text-variant examples |
 | 8.0.2 | [PR#2543](https://github.com/bbc/psammead/pull/2543) updates readme with better withServicesKnob example |
 | 8.0.1 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -45,16 +45,6 @@ const TEXT_EXAMPLES = {
     script: 'burmese',
     locale: 'my',
   },
-  chineseSimp: {
-    text: '家长们在学校门口维权。',
-    script: 'chinese',
-    locale: 'zh-cn',
-  },
-  chineseTrad: {
-    text: '家長們在學校門口維權。',
-    script: 'chinese',
-    locale: 'zh-tw',
-  },
   news: {
     text: 'Could a computer ever create better art than a human?',
     script: 'latin',


### PR DESCRIPTION
Resolves n/a

**Overall change:** From my changes in this PR: https://github.com/bbc/psammead/issues/2667

I updated the data structure of services with variants to include a value for `service` & `variant`, I also added a object for Zhongwen because I didn't notice the object for `Chinese` existed already in the TEXT EXAMPLE. This PR just removes the `Chinese` example but `Zhongwen` covers it.

**Code changes:**

- _remove the text example for chinese and zhongwen is more clear what service it is_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
