### PR TITLE
Talos - Bump @bbc/gel-foundations, @bbc/psammead-amp-geo, @bbc/psammead-assets...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.40 | [PR#2864](https://github.com/bbc/psammead/pull/2864) Talos - Bump Dependencies - @bbc/psammead-calendars |
 | 2.0.39 | [PR#2857](https://github.com/bbc/psammead/pull/2857) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.38 | [PR#2846](https://github.com/bbc/psammead/pull/2846) Remove package jest-fetch-mock |
 | 2.0.37 | [PR#2843](https://github.com/bbc/psammead/pull/2843) Bumping dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2696,12 +2696,12 @@
       }
     },
     "@bbc/psammead-calendars": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.3.tgz",
-      "integrity": "sha512-i5yzpDXiM5iwwtGyQ3X4/5tIzm8XfAlfRQmkUdOAKQJL+YCLVKs6YsoCKpar6JTUIilR4q/NaxyQ8/Ctl1J0qw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.4.tgz",
+      "integrity": "sha512-H68v8DCtj7LtpwWNkjEDdOe+11ds1MwP85MxgUmGzmuho1VffGqI+KFugCRaSCTnVccnD5aObFqbh9jvl0sacA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-locales": "^4.0.0",
+        "@bbc/psammead-locales": "^4.1.0",
         "jalaali-js": "1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -51,7 +51,7 @@
     "@bbc/gel-foundations": "^3.4.1",
     "@bbc/psammead-assets": "^2.11.0",
     "@bbc/psammead-brand": "^5.0.11",
-    "@bbc/psammead-calendars": "^2.0.3",
+    "@bbc/psammead-calendars": "^2.0.4",
     "@bbc/psammead-caption": "^2.2.20",
     "@bbc/psammead-copyright": "^1.2.18",
     "@bbc/psammead-image": "^1.2.4",

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 5.1.0-alpha.10 | [PR#2864](https://github.com/bbc/psammead/pull/2864) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 5.1.0-alpha.9 | [PR#2833](https://github.com/bbc/psammead/pull/2833) Wrap `scriptLink` in a div to fix Read&Write issue in chrome |
 | 5.1.0-alpha.8 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.1.0-alpha.7 | [PR#2680](https://github.com/bbc/psammead/pull/2680) Export `SkipLink` from a separated folder and fix its position  | 

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.1.0-alpha.9",
+  "version": "5.1.0-alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,13 +10,13 @@
       "integrity": "sha512-twwL0UcFrvq9w3O92PvkJRo+wThLqWLrxgFxxn8kwR1pni1wS6lhr3IwUPym4juS2hlTy/5C0/QiycB05IQhLg=="
     },
     "@bbc/psammead-script-link": {
-      "version": "1.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-script-link/-/psammead-script-link-1.0.0-alpha.9.tgz",
-      "integrity": "sha512-D6tHR2iDW/Rm4jJDZFdbY62w2C3nfw8mfpsDODmmkVUPCnBBFuvWVhsSYyU94b/DoZtq2nAPQtTxXuCTBJi3gA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-script-link/-/psammead-script-link-1.0.0.tgz",
+      "integrity": "sha512-deGOWJLxQIPt6W5u+aqZRJvdpmu7AJqvOGInF4+Q2uYVSQVN3Ji/D9crNEdv9qK0si/AR9D0mfP8DAcpzzfi2Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.1",
-        "@bbc/psammead-styles": "^4.1.0"
+        "@bbc/psammead-styles": "^4.1.2"
       }
     },
     "@bbc/psammead-styles": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.1.0-alpha.9",
+  "version": "5.1.0-alpha.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-visually-hidden-text": "^1.2.3"
   },
   "devDependencies": {
-    "@bbc/psammead-script-link": "^1.0.0-alpha.9",
+    "@bbc/psammead-script-link": "^1.0.0",
     "@bbc/psammead-styles": "^4.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-calendars  ^2.0.3  →  ^2.0.4

| Version | Description |
|---------|-------------|
| 2.0.4 | [PR#2857](https://github.com/bbc/psammead/pull/2857) Talos - Bump Dependencies - @bbc/psammead-locales |
</details>


@bbc/psammead-brand

<details>
<summary>Details</summary>
@bbc/psammead-script-link  ^1.0.0-alpha.9  →  ^1.0.0

| Version | Description |
|---------|-------------|
| 1.0.0 | [PR#2853](https://github.com/bbc/psammead/pull/2853) Remove alpha tag after a successful accessibility swarm |
| 1.0.0-alpha.14 | [PR#2833](https://github.com/bbc/psammead/pull/2833) Refactor to fix read&write issue on IE11 |
| 1.0.0-alpha.13 | [PR#2786](https://github.com/bbc/psammead/pull/2786) Add `onClick` prop |
| 1.0.0-alpha.12 | [PR#2750](https://github.com/bbc/psammead/pull/2750) Add ScriptLink touch area styles |
| 1.0.0-alpha.11 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |
| 1.0.0-alpha.10 | [PR#2697](https://github.com/bbc/psammead/pull/2697) Talos - Bump Dependencies - @bbc/psammead-styles |
</details>

