### PR TITLE
Remove package jest-fetch-mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.38 | [PR#2846](https://github.com/bbc/psammead/pull/2846) Remove package jest-fetch-mock |
 | 2.0.37 | [PR#2843](https://github.com/bbc/psammead/pull/2843) Bumping dependencies |
 | 2.0.36 | [PR#2828](https://github.com/bbc/psammead/pull/2828) Add guide on creating new components |
 | 2.0.35 | [PR#2831](https://github.com/bbc/psammead/pull/2831) Bump Dev Dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,24 +10842,6 @@
         "gud": "^1.0.0"
       }
     },
-    "cross-fetch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
-      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.0",
-        "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        }
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -17311,16 +17293,6 @@
         "jest-util": "^24.9.0"
       }
     },
-    "jest-fetch-mock": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.0.tgz",
-      "integrity": "sha512-lPizzB0qLury+RNutT//G+XVPihMU4Eb/RJziXMdlBSr9jkrj1wKEvf3dGfzX9/1x3Npg5/LdG579q+1Bey/cg==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^3.0.4",
-        "promise-polyfill": "^8.1.3"
-      }
-    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
@@ -21583,12 +21555,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
-    },
-    "promise-polyfill": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
       "dev": true
     },
     "promise-retry": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "glob-loader": "^0.3.0",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
-    "jest-fetch-mock": "^3.0.0",
     "jest-styled-components": "^6.3.4",
     "json5": "^2.1.1",
     "lerna": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _Remove unused NPM package `jest-fetch-mock`._

**Code changes:**

- _Removed `jest-fetch-mock` from `package.json` and `package-lock.json`._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
