### PR TITLE
Bulletin - Use mediaType

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.15 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `mediaType` to apply `padding-right` to summary above 600px for Radio Bulletin only |
 | 0.1.0-alpha.14 | [PR#2761](https://github.com/bbc/psammead/pull/2761) Rename `type` to `mediaType` |
 | 0.1.0-alpha.13 | [PR#2760](https://github.com/bbc/psammead/pull/2760) Add `padding-right` to summary above 600px for Radio Bulletin only |
 | 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.15 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Use `mediaType` to apply `padding-right` to summary above 600px for Radio Bulletin only |
+| 0.1.0-alpha.15 | [PR#2764](https://github.com/bbc/psammead/pull/2764) Use `mediaType` to apply `padding-right` to summary above 600px for Radio Bulletin only |
 | 0.1.0-alpha.14 | [PR#2761](https://github.com/bbc/psammead/pull/2761) Rename `type` to `mediaType` |
 | 0.1.0-alpha.13 | [PR#2760](https://github.com/bbc/psammead/pull/2760) Add `padding-right` to summary above 600px for Radio Bulletin only |
 | 0.1.0-alpha.12 | [PR#2755](https://github.com/bbc/psammead/pull/2755) Add `padding-right` to summary above 600px |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -217,7 +217,7 @@ exports[`Bulletin should render audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c7 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 
@@ -541,7 +541,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
 @media (min-width:37.5rem) {
   .c8 {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5rem;
   }
 }
 

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -158,7 +158,8 @@ const BulletinSummary = styled.p`
   padding: 0 ${GEL_SPACING};
   @media(min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding-left: 0;
-    padding-right: ${({ type }) => (type === 'audio' ? `${GEL_SPACING}` : `0`)};
+    padding-right: ${({ mediaType }) =>
+      mediaType === 'audio' ? `${GEL_SPACING}` : `0`};
   }
   padding-bottom: ${GEL_SPACING_DBL};
 `;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Use `mediaType` to apply `padding-right` to Radio Bulletin summary.

**Code changes:**
- Replace `type` with `mediaType`:
```
 padding-right: ${({ mediaType }) =>
      mediaType === 'audio' ? `${GEL_SPACING}` : `0`};
```

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
