### PR TITLE
Refactor navigation props

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.0-alpha.11 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Refactor Canonical MenuButton props |
+| 6.0.0-alpha.11 | [PR#2799](https://github.com/bbc/psammead/pull/2799) Refactor Canonical MenuButton props |
 | 6.0.0-alpha.10 | [PR#2785](https://github.com/bbc/psammead/pull/2785) Add `id`, `ampOpenClass` props to `Navigation` |
 | 6.0.0-alpha.9 | [PR#2779](https://github.com/bbc/psammead/pull/2779) Merge AMP tap handlers correctly |
 | 6.0.0-alpha.8 | [PR#2778](https://github.com/bbc/psammead/pull/2778) Fix menu border in FireFox high contrast mode |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.11 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Refactor Canonical MenuButton props |
 | 6.0.0-alpha.10 | [PR#2785](https://github.com/bbc/psammead/pull/2785) Add `id`, `ampOpenClass` props to `Navigation` |
 | 6.0.0-alpha.9 | [PR#2779](https://github.com/bbc/psammead/pull/2779) Merge AMP tap handlers correctly |
 | 6.0.0-alpha.8 | [PR#2778](https://github.com/bbc/psammead/pull/2778) Fix menu border in FireFox high contrast mode |

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -95,8 +95,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | Argument | Type | Required | Default | Example |
 | -------- | ---- | -------- | ------- | ------- |
 | announcedText | string | Yes | N/A | `'Menu'` |
-| onOpen | function | Yes | N/A | `() => { console.log("Handle open action"); }` |
-| onClose | function | Yes | N/A | `() => { console.log("Handle close action"); }` |
+| onClick | function | Yes | N/A | `() => { console.log("Handle open action"); }` |
 | isOpen | bool | Yes | N/A | `false` |
 | dir | string | no | `'ltr'` | `'rtl'` |
 | script   | object  | Yes      | N/A     |  `{ canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }` |
@@ -184,12 +183,10 @@ import { latin } from '@bbc/gel-foundations/scripts';
 
 <CanonicalMenuButton
   announcedText="Menu"
-  isOpen={true}
-  onOpen={() => {
+  isOpen
+  dir={dir}
+  onClick={() => {
     console.log('Handle open action');
-  }}
-  onClose={() => {
-    console.log('Handle close action');
   }}
   script={latin}
 />
@@ -206,6 +203,7 @@ import { latin } from '@bbc/gel-foundations/scripts';
   announcedText="Menu"
   onToggle="menu.toggleVisibility"
   script={latin}
+  dir={dir}
 />
 ```
 

--- a/packages/components/psammead-navigation/README.md
+++ b/packages/components/psammead-navigation/README.md
@@ -95,7 +95,7 @@ The `@bbc/psammead-navigation` package is a set of two components, `NavigationUl
 | Argument | Type | Required | Default | Example |
 | -------- | ---- | -------- | ------- | ------- |
 | announcedText | string | Yes | N/A | `'Menu'` |
-| onClick | function | Yes | N/A | `() => { console.log("Handle open action"); }` |
+| onClick | function | Yes | N/A | `() => { console.log("Handle onClick action"); }` |
 | isOpen | bool | Yes | N/A | `false` |
 | dir | string | no | `'ltr'` | `'rtl'` |
 | script   | object  | Yes      | N/A     |  `{ canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }` |
@@ -186,7 +186,7 @@ import { latin } from '@bbc/gel-foundations/scripts';
   isOpen
   dir={dir}
   onClick={() => {
-    console.log('Handle open action');
+    console.log('Handle onClick action');
   }}
   script={latin}
 />

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.11",
+  "version": "6.0.0-alpha.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.11",
+  "version": "6.0.0-alpha.12",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -175,14 +175,13 @@ const MenuButton = styled(Button)`
 export const CanonicalMenuButton = ({
   announcedText,
   isOpen,
-  onOpen,
-  onClose,
+  onClick,
   dir,
   script,
 }) => (
   <MenuButton
     aria-label={announcedText}
-    onClick={isOpen ? onClose : onOpen}
+    onClick={onClick}
     aria-expanded={isOpen ? 'true' : 'false'}
     dir={dir}
     script={script}
@@ -193,8 +192,7 @@ export const CanonicalMenuButton = ({
 
 CanonicalMenuButton.propTypes = {
   announcedText: string.isRequired,
-  onOpen: func.isRequired,
-  onClose: func.isRequired,
+  onClick: func.isRequired,
   isOpen: bool.isRequired,
   dir: oneOf(['ltr', 'rtl']),
   script: shape(scriptPropType).isRequired,

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
@@ -35,32 +35,28 @@ const dropdownList = (
 
 describe('Canonical', () => {
   describe('Open menu button', () => {
-    it('should call onClose handler when clicked', () => {
-      const mockOnClose = jest.fn();
-      const mockOnOpen = jest.fn();
+    it('should call onClick handler when clicked', () => {
+      const mockOnClick = jest.fn();
       const { container } = render(
         <CanonicalMenuButton
           announcedText="Menu"
-          onOpen={mockOnOpen}
+          onClick={mockOnClick}
           isOpen
-          onClose={mockOnClose}
           script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
 
       fireEvent.click(menuButton);
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
-      expect(mockOnOpen).not.toHaveBeenCalled();
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
 
     it('should have aria-expanded set as true', () => {
       const { container } = render(
         <CanonicalMenuButton
           announcedText="Menu"
-          onOpen={() => {}}
+          onClick={() => {}}
           isOpen
-          onClose={() => {}}
           script={latin}
         />,
       );
@@ -72,9 +68,8 @@ describe('Canonical', () => {
       'should render correctly',
       <CanonicalMenuButton
         announcedText="Menu"
-        onOpen={() => {}}
+        onClick={() => {}}
         isOpen
-        onClose={() => {}}
         script={latin}
         dir="ltr"
       />,
@@ -84,9 +79,8 @@ describe('Canonical', () => {
       'should render rtl correctly',
       <CanonicalMenuButton
         announcedText="Menu"
-        onOpen={() => {}}
+        onClick={() => {}}
         isOpen
-        onClose={() => {}}
         script={arabic}
         dir="rtl"
       />,
@@ -94,32 +88,28 @@ describe('Canonical', () => {
   });
 
   describe('Closed menu button', () => {
-    it('should call onOpen handler when clicked', () => {
-      const mockOnClose = jest.fn();
-      const mockOnOpen = jest.fn();
+    it('should call onClick handler when clicked', () => {
+      const mockOnClick = jest.fn();
       const { container } = render(
         <CanonicalMenuButton
           announcedText="Menu"
-          onOpen={mockOnOpen}
+          onClick={mockOnClick}
           isOpen={false}
-          onClose={mockOnClose}
           script={latin}
         />,
       );
       const menuButton = getByRole(container, 'button');
 
       fireEvent.click(menuButton);
-      expect(mockOnOpen).toHaveBeenCalledTimes(1);
-      expect(mockOnClose).not.toHaveBeenCalled();
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
 
     it('should have aria-expanded set as false', () => {
       const { container } = render(
         <CanonicalMenuButton
           announcedText="Menu"
-          onOpen={() => {}}
+          onClick={() => {}}
           isOpen={false}
-          onClose={() => {}}
           script={latin}
         />,
       );
@@ -131,9 +121,8 @@ describe('Canonical', () => {
       'should render correctly',
       <CanonicalMenuButton
         announcedText="Menu"
-        onOpen={() => {}}
+        onClick={() => {}}
         isOpen={false}
-        onClose={() => {}}
         script={latin}
         dir="ltr"
       />,
@@ -143,9 +132,8 @@ describe('Canonical', () => {
       'should render rtl correctly',
       <CanonicalMenuButton
         announcedText="Menu"
-        onOpen={() => {}}
+        onClick={() => {}}
         isOpen={false}
-        onClose={() => {}}
         script={arabic}
         dir="rtl"
       />,

--- a/packages/components/psammead-navigation/src/index.stories.jsx
+++ b/packages/components/psammead-navigation/src/index.stories.jsx
@@ -232,9 +232,8 @@ canonicalStories.add(
       <BackgroundContainer>
         <CanonicalMenuButton
           announcedText="Menu"
-          onOpen={() => {}}
+          onClick={() => {}}
           isOpen={isOpen}
-          onClose={() => {}}
           dir={dir}
           script={script}
         />


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Canonical Menu Button had separate `onOpen` and `onClose` props for handling action. While integrating navigation in Simorgh we saw that these props do not need to be separated and we can merge them together into just one for a purpose of having cleaner code.

**Code changes:**
- _Merge `onOpen` and `onClose` props into one `onClick` prop_
- _Update tests, stories and readme_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
