### PR TITLE
correct variant value of serbianLat

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 8.1.1 | [PR#2668](https://github.com/bbc/psammead/pull/2668) Remove `chineseTrad` & `chineseSimp` example as Zhongwen example covers it.  |
+| 8.1.2 | [PR#2695](https://github.com/bbc/psammead/pull/2695) Correct the variant value in the serbian TEXT_EXAMPLE  |
+| 8.1.1 | [PR#2691](https://github.com/bbc/psammead/pull/2691) Remove `chineseTrad` & `chineseSimp` example as Zhongwen example covers it.  |
 | 8.1.0 | [PR#2668](https://github.com/bbc/psammead/pull/2668) Add variant prop to `storyProps` and update text-variant examples |
 | 8.0.2 | [PR#2543](https://github.com/bbc/psammead/pull/2543) updates readme with better withServicesKnob example |
 | 8.0.1 | [PR#2488](https://github.com/bbc/psammead/pull/2488) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -143,7 +143,7 @@ const TEXT_EXAMPLES = {
   },
   serbianLat: {
     service: 'serbian',
-    variant: 'cyr',
+    variant: 'lat',
     text: 'Karadžić se godinama krio pre nego što je uhapšen 2008. godine',
     script: 'latin',
     locale: 'sr',


### PR DESCRIPTION
Resolves: n/a

**Overall change:** _Fixing my mindless copy and pasting mistake._

**Code-change:**
- correct the variant value for SerbianLat, to equal `lat` not `cyr`


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
