### PR TITLE
Change menu button height depending on script in use

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.5 | [PR#2759](https://github.com/bbc/psammead/pull/2759) Change size of menu button depending on script |
 | 6.0.0-alpha.4 | [PR#2747](https://github.com/bbc/psammead/pull/2747) Fix MenuButton not acting as a block element |
 | 6.0.0-alpha.3 | [PR#2745](https://github.com/bbc/psammead/pull/2745) Add dir prop to Amp and Canonical MenuButton |
 | 6.0.0-alpha.2 | [PR#2725](https://github.com/bbc/psammead/pull/2725) Move hooks directory into src |

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -172,12 +172,14 @@ import { latin } from '@bbc/gel-foundations/scripts';
 ```jsx
 import React from 'react';
 import { CanonicalMenuButton } from '@bbc/psammead-navigation/dropdown';
+import { latin } from '@bbc/gel-foundations/scripts';
 
 <CanonicalMenuButton 
     announcedText="Menu"
     isOpen={true}
     onOpen={() => { console.log("Handle open action"); }}
     onClose={() => { console.log("Handle close action"); }} 
+    script={latin}
 />
 ```
 
@@ -186,8 +188,13 @@ import { CanonicalMenuButton } from '@bbc/psammead-navigation/dropdown';
 ```jsx
 import React from 'react';
 import { AmpMenuButton } from '@bbc/psammead-navigation/dropdown';
+import { latin } from '@bbc/gel-foundations/scripts';
 
-<AmpMenuButton announcedText="Menu" onToggle="tap:menu.toggleVisibility" />
+<AmpMenuButton
+  announcedText="Menu"
+  onToggle="tap:menu.toggleVisibility"
+  script={latin}
+/>
 ```
 
 ### When to use this component

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -95,6 +95,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | onClose | function | Yes | N/A | `() => { console.log("Handle close action"); }` |
 | isOpen | bool | Yes | N/A | `false` |
 | dir | string | no | `'ltr'` | `'rtl'` |
+| script   | object  | Yes      | N/A     |  `{ canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }` |
 
 ### AmpMenuButton
 
@@ -104,6 +105,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | announcedText | string | Yes | N/A | `'Menu'` |
 | onToggle | string | Yes | N/A | `"tap:menu.toggleVisibility"` |
 | dir | string | no | `'ltr'` | `'rtl'` |
+| script   | object  | Yes      | N/A     |  `{ canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }` |
 
 ## Navigation Usage
 

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -51,13 +51,6 @@ exports[`AMP Menu Button should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
-  .c0 {
-    height: 2.75rem;
-    width: 2.75rem;
-  }
-}
-
 <html>
   <head>
     <script
@@ -179,13 +172,6 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
-  .c0 {
-    height: 3.125rem;
-    width: 3.125rem;
-  }
-}
-
 <div>
       <amp-state
         id="menuState"
@@ -289,13 +275,6 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
-  .c0 {
-    height: 2.75rem;
-    width: 2.75rem;
-  }
-}
-
 <button
   aria-expanded="false"
   aria-label="Menu"
@@ -362,13 +341,6 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
 }
 
 @media (min-width:20rem) {
-  .c0 {
-    height: 3.125rem;
-    width: 3.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
   .c0 {
     height: 3.125rem;
     width: 3.125rem;
@@ -447,13 +419,6 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
-  .c0 {
-    height: 2.75rem;
-    width: 2.75rem;
-  }
-}
-
 <button
   aria-expanded="true"
   aria-label="Menu"
@@ -521,13 +486,6 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
 }
 
 @media (min-width:20rem) {
-  .c0 {
-    height: 3.125rem;
-    width: 3.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
   .c0 {
     height: 3.125rem;
     width: 3.125rem;

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -119,6 +119,125 @@ exports[`AMP Menu Button should render correctly 1`] = `
 </html>
 `;
 
+exports[`AMP Menu Button should render rtl correctly 1`] = `
+<html>
+  <head>
+    <script
+      async="true"
+      custom-element="amp-bind"
+      src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
+    />
+  </head>
+  <body>
+    .c1 {
+  color: #fff;
+  fill: currentColor;
+}
+
+.c0 {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  float: left;
+  height: 3.125rem;
+  width: 3.125rem;
+}
+
+.c0:hover,
+.c0:focus {
+  box-shadow: inset 0 0 0 0.25rem #FFFFFF;
+}
+
+.c0:hover::after,
+.c0:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c0 svg {
+  vertical-align: middle;
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
+  }
+}
+
+<div>
+      <amp-state
+        id="menuState"
+      >
+        <script
+          type="application/json"
+        >
+          {"expanded":false}
+        </script>
+      </amp-state>
+      <button
+        aria-expanded="false"
+        aria-label="Menu"
+        class="c0"
+        data-amp-bind-aria-expanded="menuState.expanded ? \\"true\\" : \\"false\\""
+        dir="ltr"
+        on="tap:AMP.setState({ menuState: { expanded: !menuState.expanded }});"
+      >
+        <svg
+          aria-hidden="true"
+          class="c1"
+          data-amp-bind-hidden="menuState.expanded"
+          focusable="false"
+          height="2.75rem"
+          viewBox="0 0 44 44"
+          width="2.75rem"
+        >
+          <path
+            d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          class="c1"
+          data-amp-bind-hidden="!menuState.expanded"
+          focusable="false"
+          height="2.75rem"
+          hidden=""
+          viewBox="0 0 44 44"
+          width="2.75rem"
+        >
+          <path
+            d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  </body>
+</html>
+`;
+
 exports[`Canonical Closed menu button should render correctly 1`] = `
 .c1 {
   color: #fff;
@@ -198,6 +317,85 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
 </button>
 `;
 
+exports[`Canonical Closed menu button should render rtl correctly 1`] = `
+.c1 {
+  color: #fff;
+  fill: currentColor;
+}
+
+.c0 {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  float: left;
+  height: 3.125rem;
+  width: 3.125rem;
+}
+
+.c0:hover,
+.c0:focus {
+  box-shadow: inset 0 0 0 0.25rem #FFFFFF;
+}
+
+.c0:hover::after,
+.c0:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c0 svg {
+  vertical-align: middle;
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
+  }
+}
+
+<button
+  aria-expanded="false"
+  aria-label="Menu"
+  class="c0"
+  dir="ltr"
+>
+  <svg
+    aria-hidden="true"
+    class="c1"
+    focusable="false"
+    height="2.75rem"
+    viewBox="0 0 44 44"
+    width="2.75rem"
+  >
+    <path
+      d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
+    />
+  </svg>
+</button>
+`;
+
 exports[`Canonical Open menu button should render correctly 1`] = `
 .c1 {
   color: #fff;
@@ -253,6 +451,86 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   .c0 {
     height: 2.75rem;
     width: 2.75rem;
+  }
+}
+
+<button
+  aria-expanded="true"
+  aria-label="Menu"
+  class="c0"
+  dir="ltr"
+>
+  <svg
+    aria-hidden="true"
+    class="c1"
+    focusable="false"
+    height="2.75rem"
+    viewBox="0 0 44 44"
+    width="2.75rem"
+  >
+    <path
+      d="M26.741 15L21.6 20.142 16.458 15 15 16.458l5.142 5.142L15 26.742l1.458 1.458 5.142-5.141 5.141 5.141 1.459-1.458-5.142-5.142 5.142-5.142z"
+      fill-rule="evenodd"
+    />
+  </svg>
+</button>
+`;
+
+exports[`Canonical Open menu button should render rtl correctly 1`] = `
+.c1 {
+  color: #fff;
+  fill: currentColor;
+}
+
+.c0 {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  float: left;
+  height: 3.125rem;
+  width: 3.125rem;
+}
+
+.c0:hover,
+.c0:focus {
+  box-shadow: inset 0 0 0 0.25rem #FFFFFF;
+}
+
+.c0:hover::after,
+.c0:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c0 svg {
+  vertical-align: middle;
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 3.125rem;
+    width: 3.125rem;
   }
 }
 

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
-  float: left;
+  float: right;
   height: 3.125rem;
   width: 3.125rem;
 }
@@ -201,7 +201,7 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
         aria-label="Menu"
         class="c0"
         data-amp-bind-aria-expanded="menuState.expanded ? \\"true\\" : \\"false\\""
-        dir="ltr"
+        dir="rtl"
         on="tap:AMP.setState({ menuState: { expanded: !menuState.expanded }});"
       >
         <svg
@@ -329,7 +329,7 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
-  float: left;
+  float: right;
   height: 3.125rem;
   width: 3.125rem;
 }
@@ -379,7 +379,7 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   aria-expanded="false"
   aria-label="Menu"
   class="c0"
-  dir="ltr"
+  dir="rtl"
 >
   <svg
     aria-hidden="true"
@@ -488,7 +488,7 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   margin: 0;
   border: 0;
   background-color: transparent;
-  float: left;
+  float: right;
   height: 3.125rem;
   width: 3.125rem;
 }
