### PR TITLE
Add `id`,  `ampOpenClass` props to Navigation

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.10 | [PR#2785](https://github.com/bbc/psammead/pull/2785) Add `id`, `ampOpenClass` props to `Navigation` |
 | 6.0.0-alpha.9 | [PR#2779](https://github.com/bbc/psammead/pull/2779) Merge AMP tap handlers correctly |
 | 6.0.0-alpha.8 | [PR#2778](https://github.com/bbc/psammead/pull/2778) Fix menu border in FireFox high contrast mode |
 | 6.0.0-alpha.7 | [PR#2771](https://github.com/bbc/psammead/pull/2771) Spread the `on` prop (and others) onto the button, and set AMP Nav menu button initial state |

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -27,6 +27,8 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | children | node | Yes | N/A | `<ScrollableNavigation dir={dir}><NavigationUl><NavigationLi url="/" script={latin} active="true">Home</NavigationLi><NavigationLi url="/sport" script={latin}>{Sport}</NavigationLi></NavigationUl><ScrollableNavigation/>` |
 | dir | string | No | `'ltr'` | `'rtl'` |
 | isOpen | boolean | No | `false` | `true` |
+| id | string | No | `null` | `navigation-id` |
+| ampOpenClass | string | No | `null` | `'open'` |
 
 ### NavigationUl
 

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.9",
+  "version": "6.0.0-alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.9",
+  "version": "6.0.0-alpha.10",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -263,6 +263,281 @@ exports[`Navigation should render correctly 1`] = `
 </nav>
 `;
 
+exports[`Navigation should render correctly when ampOpenClass is provided 1`] = `
+.c7 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c1 {
+  position: relative;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c2 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+}
+
+.c5 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c5:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.3125rem solid #FFFFFF;
+}
+
+.c5:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c8 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c8:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c8:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c4 {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+}
+
+.c6::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c9 .c3::after {
+  left: 0;
+}
+
+.c10 .c3::after {
+  left: 0;
+}
+
+.c0 {
+  position: relative;
+  background-color: #B80000;
+  border-top: 0.0625rem solid #FFFFFF;
+}
+
+.c0.is-open {
+  background-color: #222222;
+}
+
+.c0 .c3::after {
+  left: 0;
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    overflow: hidden;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c5 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c5 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c5 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c8 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c4:last-child {
+    margin-right: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    width: 80rem;
+    border-bottom: 0.0625rem solid #eab3b3;
+    z-index: -1;
+  }
+}
+
+<nav
+  class="c0"
+  dir="ltr"
+  role="navigation"
+>
+  <div
+    class="c1"
+  >
+    <ul
+      class="c2"
+      role="list"
+    >
+      <li
+        class="c3 c4"
+        dir="ltr"
+        role="listitem"
+      >
+        <a
+          class="c5"
+          data-navigation="test_navigation"
+          href="/igbo"
+        >
+          <span
+            class="c6"
+            role="text"
+          >
+            <span
+              class="c7"
+            >
+              Current page
+              , 
+            </span>
+            Akụkọ
+          </span>
+        </a>
+      </li>
+      <li
+        class="c3 c4"
+        dir="ltr"
+        role="listitem"
+      >
+        <a
+          class="c8"
+          data-navigation="test_navigation"
+          href="/igbo/egwuregwu"
+        >
+          Egwuregwu
+        </a>
+      </li>
+      <li
+        class="c3 c4"
+        dir="ltr"
+        role="listitem"
+      >
+        <a
+          class="c8"
+          data-navigation="test_navigation"
+          href="/igbo/media/video"
+        >
+          Ihe nkiri
+        </a>
+      </li>
+      <li
+        class="c3 c4"
+        dir="ltr"
+        role="listitem"
+      >
+        <a
+          class="c8"
+          data-navigation="test_navigation"
+          href="/igbo/popular/read"
+        >
+          Nke ka ewuewu
+        </a>
+      </li>
+    </ul>
+  </div>
+</nav>
+`;
+
 exports[`Navigation should render correctly when isOpen is true 1`] = `
 .c7 {
   -webkit-clip-path: inset(100%);
@@ -654,6 +929,10 @@ exports[`Scrollable Navigation should render AMP version correctly 1`] = `
   left: 0;
 }
 
+.c11 .c4::after {
+  left: 0;
+}
+
 @media (max-width:37.4375rem) {
   .c0 {
     white-space: nowrap;
@@ -957,6 +1236,10 @@ exports[`Scrollable Navigation should render Canonical version correctly 1`] = `
 }
 
 .c10 .c4::after {
+  left: 0;
+}
+
+.c11 .c4::after {
   left: 0;
 }
 

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -263,7 +263,7 @@ exports[`Navigation should render correctly 1`] = `
 </nav>
 `;
 
-exports[`Navigation should render correctly when ampOpenClass is provided 1`] = `
+exports[`Navigation should render correctly when ampOpenClass prop is provided 1`] = `
 .c7 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -387,7 +387,7 @@ exports[`Navigation should render correctly when ampOpenClass is provided 1`] = 
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.c0.is-open {
+.c0 {
   background-color: #222222;
 }
 

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -217,9 +217,19 @@ NavigationLi.defaultProps = {
   dir: 'ltr',
 };
 
+// ampOpenClass is the class added to the Navigation, and is toggled on tap.
+// It indicates whether the menu is open or not. This overrides the background
+// color of the Navigation
 const StyledNav = styled.nav`
   position: relative;
   ${({ isOpen }) => `background-color: ${isOpen ? C_EBON : C_POSTBOX};`}
+  ${({ ampOpenClass }) =>
+    ampOpenClass &&
+    css`
+      &.${ampOpenClass} {
+        background-color: ${C_EBON};
+      }
+    `}
   border-top: 0.0625rem solid ${C_WHITE};
 
   ${StyledListItem} {
@@ -231,9 +241,15 @@ const StyledNav = styled.nav`
   }
 `;
 
-const Navigation = ({ children, dir, isOpen }) => {
+const Navigation = ({ children, dir, isOpen, id, ampOpenClass }) => {
   return (
-    <StyledNav role="navigation" dir={dir} isOpen={isOpen}>
+    <StyledNav
+      role="navigation"
+      dir={dir}
+      isOpen={isOpen}
+      id={id}
+      ampOpenClass={ampOpenClass}
+    >
       <NavWrapper>{children}</NavWrapper>
     </StyledNav>
   );
@@ -243,11 +259,15 @@ Navigation.propTypes = {
   children: node.isRequired,
   dir: oneOf(['ltr', 'rtl']),
   isOpen: bool,
+  id: string,
+  ampOpenClass: string,
 };
 
 Navigation.defaultProps = {
   dir: 'ltr',
   isOpen: false,
+  id: null,
+  ampOpenClass: null,
 };
 
 export default Navigation;

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -226,7 +226,7 @@ const StyledNav = styled.nav`
   ${({ ampOpenClass }) =>
     ampOpenClass &&
     css`
-      &.${ampOpenClass} {
+       {
         background-color: ${C_EBON};
       }
     `}

--- a/packages/components/psammead-navigation/src/index.test.jsx
+++ b/packages/components/psammead-navigation/src/index.test.jsx
@@ -54,7 +54,7 @@ describe('Navigation', () => {
   );
 
   shouldMatchSnapshot(
-    'should render correctly when ampOpenClass is provided',
+    'should render correctly when ampOpenClass prop is provided',
     <Navigation
       script={latin}
       skipLinkText="Wụga n’ọdịnaya"

--- a/packages/components/psammead-navigation/src/index.test.jsx
+++ b/packages/components/psammead-navigation/src/index.test.jsx
@@ -40,6 +40,7 @@ const NavigationExample = (
 
 describe('Navigation', () => {
   shouldMatchSnapshot('should render correctly', NavigationExample);
+
   shouldMatchSnapshot(
     'should render correctly when isOpen is true',
     <Navigation
@@ -47,6 +48,18 @@ describe('Navigation', () => {
       skipLinkText="Wụga n’ọdịnaya"
       service="news"
       isOpen
+    >
+      {navigationUlComponent}
+    </Navigation>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly when ampOpenClass is provided',
+    <Navigation
+      script={latin}
+      skipLinkText="Wụga n’ọdịnaya"
+      service="news"
+      ampOpenClass="is-open"
     >
       {navigationUlComponent}
     </Navigation>,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _Adds `id`,  `ampOpenClass` props to Navigation component._

**Code changes:**
- _Adds `id`,  `ampOpenClass` props._ 
- _Add test._
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
