### PR TITLE
Spacing of map timestamp

### DIFF
--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.21 | [PR#2891](https://github.com/bbc/psammead/pull/2891) last child bottom padding doubled |
 | 2.2.20 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.19 | [PR#2697](https://github.com/bbc/psammead/pull/2697) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.18 | [PR#2607](https://github.com/bbc/psammead/pull/2607) Bump dependencies |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`Timestamp should render Timestamp correctly 1`] = `
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -51,7 +51,7 @@ exports[`Timestamp should render Timestamp with a prefix 1`] = `
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -122,7 +122,7 @@ exports[`Timestamp should render with the correct typography style applied 1`] =
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { node, string, func, shape, bool } from 'prop-types';
 import {
   GEL_SPACING_HLF,
-  GEL_SPACING_DBL,
+  GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
 import { getBrevier } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
@@ -13,7 +13,7 @@ import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 const PADDING = `
   padding-bottom: ${GEL_SPACING_HLF};
   &:last-child {
-    padding-bottom: ${GEL_SPACING_DBL};
+    padding-bottom: ${GEL_SPACING_QUAD};
   }
 `;
 

--- a/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`Timestamp should add prefix and suffix 1`] = `
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -53,7 +53,7 @@ exports[`Timestamp should render correctly 1`] = `
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -91,7 +91,7 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
 }
 
 .c0:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {


### PR DESCRIPTION
Resolves [#5053](https://github.com/bbc/simorgh/issues/5053)

**Overall change:** Updated the bottom border for the last-child timestamp from 1rem to 2rem to match Zeplin design. 


**Code changes:**

*  Changed `:last-child {padding-bottom: }` on the psammead-timestamp component from `GEL_SPACING_DBL` (1rem) to `GEL_SPACING_QUAD` (2rem) to match https://app.zeplin.io/project/5d4d77b1fcbfc79bf47e0294/dashboard?seid=5e14855290299456375c16ac

* Updated expected values in `packages/containers/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap` tests to reflect this change.

---

- [√ ] I have assigned myself to this PR and the corresponding issues
- [√ ] Automated jest tests added (for new features) or updated (for existing features)
- [√ ] This PR requires manual testing
