### PR TITLE
Convert psammead-bulleted-list bullet svg completely to base64

### DIFF
--- a/packages/components/psammead-bulleted-list/CHANGELOG.md
+++ b/packages/components/psammead-bulleted-list/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.2.0-alpha.2 | [PR#2798](https://github.com/bbc/psammead/pull/2798) Convert psammead-bulleted-list bullet svg completely to base64. |
 | 0.2.0-alpha.1 | [PR#2746](https://github.com/bbc/psammead/pull/2746) Add a11y role to list and spacing to list item. |
 | 0.1.0-alpha.4 | [PR#2698](https://github.com/bbc/psammead/pull/2698) Add test for list styling to psammead-bulleted-lists. |
 | 0.1.0-alpha.3 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-bulleted-list/package-lock.json
+++ b/packages/components/psammead-bulleted-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulleted-list/package.json
+++ b/packages/components/psammead-bulleted-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
@@ -14,7 +14,12 @@ exports[`PsammeadBulletedList should render correctly from ltr 1`] = `
   content: ' ';
   display: inline-block;
   width: 2rem;
-  background: url("data:image/svg+xml,%3Csvg height='10' width='10' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E @media screen and (-ms-high-contrast: active){svg{fill: #fff;
+  background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E') no-repeat center;
+  margin-left: -2rem;
+}
+
+.c1 {
+  margin-bottom: 1rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -37,19 +42,19 @@ exports[`PsammeadBulletedList should render correctly from ltr 1`] = `
   role="list"
 >
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     First item on the list
   </li>
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     Second item on the list
   </li>
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     Final list item
@@ -58,25 +63,60 @@ exports[`PsammeadBulletedList should render correctly from ltr 1`] = `
 `;
 
 exports[`PsammeadBulletedList should render correctly from rtl 1`] = `
+.c0 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  list-style-type: none;
+}
+
+.c0 > li::before {
+  content: ' ';
+  display: inline-block;
+  width: 2rem;
+  background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E') no-repeat center;
+  margin-right: -2rem;
+}
+
+.c1 {
+  margin-bottom: 1rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.375rem;
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1.375rem;
+    line-height: 2rem;
+  }
+}
+
 <ul
-  class=""
+  class="c0"
   dir="rtl"
   role="list"
 >
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     العنصر الأول في القائمة
   </li>
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     البند الثاني في القائمة
   </li>
   <li
-    class=""
+    class="c1"
     role="listitem"
   >
     عنصر القائمة النهائية

--- a/packages/components/psammead-bulleted-list/src/index.jsx
+++ b/packages/components/psammead-bulleted-list/src/index.jsx
@@ -18,7 +18,7 @@ const BulletedList = styled.ul.attrs(() => ({
     content: '\u00A0';
     display: inline-block;
     width: ${GEL_SPACING_QUAD};
-    background: url("data:image/svg+xml,%3Csvg height='10' width='10' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E @media screen and (-ms-high-contrast: active){svg{fill: #fff}}%3C/style%3E%3Ccircle cx='5' cy='5' r='3'%3E%3C/circle%3E%3C/svg%3E")
+    background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E')
       no-repeat center;
     ${({ dir }) =>
       dir === 'rtl'


### PR DESCRIPTION
Resolves #2795

**Overall change:** 
Convert `psammead-bulleted-list` bullet `svg` completely to base64.

**Code changes:**
- Update background image to be completely in b64

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
