### PR TITLE
Bulletin: rename type to mediaType

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.14 | [PR#2761](https://github.com/bbc/psammead/pull/2761) Rename `type` to `mediaType` |
 | 0.1.0-alpha.13 | [PR#2760](https://github.com/bbc/psammead/pull/2760) Add `padding-right` to summary above 600px for Radio Bulletin only |
 | 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |
 | 0.1.0-alpha.11 | [PR#2744](https://github.com/bbc/psammead/pull/2744) Add a transparent border around PlayCTA |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -217,7 +217,7 @@ exports[`Bulletin should render audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c7 {
     padding-left: 0;
-    padding-right: 0.5rem;
+    padding-right: 0;
   }
 }
 
@@ -541,7 +541,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c8 {
     padding-left: 0;
-    padding-right: 0.5rem;
+    padding-right: 0;
   }
 }
 

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -282,7 +282,6 @@ exports[`Bulletin should render audio correctly 1`] = `
     </h3>
     <p
       class="c7"
-      type="audio"
     >
       This is the summary text
     </p>
@@ -614,7 +613,6 @@ exports[`Bulletin should render live audio correctly 1`] = `
     </h3>
     <p
       class="c8"
-      type="audio"
     >
       This is the summary text
     </p>
@@ -950,7 +948,6 @@ exports[`Bulletin should render live video correctly 1`] = `
     </h3>
     <p
       class="c8"
-      type="video"
     >
       This is the summary text
     </p>
@@ -1267,7 +1264,6 @@ exports[`Bulletin should render video correctly 1`] = `
     </h3>
     <p
       class="c7"
-      type="video"
     >
       This is the summary text
     </p>

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -193,7 +193,7 @@ const Bulletin = ({
   headlineText,
   summaryText,
   image,
-  type,
+  mediaType,
   ctaText,
   ctaLink,
   liveText,
@@ -201,7 +201,7 @@ const Bulletin = ({
   lang,
   offScreenText,
 }) => {
-  const isAudio = type === 'audio';
+  const isAudio = mediaType === 'audio';
   const BulletinWrapper = isAudio ? RadioBulletinWrapper : TVBulletinWrapper;
   const ImageWrapper = isAudio ? RadioImageWrapper : TVImageWrapper;
   const TextWrapper = isAudio ? RadioTextWrapper : TVTextWrapper;
@@ -227,7 +227,11 @@ const Bulletin = ({
             </span>
           </Link>
         </BulletinHeading>
-        <BulletinSummary script={script} service={service} type={type}>
+        <BulletinSummary
+          script={script}
+          service={service}
+          mediaType={mediaType}
+        >
           {summaryText}
         </BulletinSummary>
         <PlayCTA
@@ -237,7 +241,7 @@ const Bulletin = ({
           isAudio={isAudio}
           dir={dir}
         >
-          <IconWrapper dir={dir}>{mediaIcons[type]}</IconWrapper>
+          <IconWrapper dir={dir}>{mediaIcons[mediaType]}</IconWrapper>
           {ctaText}
         </PlayCTA>
       </TextWrapper>
@@ -246,7 +250,7 @@ const Bulletin = ({
 };
 
 Bulletin.propTypes = {
-  type: oneOf(['video', 'audio']).isRequired,
+  mediaType: oneOf(['video', 'audio']).isRequired,
   isLive: bool,
   service: string.isRequired,
   script: shape(scriptPropType).isRequired,

--- a/packages/components/psammead-bulletin/src/index.stories.jsx
+++ b/packages/components/psammead-bulletin/src/index.stories.jsx
@@ -7,11 +7,18 @@ import notes from '../README.md';
 import Bulletin from '.';
 
 /* eslint-disable react/prop-types */
-const BulletinComponent = ({ script, service, type, hasImage, dir, text }) => {
+const BulletinComponent = ({
+  script,
+  service,
+  mediaType,
+  hasImage,
+  dir,
+  text,
+}) => {
   const ctaLink = 'https://bbc.co.uk';
 
   const isLive = boolean('Live', false);
-  const ctaText = type === 'audio' ? 'Listen' : 'Watch';
+  const ctaText = mediaType === 'audio' ? 'Listen' : 'Watch';
   const playCtaText = isLive ? `${ctaText} Live` : ctaText;
   const offScreenText = isLive ? `${ctaText} LIVE` : ctaText;
 
@@ -25,7 +32,7 @@ const BulletinComponent = ({ script, service, type, hasImage, dir, text }) => {
   return (
     <Bulletin
       image={hasImage && image}
-      type={type}
+      mediaType={mediaType}
       isLive={isLive}
       script={script}
       service={service}
@@ -48,7 +55,7 @@ storiesOf('Components|Bulletin', module)
       <BulletinComponent
         script={script}
         service={service}
-        type="video"
+        mediaType="video"
         hasImage
         dir={dir}
         text={textSnipet}
@@ -65,7 +72,7 @@ storiesOf('Components|Bulletin', module)
         <BulletinComponent
           script={script}
           service={service}
-          type="audio"
+          mediaType="audio"
           hasImage={hasImage}
           dir={dir}
           text={textSnipet}

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -5,7 +5,7 @@ import Image from '@bbc/psammead-image';
 import Bulletin from '.';
 
 /* eslint-disable react/prop-types */
-const BulletinComponent = ({ script, service, isLive, type, ctaText }) => {
+const BulletinComponent = ({ script, service, isLive, mediaType, ctaText }) => {
   const summaryText = 'This is the summary text';
   const headlineText = 'This is the headline';
   const ctaLink = 'https://bbc.co.uk';
@@ -22,7 +22,7 @@ const BulletinComponent = ({ script, service, isLive, type, ctaText }) => {
   return (
     <Bulletin
       image={image}
-      type={type}
+      mediaType={mediaType}
       isLive={isLive}
       script={script}
       service={service}
@@ -42,7 +42,7 @@ describe('Bulletin', () => {
       script={latin}
       service="news"
       ctaText="Listen"
-      type="audio"
+      mediaType="audio"
     />,
   );
 
@@ -52,7 +52,7 @@ describe('Bulletin', () => {
       script={latin}
       service="news"
       ctaText="Watch"
-      type="video"
+      mediaType="video"
     />,
   );
 
@@ -62,7 +62,7 @@ describe('Bulletin', () => {
       script={latin}
       service="news"
       ctaText="Listen"
-      type="audio"
+      mediaType="audio"
       isLive
     />,
   );
@@ -73,7 +73,7 @@ describe('Bulletin', () => {
       script={latin}
       service="news"
       ctaText="Watch"
-      type="video"
+      mediaType="video"
       isLive
     />,
   );


### PR DESCRIPTION
Resolves N/A

**Overall change:** rename `type` variable to `mediaType`

**Code changes:**

- rename `type` to `mediaType` in component, story, and tests.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
