### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container, @bbc/psammead-calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.40 | [PR#2862](https://github.com/bbc/psammead/pull/2862) Talos - Bump Dependencies - @bbc/psammead-calendars |
 | 2.0.39 | [PR#2857](https://github.com/bbc/psammead/pull/2857) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.38 | [PR#2846](https://github.com/bbc/psammead/pull/2846) Remove package jest-fetch-mock |
 | 2.0.37 | [PR#2843](https://github.com/bbc/psammead/pull/2843) Bumping dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2696,12 +2696,12 @@
       }
     },
     "@bbc/psammead-calendars": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.3.tgz",
-      "integrity": "sha512-i5yzpDXiM5iwwtGyQ3X4/5tIzm8XfAlfRQmkUdOAKQJL+YCLVKs6YsoCKpar6JTUIilR4q/NaxyQ8/Ctl1J0qw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.4.tgz",
+      "integrity": "sha512-H68v8DCtj7LtpwWNkjEDdOe+11ds1MwP85MxgUmGzmuho1VffGqI+KFugCRaSCTnVccnD5aObFqbh9jvl0sacA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-locales": "^4.0.0",
+        "@bbc/psammead-locales": "^4.1.0",
         "jalaali-js": "1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -51,7 +51,7 @@
     "@bbc/gel-foundations": "^3.4.1",
     "@bbc/psammead-assets": "^2.11.0",
     "@bbc/psammead-brand": "^5.0.11",
-    "@bbc/psammead-calendars": "^2.0.3",
+    "@bbc/psammead-calendars": "^2.0.4",
     "@bbc/psammead-caption": "^2.2.20",
     "@bbc/psammead-copyright": "^1.2.18",
     "@bbc/psammead-image": "^1.2.4",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-calendars  ^2.0.3  →  ^2.0.4

| Version | Description |
|---------|-------------|
| 2.0.4 | [PR#2857](https://github.com/bbc/psammead/pull/2857) Talos - Bump Dependencies - @bbc/psammead-locales |
</details>

