### PR TITLE
Psammead Grid - Remove alpha tag

### DIFF
--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Remove alpha tag |
+| 1.1.0 | [PR#2876](https://github.com/bbc/psammead/pull/2876) Remove alpha tag |
 | 1.1.0-alpha.2 | [PR#2815](https://github.com/bbc/psammead/pull/2815) Remove display:inline on outer grids |
 | 1.1.0-alpha.1 | [PR#2796](https://github.com/bbc/psammead/pull/2796) Fix padding on outer grid  |
 | 1.1.0-alpha.0 | [PR#2653](https://github.com/bbc/psammead/pull/2653) Remove enableGelMargins &enableNegativeGelMargins props & replace with margins. Update width calculations for fallbacks when using enableGelGutters. |

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Remove alpha tag |
 | 1.1.0-alpha.2 | [PR#2815](https://github.com/bbc/psammead/pull/2815) Remove display:inline on outer grids |
 | 1.1.0-alpha.1 | [PR#2796](https://github.com/bbc/psammead/pull/2796) Fix padding on outer grid  |
 | 1.1.0-alpha.0 | [PR#2653](https://github.com/bbc/psammead/pull/2653) Remove enableGelMargins &enableNegativeGelMargins props & replace with margins. Update width calculations for fallbacks when using enableGelGutters. |

--- a/packages/components/psammead-grid/README.md
+++ b/packages/components/psammead-grid/README.md
@@ -329,7 +329,7 @@ This `Grid` component can be used for page-level layouts as well as for layouts 
 
 ### Accessibility notes
 
-The `<Grid>` component is semantically a `div` element with relevant styles according to the layout.
+The `<Grid>` component is semantically a `div` element.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-grid/README.md
+++ b/packages/components/psammead-grid/README.md
@@ -329,7 +329,7 @@ This `Grid` component can be used for page-level layouts as well as for layouts 
 
 ### Accessibility notes
 
-Currently this component is in alpha. This is because it has not yet been tested with various assistive technologies. After it has had an accessibility swarm, this will be published under a standard version.
+The `<Grid>` component is semantically a `div` element with relevant styles according to the layout.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,10 +1,7 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.0-alpha.2",
-  "publishConfig": {
-    "tag": "alpha"
-  },
-  "description": "Grid setup for components",
+  "version": "1.1.0",
+  "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "repository": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -4,6 +4,7 @@
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/bbc/psammead/tree/latest/packages/components/psammead-grid"


### PR DESCRIPTION
Resolves #2874

**Overall change:** Removes alpha tag from component, following a successful accessibility swarm. 

**Code changes:**

- Removes alpha tag from component
- Adds `sideEffects: false,` as a treeshaking hint to Webpack: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
