### PR TITLE
Remove display:inline on outer grids

### DIFF
--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.0-alpha.2 | [PR#2815](https://github.com/bbc/psammead/pull/2815) Remove display:inline on outer grids |
 | 1.1.0-alpha.1 | [PR#2796](https://github.com/bbc/psammead/pull/2796) Fix padding on outer grid  |
 | 1.1.0-alpha.0 | [PR#2653](https://github.com/bbc/psammead/pull/2653) Remove enableGelMargins &enableNegativeGelMargins props & replace with margins. Update width calculations for fallbacks when using enableGelGutters. |
 | 1.0.0-alpha.15 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-grid/README.md
+++ b/packages/components/psammead-grid/README.md
@@ -18,7 +18,7 @@ Psammead Grid is a component that you can use to set out column-based layouts us
 | startOffset | object | no | Sets all values as 1 for each of the groups defined in `columns` | `{ group0: 1, group1: 1, group2: 1, group3: 1, group4: 2, group5: 5 }` |
 | item | boolean | no | false | `item` |
 | enableGelGutters | boolean | no | false | `enableGelGutter` |
-| margins | object | no | false | `{ group0: true, group1: true, group2: true, group3: true }` |
+| margins | object | no | `{ group0: false, group1: false, group2: false, group3: false, group4: false, group5: false }` | `{ group0: true, group1: true, group2: true, group3: true }` |
 
 - When should I use the `columns` prop?
   - This should always be defined.

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Grid component should render Grid with Grid items 1`] = `
-.c0 {
-  display: inline-block;
-}
-
 .c2 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -516,14 +512,6 @@ exports[`Grid component should render Grid with Grid items 1`] = `
 `;
 
 exports[`Grid component should render Grid with Grid items including nested non-Grid Figure element 1`] = `
-.c0 {
-  display: inline-block;
-}
-
-.c4 {
-  display: inline-block;
-}
-
 .c2 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -1004,10 +992,6 @@ exports[`Grid component should render Grid with Grid items including nested non-
 `;
 
 exports[`Grid component should render Grid with enableGelGutters & margins on only one of the Grid items 1`] = `
-.c0 {
-  display: inline-block;
-}
-
 .c3 {
   display: block;
   width: 100%;

--- a/packages/components/psammead-grid/src/index.jsx
+++ b/packages/components/psammead-grid/src/index.jsx
@@ -228,8 +228,7 @@ const gridFallbacks = css`
 
     const selectedGroups = Object.keys(columns);
     return `
-      ${isOuterGrid ? 'display: inline-block;' : ''}
-
+    
       ${selectedGroups
         .map(
           group => `


### PR DESCRIPTION
Resolves #2814 

**Overall change:** _Currently, the outer grid is displayed as an `inline` element. This causes it to misbehave when `paddings` and `margins` are applied to it. In this solution, I'm removing inline display in outer grid, we can display the grid in an inline manner by adding an inline wrapper around it on a need basis._

**Code changes:**

- _Remove `display:inline-block` in fallbacks for outer grid._
- _Update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
