### PR TITLE
update timestamp prop to not be required

### DIFF
--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.4.0-alpha.2 | [PR#2860](https://github.com/bbc/psammead/pull/2717) Update timestamp prop to not be required |
 | 0.4.0-alpha.1 | [PR#2860](https://github.com/bbc/psammead/pull/2717) Update props for MostReadItem and update Readme |
 | 0.3.0-alpha.1 | [PR#2717](https://github.com/bbc/psammead/pull/2717) Update MostReadList with UX changes and various fixes |
 | 0.2.1-alpha.3 | [PR#2797](https://github.com/bbc/psammead/pull/2797) Import grid from psammead-grid |

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.4.0-alpha.2 | [PR#2860](https://github.com/bbc/psammead/pull/2717) Update timestamp prop to not be required |
+| 0.4.0-alpha.2 | [PR#2870](https://github.com/bbc/psammead/pull/2870) Update timestamp prop to not be required |
 | 0.4.0-alpha.1 | [PR#2860](https://github.com/bbc/psammead/pull/2717) Update props for MostReadItem and update Readme |
 | 0.3.0-alpha.1 | [PR#2717](https://github.com/bbc/psammead/pull/2717) Update MostReadList with UX changes and various fixes |
 | 0.2.1-alpha.3 | [PR#2797](https://github.com/bbc/psammead/pull/2797) Import grid from psammead-grid |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-most-read/src/testHelpers/itemsHelper.jsx
+++ b/packages/components/psammead-most-read/src/testHelpers/itemsHelper.jsx
@@ -20,7 +20,7 @@ export const getItem = (service, withTimestamp = false) => {
   const { text, articlePath } = TEXT_VARIANTS[service];
   const timestamp = withTimestamp ? lastUpdated(latin, service) : null;
   return {
-    id: Math.floor(Math.random() * 100000) + 1,
+    id: `${Math.floor(Math.random() * 100000) + 1}`,
     title: text,
     href: `${baseUrl}${articlePath}`,
     timestamp,

--- a/packages/components/psammead-most-read/src/testHelpers/itemsHelper.jsx
+++ b/packages/components/psammead-most-read/src/testHelpers/itemsHelper.jsx
@@ -34,5 +34,5 @@ export const itemPropTypes = shape({
   id: string.isRequired,
   title: string.isRequired,
   href: string.isRequired,
-  timestamp: node.isRequired,
+  timestamp: node,
 });


### PR DESCRIPTION
Resolves n/a

**Overall change:** raising this PR to fix the issue here: https://github.com/bbc/simorgh/pull/5023#discussion_r362871432

**Code changes:**

- _update timestamp prop to not be required so don't have to pass a value to it._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
