### PR TITLE
Bulletin - add padding right above 600px

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Add `padding-right` to summary above 600px and remove alpha tag |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |
 | 0.1.0-alpha.10 | [PR#2723](https://github.com/bbc/psammead/pull/2723) Add `offScreenText` prop |
 | 0.1.0-alpha.9 | [PR#2634](https://github.com/bbc/psammead/pull/2634) Add styling for desktop and tablet |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px and remove alpha tag |
+| 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |
 | 0.1.0-alpha.10 | [PR#2723](https://github.com/bbc/psammead/pull/2723) Add `offScreenText` prop |
 | 0.1.0-alpha.9 | [PR#2634](https://github.com/bbc/psammead/pull/2634) Add styling for desktop and tablet |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#???](https://github.com/bbc/psammead/pull/???) Add `padding-right` to summary above 600px and remove alpha tag |
+| 1.0.0 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px and remove alpha tag |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |
 | 0.1.0-alpha.10 | [PR#2723](https://github.com/bbc/psammead/pull/2723) Add `offScreenText` prop |
 | 0.1.0-alpha.9 | [PR#2634](https://github.com/bbc/psammead/pull/2634) Add styling for desktop and tablet |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "1.0.0",
+  "version": "0.1.0-alpha.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.11",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "1.0.0",
+  "version": "0.1.0-alpha.12",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,5 +27,8 @@
     "react": "^16.10.2",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
+  },
+  "publishConfig": {
+    "tag": "alpha"
   }
 }

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.11",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,8 +27,5 @@
     "react": "^16.10.2",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
-  },
-  "publishConfig": {
-    "tag": "alpha"
   }
 }

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -217,7 +217,7 @@ exports[`Bulletin should render audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c7 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 
@@ -542,7 +542,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c8 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 
@@ -878,7 +878,7 @@ exports[`Bulletin should render live video correctly 1`] = `
 @media (min-width:37.5rem) {
   .c8 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 
@@ -1202,7 +1202,7 @@ exports[`Bulletin should render video correctly 1`] = `
 @media (min-width:37.5rem) {
   .c7 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -158,7 +158,7 @@ const BulletinSummary = styled.p`
   padding: 0 ${GEL_SPACING};
   @media(min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: ${GEL_SPACING};
   }
   padding-bottom: ${GEL_SPACING_DBL};
 `;


### PR DESCRIPTION
Resolves #2754 

**Overall change:** Add `padding-right` to summary above 600px breakpoint.

**Code changes:**

- Add `padding-right: GEL_SPACING` above `GEL_GROUP_3_SCREEN_WIDTH_MIN` breakpoint.
- Bump version and CHANGELOG
- Update snapshot

## Before
![image](https://user-images.githubusercontent.com/13763899/70054680-e9042d00-15cf-11ea-9551-709cd20ee868.png)

![image](https://user-images.githubusercontent.com/13763899/70054748-076a2880-15d0-11ea-9f76-431e1d792cb5.png)


## After
![image](https://user-images.githubusercontent.com/13763899/70054686-ec97b400-15cf-11ea-92cb-b95c84d78a66.png)

![image](https://user-images.githubusercontent.com/13763899/70054720-fd482a00-15cf-11ea-9d51-1cabce1a597b.png)


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
