### PR TITLE
Fix nav menu border in High Contrast

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.0-alpha.8 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Fix menu border in FireFox high contrast mode |
+| 6.0.0-alpha.8 | [PR#2778](https://github.com/bbc/psammead/pull/2778) Fix menu border in FireFox high contrast mode |
 | 6.0.0-alpha.7 | [PR#2771](https://github.com/bbc/psammead/pull/2771) Spread the `on` prop (and others) onto the button, and set AMP Nav menu button initial state |
 | 6.0.0-alpha.6 | [PR#2769](https://github.com/bbc/psammead/pull/2769) Add `isOpen` prop to `Navigation` |
 | 6.0.0-alpha.5 | [PR#2759](https://github.com/bbc/psammead/pull/2759) Change size of menu button depending on script |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.6 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Fix menu border in FireFox high contrast mode |
 | 6.0.0-alpha.5 | [PR#2759](https://github.com/bbc/psammead/pull/2759) Change size of menu button depending on script |
 | 6.0.0-alpha.4 | [PR#2747](https://github.com/bbc/psammead/pull/2747) Fix MenuButton not acting as a block element |
 | 6.0.0-alpha.3 | [PR#2745](https://github.com/bbc/psammead/pull/2745) Add dir prop to Amp and Canonical MenuButton |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.5",
+  "version": "6.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.5",
+  "version": "6.0.0-alpha.6",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -10,11 +10,11 @@ exports[`AMP Menu Button should render correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
+  border: 0;
 }
 
 .c0:hover,
@@ -132,11 +132,11 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
+  border: 0;
 }
 
 .c0:hover,
@@ -236,11 +236,11 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
+  border: 0;
 }
 
 .c0:hover,
@@ -309,11 +309,11 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
+  border: 0;
 }
 
 .c0:hover,
@@ -382,11 +382,11 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
+  border: 0;
 }
 
 .c0:hover,
@@ -456,11 +456,11 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
+  border: 0;
 }
 
 .c0:hover,

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -11,10 +11,10 @@ exports[`AMP Menu Button should render correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
-  border: 0;
 }
 
 .c0:hover,
@@ -133,10 +133,10 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
-  border: 0;
 }
 
 .c0:hover,
@@ -237,10 +237,10 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
-  border: 0;
 }
 
 .c0:hover,
@@ -310,10 +310,10 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
-  border: 0;
 }
 
 .c0:hover,
@@ -383,10 +383,10 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: left;
   height: 2.75rem;
   width: 2.75rem;
-  border: 0;
 }
 
 .c0:hover,
@@ -457,10 +457,10 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
   float: right;
   height: 3.125rem;
   width: 3.125rem;
-  border: 0;
 }
 
 .c0:hover,

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -143,6 +143,8 @@ const MenuButton = styled(Button)`
   padding: 0;
   margin: 0;
   background-color: transparent;
+  border: 0;
+
   ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
   ${({ script }) =>
     script &&
@@ -155,7 +157,6 @@ const MenuButton = styled(Button)`
       ${iconBorder};
     }
   }
-  border: 0;
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     display: none;

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -131,7 +131,6 @@ const MenuButton = styled.button`
   position: relative;
   padding: 0;
   margin: 0;
-  border: 0;
   background-color: transparent;
   ${({ dir }) => (dir === 'ltr' ? `float: left;` : `float: right;`)}
   ${({ script }) =>
@@ -145,6 +144,7 @@ const MenuButton = styled.button`
       ${iconBorder};
     }
   }
+  border: 0;
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     display: none;


### PR DESCRIPTION
Resolves #2774

**Overall change:**
Borders and icon are now properly located on a button and do not get shifted in High Contrast mode on FireFox.
<img width="163" alt="Screenshot 2019-12-05 at 14 37 25" src="https://user-images.githubusercontent.com/17802955/70244820-09b5b980-176d-11ea-8198-ee9df26469c3.png">

**Code changes:**
The problem before was that (only in FF HC mode) a border appeared which was not supposed to be there. Rearranging the styling fixed the issue.
<img width="272" alt="Screenshot 2019-12-05 at 14 35 51" src="https://user-images.githubusercontent.com/17802955/70244948-37026780-176d-11ea-9f68-245935eaac82.png">


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
