### PR TITLE
Export Nepali numerals

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.0.0 | [PR#2749](https://github.com/bbc/psammead/pull/2749) Use nepali numerals instead of western arabic numerals |
+| 4.1.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Export Nepali numerals. |
+| 4.0.0 | [PR#2749](https://github.com/bbc/psammead/pull/2749) Use nepali numerals instead of western arabic numerals for moment datetime. |
 | 3.0.1 | [PR#2525](https://github.com/bbc/psammead/pull/2525) Disable Chromatic QA running on psammead-locales/moment stories. |
 | 3.0.0 | [PR#2375](https://github.com/bbc/psammead/pull/2375) Removed `fa` locale override and jalaali calendar helper  |
 | 2.23.0 | [PR#2300](https://github.com/bbc/psammead/pull/2300) Add `makeNumeralTranslator` helper |

--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.1.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Export Nepali numerals. |
+| 4.1.0 | [PR#2855](https://github.com/bbc/psammead/pull/2855) Export Nepali numerals. |
 | 4.0.0 | [PR#2749](https://github.com/bbc/psammead/pull/2749) Use nepali numerals instead of western arabic numerals for moment datetime. |
 | 3.0.1 | [PR#2525](https://github.com/bbc/psammead/pull/2525) Disable Chromatic QA running on psammead-locales/moment stories. |
 | 3.0.0 | [PR#2375](https://github.com/bbc/psammead/pull/2375) Removed `fa` locale override and jalaali calendar helper  |

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-locales/src/numerals/__snapshots__/index.test.js.snap
+++ b/packages/utilities/psammead-locales/src/numerals/__snapshots__/index.test.js.snap
@@ -48,6 +48,22 @@ Array [
 ]
 `;
 
+exports[`Numeral systems should return Nepali numerals 1`] = `
+Array [
+  "०",
+  "१",
+  "२",
+  "३",
+  "४",
+  "५",
+  "६",
+  "७",
+  "८",
+  "९",
+  "१०",
+]
+`;
+
 exports[`Numeral systems should return WesternArabic numerals 1`] = `
 Array [
   "0",

--- a/packages/utilities/psammead-locales/src/numerals/index.js
+++ b/packages/utilities/psammead-locales/src/numerals/index.js
@@ -13,6 +13,7 @@ export const EasternArabic = [
   '۹',
   '۱۰',
 ];
+export const Nepali = ['०', '१', '२', '३', '४', '५', '६', '७', '८', '९', '१०'];
 export const WesternArabic = [
   '0',
   '1',


### PR DESCRIPTION
Resolves #2854

**Overall change:** Adds Nepali numerals to the `@bbc/psammead-locales` package. 

**Code changes:**

- Exports Nepali numerals

Storybook: http://localhost:8180/?path=/story/utilities-psammead-locales--numerals
<img width="798" alt="Screenshot of storybook showing numerals" src="https://user-images.githubusercontent.com/3028997/71579478-9ea19d80-2af4-11ea-9f5c-bc31c8b81932.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
