### PR TITLE
Fix MenuButton not acting as block element.

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.4 | [PR#](https://github.com/bbc/psammead/pull/) Fix MenuButton not acting as a block element |
 | 6.0.0-alpha.3 | [PR#2745](https://github.com/bbc/psammead/pull/2745) Add dir prop to Amp and Canonical MenuButton |
 | 6.0.0-alpha.2 | [PR#2725](https://github.com/bbc/psammead/pull/2725) Move hooks directory into src |
 | 6.0.0-alpha.1 | [PR#2613](https://github.com/bbc/psammead/pull/2613) Add dropdown menu with a hamburger button |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.0-alpha.4 | [PR#](https://github.com/bbc/psammead/pull/) Fix MenuButton not acting as a block element |
+| 6.0.0-alpha.4 | [PR#2747](https://github.com/bbc/psammead/pull/2747) Fix MenuButton not acting as a block element |
 | 6.0.0-alpha.3 | [PR#2745](https://github.com/bbc/psammead/pull/2745) Add dir prop to Amp and Canonical MenuButton |
 | 6.0.0-alpha.2 | [PR#2725](https://github.com/bbc/psammead/pull/2725) Move hooks directory into src |
 | 6.0.0-alpha.1 | [PR#2613](https://github.com/bbc/psammead/pull/2613) Add dropdown menu with a hamburger button |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.3",
+  "version": "6.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.3",
+  "version": "6.0.0-alpha.4",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -239,6 +239,7 @@ exports[`Dropdown navigation should render correctly 1`] = `
 
 .c0 {
   background-color: #222222;
+  clear: both;
 }
 
 .c1 {

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -25,6 +25,7 @@ const getStyles = dir => {
 
 export const Dropdown = styled.div`
   background-color: ${C_EBON};
+  clear: both;
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     display: none;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _Fix MenuButton not acting as block element (pictured)._

<img width="292" alt="Screenshot 2019-12-02 at 19 20 42" src="https://user-images.githubusercontent.com/12303856/69975818-f5897680-1538-11ea-9932-0ee8a196c052.png">

**Code changes:**

- _Add `clear: both` to `<Dropdown />` navigation component._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
