### PR TITLE
Add `dir` prop to Amp and Canonical MenuButton.

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.3 | [PR#](https://github.com/bbc/psammead/pull/) Add dir prop to Amp and Canonical MenuButton |
 | 6.0.0-alpha.2 | [PR#2725](https://github.com/bbc/psammead/pull/2725) Move hooks directory into src |
 | 6.0.0-alpha.1 | [PR#2613](https://github.com/bbc/psammead/pull/2613) Add dropdown menu with a hamburger button |
 | 5.0.0-alpha.2 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.0-alpha.3 | [PR#](https://github.com/bbc/psammead/pull/) Add dir prop to Amp and Canonical MenuButton |
+| 6.0.0-alpha.3 | [PR#2745](https://github.com/bbc/psammead/pull/2745) Add dir prop to Amp and Canonical MenuButton |
 | 6.0.0-alpha.2 | [PR#2725](https://github.com/bbc/psammead/pull/2725) Move hooks directory into src |
 | 6.0.0-alpha.1 | [PR#2613](https://github.com/bbc/psammead/pull/2613) Add dropdown menu with a hamburger button |
 | 5.0.0-alpha.2 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -94,7 +94,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | onOpen | function | Yes | N/A | `() => { console.log("Handle open action"); }` |
 | onClose | function | Yes | N/A | `() => { console.log("Handle close action"); }` |
 | isOpen | bool | Yes | N/A | `false` |
-| dir | string | no | `'ltr'` | `'ltr'` |
+| dir | string | no | `'ltr'` | `'rtl'` |
 
 ### AmpMenuButton
 

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -94,6 +94,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | onOpen | function | Yes | N/A | `() => { console.log("Handle open action"); }` |
 | onClose | function | Yes | N/A | `() => { console.log("Handle close action"); }` |
 | isOpen | bool | Yes | N/A | `false` |
+| dir | string | no | `'ltr'` | `'ltr'` |
 
 ### AmpMenuButton
 
@@ -102,6 +103,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | -------- | ---- | -------- | ------- | ------- |
 | announcedText | string | Yes | N/A | `'Menu'` |
 | onToggle | string | Yes | N/A | `"tap:menu.toggleVisibility"` |
+| dir | string | no | `'ltr'` | `'ltr'` |
 
 ## Navigation Usage
 

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -103,7 +103,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | -------- | ---- | -------- | ------- | ------- |
 | announcedText | string | Yes | N/A | `'Menu'` |
 | onToggle | string | Yes | N/A | `"tap:menu.toggleVisibility"` |
-| dir | string | no | `'ltr'` | `'ltr'` |
+| dir | string | no | `'ltr'` | `'rtl'` |
 
 ## Navigation Usage
 

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`AMP Menu Button should render correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
+  float: left;
 }
 
 .c0:hover,
@@ -63,6 +64,7 @@ exports[`AMP Menu Button should render correctly 1`] = `
         aria-label="Menu"
         class="c0"
         data-amp-bind-aria-expanded="menuState.expanded ? \\"true\\" : \\"false\\""
+        dir="ltr"
         on="tap:AMP.setState({ menuState: { expanded: !menuState.expanded }});"
       >
         <svg
@@ -113,6 +115,7 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
+  float: left;
 }
 
 .c0:hover,
@@ -142,6 +145,7 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   aria-expanded="false"
   aria-label="Menu"
   class="c0"
+  dir="ltr"
 >
   <svg
     aria-hidden="true"
@@ -172,6 +176,7 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
+  float: left;
 }
 
 .c0:hover,
@@ -201,6 +206,7 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   aria-expanded="true"
   aria-label="Menu"
   class="c0"
+  dir="ltr"
 >
   <svg
     aria-hidden="true"

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -122,6 +122,7 @@ const MenuButton = styled.button`
   margin: 0;
   border: 0;
   background-color: transparent;
+  ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
 
   &:hover,
   &:focus {
@@ -142,11 +143,13 @@ export const CanonicalMenuButton = ({
   isOpen,
   onOpen,
   onClose,
+  dir,
 }) => (
   <MenuButton
     aria-label={announcedText}
     onClick={isOpen ? onClose : onOpen}
     aria-expanded={isOpen ? 'true' : 'false'}
+    dir={dir}
   >
     {isOpen ? navigationIcons.cross : navigationIcons.hamburger}
   </MenuButton>
@@ -157,6 +160,11 @@ CanonicalMenuButton.propTypes = {
   onOpen: func.isRequired,
   onClose: func.isRequired,
   isOpen: bool.isRequired,
+  dir: oneOf(['ltr', 'rtl']),
+};
+
+CanonicalMenuButton.defaultProps = {
+  dir: 'ltr',
 };
 
 const AmpHead = () => (
@@ -169,7 +177,7 @@ const AmpHead = () => (
   </Helmet>
 );
 
-export const AmpMenuButton = ({ announcedText, onToggle }) => {
+export const AmpMenuButton = ({ announcedText, onToggle, dir }) => {
   const expandedHandler =
     'tap:AMP.setState({ menuState: { expanded: !menuState.expanded }})';
 
@@ -188,6 +196,7 @@ export const AmpMenuButton = ({ announcedText, onToggle }) => {
         aria-expanded="false"
         data-amp-bind-aria-expanded='menuState.expanded ? "true" : "false"'
         on={`${expandedHandler};${onToggle}`}
+        dir={dir}
       >
         {cloneElement(navigationIcons.hamburger, {
           'data-amp-bind-hidden': 'menuState.expanded',
@@ -204,4 +213,9 @@ export const AmpMenuButton = ({ announcedText, onToggle }) => {
 AmpMenuButton.propTypes = {
   announcedText: string.isRequired,
   onToggle: string.isRequired,
+  dir: oneOf(['ltr', 'rtl']),
+};
+
+AmpMenuButton.defaultProps = {
+  dir: 'ltr',
 };

--- a/packages/components/psammead-navigation/src/index.stories.jsx
+++ b/packages/components/psammead-navigation/src/index.stories.jsx
@@ -219,7 +219,7 @@ navStoriesData.map(item => {
 
 canonicalStories.add(
   'Canonical Menu Button',
-  () => {
+  ({ dir }) => {
     const isOpen = boolean('Open', false);
     return (
       <BackgroundContainer>
@@ -228,6 +228,7 @@ canonicalStories.add(
           onOpen={() => {}}
           isOpen={isOpen}
           onClose={() => {}}
+          dir={dir}
         />
       </BackgroundContainer>
     );
@@ -277,9 +278,9 @@ navStoriesData.map(item => {
 
 ampStories.add(
   'AMP Menu Button',
-  () => (
+  ({ dir }) => (
     <BackgroundContainer>
-      <AmpMenuButton announcedText="Menu" onToggle="" />
+      <AmpMenuButton announcedText="Menu" onToggle="" dir={dir} />
     </BackgroundContainer>
   ),
   {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _Add `dir` prop to Amp and Canonical MenuButton._

**Code changes:**

- _Add `dir` prop to Amp and Canonical MenuButton._
- _Update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
