### PR TITLE
Remove alpha tag from Bulletin

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Remove alpha tag |
+| 1.0.0 | [PR#2756](https://github.com/BBC/psammead/pull/2756) Remove alpha tag |
 | 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |
 | 0.1.0-alpha.10 | [PR#2723](https://github.com/bbc/psammead/pull/2723) Add `offScreenText` prop |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Remove alpha tag |
 | 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |
 | 0.1.0-alpha.10 | [PR#2723](https://github.com/bbc/psammead/pull/2723) Add `offScreenText` prop |

--- a/packages/components/psammead-bulletin/README.md
+++ b/packages/components/psammead-bulletin/README.md
@@ -1,7 +1,3 @@
-# ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-bulletin - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-bulletin%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-bulletin%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-bulletin)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-bulletin) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-bulletin)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-bulletin&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/bulletin--containing-image) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-bulletin.svg)](https://www.npmjs.com/package/@bbc/psammead-bulletin) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.12",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.12",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,8 +27,5 @@
     "react": "^16.10.2",
     "styled-components": "^4.3.2",
     "prop-types": "^15.7.2"
-  },
-  "publishConfig": {
-    "tag": "alpha"
   }
 }

--- a/packages/components/psammead-bulletin/src/index.stories.jsx
+++ b/packages/components/psammead-bulletin/src/index.stories.jsx
@@ -12,8 +12,7 @@ const BulletinComponent = ({ script, service, type, hasImage, dir, text }) => {
 
   const isLive = boolean('Live', false);
   const ctaText = type === 'audio' ? 'Listen' : 'Watch';
-  const playCtaText = isLive ? `${ctaText} Live` : ctaText;
-  const offScreenText = isLive ? `${ctaText} LIVE` : ctaText;
+  const offScreenText = isLive ? `${ctaText} Live` : ctaText;
 
   const image = (
     <Image
@@ -32,7 +31,7 @@ const BulletinComponent = ({ script, service, type, hasImage, dir, text }) => {
       headlineText={text}
       summaryText={text}
       ctaLink={ctaLink}
-      ctaText={playCtaText}
+      ctaText={ctaText}
       dir={dir}
       offScreenText={offScreenText}
     />


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/2383

**Overall change:** 
After carried out an [Accessibility Swarm](https://github.com/bbc/psammead/issues/23844) for the `Bulletin` component and tested that everything is fine, we can move forward and remove the alpha tag from the component.

**Code changes:**
- Remove `alpha` tag from the `package.json`
- Bump package to a stable version
- Remove alpha text from `README`
- Replace offscreen `LIVE` text with `Live` as it should be pronounced as ‘live’ as in ‘live event’ rather than ‘live’ as in ‘I live here’ .
- Remove `playCtaText` as we shouldn't have the Live label in the CTA.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