@@ -538,7 +538,7 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   aria-expanded="true"
   aria-label="Menu"
   class="c0"
-  dir="ltr"
+  dir="rtl"
 >
   <svg
     aria-hidden="true"

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -7,14 +7,14 @@ exports[`AMP Menu Button should render correctly 1`] = `
 }
 
 .c0 {
-  width: 2.75rem;
-  height: 2.75rem;
   position: relative;
   padding: 0;
   margin: 0;
   border: 0;
   background-color: transparent;
   float: left;
+  height: 2.75rem;
+  width: 2.75rem;
 }
 
 .c0:hover,
@@ -33,10 +33,28 @@ exports[`AMP Menu Button should render correctly 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
+.c0 svg {
+  vertical-align: middle;
+}
+
 @media (min-width:37.5rem) {
   .c0 {
     display: none;
     visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
   }
 }
 
@@ -108,14 +126,14 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
 }
 
 .c0 {
-  width: 2.75rem;
-  height: 2.75rem;
   position: relative;
   padding: 0;
   margin: 0;
   border: 0;
   background-color: transparent;
   float: left;
+  height: 2.75rem;
+  width: 2.75rem;
 }
 
 .c0:hover,
@@ -134,10 +152,28 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
+.c0 svg {
+  vertical-align: middle;
+}
+
 @media (min-width:37.5rem) {
   .c0 {
     display: none;
     visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
   }
 }
 
