### PR TITLE
remove code owner restriction from /packages dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 /scripts/*  @hindsc52 @jamesdonoh @benjaminhobbs @jroebu14 @craigkj
-/packages/ @jblaut @sareh @benjaminhobbs @jroebu14 @craigkj @denishdz
 Jenkinsfile @hindsc52 @jamesdonoh @benjaminhobbs @craigkj
 
 **/*CODEOWNERS* @bbc/simorgh-admins


### PR DESCRIPTION
Removing the code owner restriction on the `/packages` dir