@@ -169,14 +205,14 @@ exports[`Canonical Open menu button should render correctly 1`] = `
 }
 
 .c0 {
-  width: 2.75rem;
-  height: 2.75rem;
   position: relative;
   padding: 0;
   margin: 0;
   border: 0;
   background-color: transparent;
   float: left;
+  height: 2.75rem;
+  width: 2.75rem;
 }
 
 .c0:hover,
@@ -195,10 +231,28 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
+.c0 svg {
+  vertical-align: middle;
+}
+
 @media (min-width:37.5rem) {
   .c0 {
     display: none;
     visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    height: 2.75rem;
+    width: 2.75rem;
   }
 }
 

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -123,6 +123,10 @@ const iconBorder = css`
 const calculateButtonSide = lineHeight =>
   lineHeight / 16 + NAV_BAR_TOP_BOTTOM_SPACING * 2;
 
+const getButtonDimensions = lineHeight =>
+  `height: ${calculateButtonSide(lineHeight)}rem;
+  width: ${calculateButtonSide(lineHeight)}rem;`;
+
 const MenuButton = styled.button`
   position: relative;
   padding: 0;
@@ -130,16 +134,9 @@ const MenuButton = styled.button`
   border: 0;
   background-color: transparent;
   ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
-  ${({ script }) => {
-    const sideLength = `${calculateButtonSide(
-      script.pica.groupA.lineHeight,
-    )}rem;`;
-    return (
-      script &&
-      `height: ${sideLength};
-      width: ${sideLength};`
-    );
-  }}
+  ${({ script }) =>
+    script &&
+    getButtonDimensions(script.pica.groupA.lineHeight)}
 
   &:hover,
   &:focus {
@@ -154,16 +151,8 @@ const MenuButton = styled.button`
     visibility: hidden;
   }
   @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
-    ${({ script }) => {
-      const sideLength = `${calculateButtonSide(
-        script.pica.groupB.lineHeight,
-      )}rem;`;
-      return (
-        script &&
-        `height: ${sideLength};
-        width: ${sideLength};`
-      );
-    }}
+    ${({ script }) =>
+      script && getButtonDimensions(script.pica.groupB.lineHeight)}
   }
 
   & svg {

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -19,7 +19,7 @@ import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const TOP_BOTTOM_SPACING = 0.75; // 12px
+const MENU_TOP_BOTTOM_SPACING = 0.75; // 12px - must be the same as TOP_BOTTOM_SPACING in ../index.jsx
 
 const getStyles = dir => {
   const direction = dir === 'ltr' ? 'left' : 'right';
@@ -122,7 +122,7 @@ const iconBorder = css`
 // The sideLength of the button should be
 //  line height + top padding + bottom padding
 const calculateButtonSide = lineHeight =>
-  lineHeight / 16 + TOP_BOTTOM_SPACING * 2;
+  lineHeight / 16 + MENU_TOP_BOTTOM_SPACING * 2;
 
 const MenuButton = styled.button`
   position: relative;

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -13,7 +13,6 @@ import Helmet from 'react-helmet';
 import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_B_MIN_WIDTH,
-  GEL_GROUP_CD_MIN_WIDTH,
 } from '@bbc/gel-foundations/breakpoints';
 import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
@@ -158,18 +157,6 @@ const MenuButton = styled.button`
     ${({ script }) => {
       const sideLength = `${calculateButtonSide(
         script.pica.groupB.lineHeight,
-      )}rem;`;
-      return (
-        script &&
-        `height: ${sideLength};
-        width: ${sideLength};`
-      );
-    }}
-  }
-  @media (min-width: ${GEL_GROUP_CD_MIN_WIDTH}rem) {
-    ${({ script }) => {
-      const sideLength = `${calculateButtonSide(
-        script.pica.groupD.lineHeight,
       )}rem;`;
       return (
         script &&

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -119,6 +119,11 @@ const iconBorder = css`
   border: ${GEL_SPACING_HLF} solid ${C_WHITE};
 `;
 
+// The sideLength of the button should be
+//  line height + top padding + bottom padding
+const calculateButtonSide = lineHeight =>
+  lineHeight / 16 + TOP_BOTTOM_SPACING * 2;
+
 const MenuButton = styled.button`
   position: relative;
   padding: 0;
@@ -127,10 +132,9 @@ const MenuButton = styled.button`
   background-color: transparent;
   ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
   ${({ script }) => {
-    // The sideLength of the button should be
-    //  line height + top padding + bottom padding
-    const sideLength = `${script.pica.groupA.lineHeight / 16 +
-      TOP_BOTTOM_SPACING * 2}rem;`;
+    const sideLength = `${calculateButtonSide(
+      script.pica.groupA.lineHeight,
+    )}rem;`;
     return (
       script &&
       `height: ${sideLength};
@@ -152,10 +156,9 @@ const MenuButton = styled.button`
   }
   @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
     ${({ script }) => {
-      // The sideLength of the button should be
-      //  line height + top padding + bottom padding
-      const sideLength = `${script.pica.groupA.lineHeight / 16 +
-        TOP_BOTTOM_SPACING * 2}rem;`;
+      const sideLength = `${calculateButtonSide(
+        script.pica.groupB.lineHeight,
+      )}rem;`;
       return (
         script &&
         `height: ${sideLength};
@@ -165,10 +168,9 @@ const MenuButton = styled.button`
   }
   @media (min-width: ${GEL_GROUP_CD_MIN_WIDTH}rem) {
     ${({ script }) => {
-      // The sideLength of the button should be
-      //  line height + top padding + bottom padding
-      const sideLength = `${script.pica.groupA.lineHeight / 16 +
-        TOP_BOTTOM_SPACING * 2}rem;`;
+      const sideLength = `${calculateButtonSide(
+        script.pica.groupD.lineHeight,
+      )}rem;`;
       return (
         script &&
         `height: ${sideLength};

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -19,7 +19,7 @@ import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const MENU_BUTTON_TOP_BOTTOM_SPACING = 0.75; // 12px - must be the same as TOP_BOTTOM_SPACING in ../index.jsx
+export const NAV_BAR_TOP_BOTTOM_SPACING = 0.75; // 12px
 
 const getStyles = dir => {
   const direction = dir === 'ltr' ? 'left' : 'right';
@@ -122,7 +122,7 @@ const iconBorder = css`
 // The sideLength of the button should be
 //  line height + top padding + bottom padding
 const calculateButtonSide = lineHeight =>
-  lineHeight / 16 + MENU_BUTTON_TOP_BOTTOM_SPACING * 2;
+  lineHeight / 16 + NAV_BAR_TOP_BOTTOM_SPACING * 2;
 
 const MenuButton = styled.button`
   position: relative;

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -19,7 +19,7 @@ import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const MENU_TOP_BOTTOM_SPACING = 0.75; // 12px - must be the same as TOP_BOTTOM_SPACING in ../index.jsx
+const MENU_BUTTON_TOP_BOTTOM_SPACING = 0.75; // 12px - must be the same as TOP_BOTTOM_SPACING in ../index.jsx
 
 const getStyles = dir => {
   const direction = dir === 'ltr' ? 'left' : 'right';
@@ -122,7 +122,7 @@ const iconBorder = css`
 // The sideLength of the button should be
 //  line height + top padding + bottom padding
 const calculateButtonSide = lineHeight =>
-  lineHeight / 16 + MENU_TOP_BOTTOM_SPACING * 2;
+  lineHeight / 16 + MENU_BUTTON_TOP_BOTTOM_SPACING * 2;
 
 const MenuButton = styled.button`
   position: relative;

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -10,12 +10,16 @@ import {
   GEL_SPACING_DBL,
 } from '@bbc/gel-foundations/spacings';
 import Helmet from 'react-helmet';
-import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_B_MIN_WIDTH,
+  GEL_GROUP_CD_MIN_WIDTH,
+} from '@bbc/gel-foundations/breakpoints';
 import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const MENU_ICON_SIDE_LENGTH = '2.75rem'; // 44px
+const TOP_BOTTOM_SPACING = 0.75; // 12px
 
 const getStyles = dir => {
   const direction = dir === 'ltr' ? 'left' : 'right';
@@ -116,14 +120,23 @@ const iconBorder = css`
 `;
 
 const MenuButton = styled.button`
-  width: ${MENU_ICON_SIDE_LENGTH};
-  height: ${MENU_ICON_SIDE_LENGTH};
   position: relative;
   padding: 0;
   margin: 0;
   border: 0;
   background-color: transparent;
   ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
+  ${({ script }) => {
+    // The sideLength of the button should be
+    //  line height + top padding + bottom padding
+    const sideLength = `${script.pica.groupA.lineHeight / 16 +
+      TOP_BOTTOM_SPACING * 2}rem;`;
+    return (
+      script &&
+      `height: ${sideLength};
+      width: ${sideLength};`
+    );
+  }}
 
   &:hover,
   &:focus {
@@ -137,6 +150,36 @@ const MenuButton = styled.button`
     display: none;
     visibility: hidden;
   }
+  @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
+    ${({ script }) => {
+      // The sideLength of the button should be
+      //  line height + top padding + bottom padding
+      const sideLength = `${script.pica.groupA.lineHeight / 16 +
+        TOP_BOTTOM_SPACING * 2}rem;`;
+      return (
+        script &&
+        `height: ${sideLength};
+        width: ${sideLength};`
+      );
+    }}
+  }
+  @media (min-width: ${GEL_GROUP_CD_MIN_WIDTH}rem) {
+    ${({ script }) => {
+      // The sideLength of the button should be
+      //  line height + top padding + bottom padding
+      const sideLength = `${script.pica.groupA.lineHeight / 16 +
+        TOP_BOTTOM_SPACING * 2}rem;`;
+      return (
+        script &&
+        `height: ${sideLength};
+        width: ${sideLength};`
+      );
+    }}
+  }
+
+  & svg {
+    vertical-align: middle;
+  }
 `;
 
 export const CanonicalMenuButton = ({
@@ -145,12 +188,14 @@ export const CanonicalMenuButton = ({
   onOpen,
   onClose,
   dir,
+  script,
 }) => (
   <MenuButton
     aria-label={announcedText}
     onClick={isOpen ? onClose : onOpen}
     aria-expanded={isOpen ? 'true' : 'false'}
     dir={dir}
+    script={script}
   >
     {isOpen ? navigationIcons.cross : navigationIcons.hamburger}
   </MenuButton>
@@ -162,6 +207,7 @@ CanonicalMenuButton.propTypes = {
   onClose: func.isRequired,
   isOpen: bool.isRequired,
   dir: oneOf(['ltr', 'rtl']),
+  script: shape(scriptPropType).isRequired,
 };
 
 CanonicalMenuButton.defaultProps = {
@@ -178,7 +224,7 @@ const AmpHead = () => (
   </Helmet>
 );
 
-export const AmpMenuButton = ({ announcedText, onToggle, dir }) => {
+export const AmpMenuButton = ({ announcedText, onToggle, dir, script }) => {
   const expandedHandler =
     'tap:AMP.setState({ menuState: { expanded: !menuState.expanded }})';
 
@@ -198,6 +244,7 @@ export const AmpMenuButton = ({ announcedText, onToggle, dir }) => {
         data-amp-bind-aria-expanded='menuState.expanded ? "true" : "false"'
         on={`${expandedHandler};${onToggle}`}
         dir={dir}
+        script={script}
       >
         {cloneElement(navigationIcons.hamburger, {
           'data-amp-bind-hidden': 'menuState.expanded',
@@ -215,6 +262,7 @@ AmpMenuButton.propTypes = {
   announcedText: string.isRequired,
   onToggle: string.isRequired,
   dir: oneOf(['ltr', 'rtl']),
+  script: shape(scriptPropType).isRequired,
 };
 
 AmpMenuButton.defaultProps = {

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
@@ -76,6 +76,7 @@ describe('Canonical', () => {
         isOpen
         onClose={() => {}}
         script={latin}
+        dir="ltr"
       />,
     );
 
@@ -87,6 +88,7 @@ describe('Canonical', () => {
         isOpen
         onClose={() => {}}
         script={arabic}
+        dir="rtl"
       />,
     );
   });
@@ -133,6 +135,7 @@ describe('Canonical', () => {
         isOpen={false}
         onClose={() => {}}
         script={latin}
+        dir="ltr"
       />,
     );
 
@@ -144,6 +147,7 @@ describe('Canonical', () => {
         isOpen={false}
         onClose={() => {}}
         script={arabic}
+        dir="rtl"
       />,
     );
   });
@@ -159,11 +163,16 @@ describe('Dropdown navigation', () => {
 describe('AMP Menu Button', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <AmpMenuButton announcedText="Menu" onToggle="" script={latin} />,
+    <AmpMenuButton announcedText="Menu" onToggle="" script={latin} dir="ltr" />,
   );
 
   shouldMatchSnapshot(
     'should render rtl correctly',
-    <AmpMenuButton announcedText="Menu" onToggle="" script={arabic} />,
+    <AmpMenuButton
+      announcedText="Menu"
+      onToggle=""
+      script={arabic}
+      dir="rtl"
+    />,
   );
 });

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { render, fireEvent, getByRole } from '@testing-library/react';
-import { latin } from '@bbc/gel-foundations/scripts';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
 import {
   Dropdown,
   DropdownUl,
@@ -78,6 +78,17 @@ describe('Canonical', () => {
         script={latin}
       />,
     );
+
+    shouldMatchSnapshot(
+      'should render rtl correctly',
+      <CanonicalMenuButton
+        announcedText="Menu"
+        onOpen={() => {}}
+        isOpen
+        onClose={() => {}}
+        script={arabic}
+      />,
+    );
   });
 
   describe('Closed menu button', () => {
@@ -124,6 +135,17 @@ describe('Canonical', () => {
         script={latin}
       />,
     );
+
+    shouldMatchSnapshot(
+      'should render rtl correctly',
+      <CanonicalMenuButton
+        announcedText="Menu"
+        onOpen={() => {}}
+        isOpen={false}
+        onClose={() => {}}
+        script={arabic}
+      />,
+    );
   });
 });
 
@@ -138,5 +160,10 @@ describe('AMP Menu Button', () => {
   shouldMatchSnapshot(
     'should render correctly',
     <AmpMenuButton announcedText="Menu" onToggle="" script={latin} />,
+  );
+
+  shouldMatchSnapshot(
+    'should render rtl correctly',
+    <AmpMenuButton announcedText="Menu" onToggle="" script={arabic} />,
   );
 });

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
@@ -44,6 +44,7 @@ describe('Canonical', () => {
           onOpen={mockOnOpen}
           isOpen
           onClose={mockOnClose}
+          script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
@@ -60,6 +61,7 @@ describe('Canonical', () => {
           onOpen={() => {}}
           isOpen
           onClose={() => {}}
+          script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
@@ -73,6 +75,7 @@ describe('Canonical', () => {
         onOpen={() => {}}
         isOpen
         onClose={() => {}}
+        script={latin}
       />,
     );
   });
@@ -87,6 +90,7 @@ describe('Canonical', () => {
           onOpen={mockOnOpen}
           isOpen={false}
           onClose={mockOnClose}
+          script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
@@ -103,6 +107,7 @@ describe('Canonical', () => {
           onOpen={() => {}}
           isOpen={false}
           onClose={() => {}}
+          script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
@@ -116,6 +121,7 @@ describe('Canonical', () => {
         onOpen={() => {}}
         isOpen={false}
         onClose={() => {}}
+        script={latin}
       />,
     );
   });
@@ -131,6 +137,6 @@ describe('Dropdown navigation', () => {
 describe('AMP Menu Button', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <AmpMenuButton announcedText="Menu" onToggle="" />,
+    <AmpMenuButton announcedText="Menu" onToggle="" script={latin} />,
   );
 });

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -18,7 +18,7 @@ import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const TOP_BOTTOM_SPACING = '0.75rem'; // 12px
+const TOP_BOTTOM_SPACING = '0.75rem'; // 12px - must be the same as MENU_TOP_BOTTOM_SPACING in DropdownNavigation/index.jsx
 const CURRENT_ITEM_HOVER_BORDER = '0.3125rem'; // 5px
 const GRADIENT_WIDTH = '3rem'; // 48px
 

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -17,8 +17,9 @@ import {
 import { getPica } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+import { NAV_BAR_TOP_BOTTOM_SPACING } from './DropdownNavigation';
 
-const TOP_BOTTOM_SPACING = '0.75rem'; // 12px - must be the same as MENU_TOP_BOTTOM_SPACING in DropdownNavigation/index.jsx
+const TOP_BOTTOM_SPACING = `${NAV_BAR_TOP_BOTTOM_SPACING}rem`; // 12px
 const CURRENT_ITEM_HOVER_BORDER = '0.3125rem'; // 5px
 const GRADIENT_WIDTH = '3rem'; // 48px
 

--- a/packages/components/psammead-navigation/src/index.stories.jsx
+++ b/packages/components/psammead-navigation/src/index.stories.jsx
@@ -219,7 +219,7 @@ navStoriesData.map(item => {
 
 canonicalStories.add(
   'Canonical Menu Button',
-  ({ dir }) => {
+  ({ dir, script }) => {
     const isOpen = boolean('Open', false);
     return (
       <BackgroundContainer>
@@ -229,6 +229,7 @@ canonicalStories.add(
           isOpen={isOpen}
           onClose={() => {}}
           dir={dir}
+          script={script}
         />
       </BackgroundContainer>
     );
@@ -278,9 +279,14 @@ navStoriesData.map(item => {
 
 ampStories.add(
   'AMP Menu Button',
-  ({ dir }) => (
+  ({ dir, script }) => (
     <BackgroundContainer>
-      <AmpMenuButton announcedText="Menu" onToggle="" dir={dir} />
+      <AmpMenuButton
+        announcedText="Menu"
+        onToggle=""
+        dir={dir}
+        script={script}
+      />
     </BackgroundContainer>
   ),
   {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Change menu button size depending on script in use - when changing the service in storybook, you'll see the menu icon seem to move place as the button changes size.

**Code changes:**

- Use the script object to change the height and width of the menu button based on the line-height
- Vertically align the svg within the button to ensure it is centred

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
