### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container, @bbc/psammead-calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.45 | [PR#2897](https://github.com/bbc/psammead/pull/2897) Talos - Bump Dependencies - @bbc/psammead-calendars |
 | 2.0.44 | [PR#2894](https://github.com/bbc/psammead/pull/2894) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.43 | [PR#2878](https://github.com/bbc/psammead/pull/2878) Adding Psammead Grid as a dependency |
 | 2.0.42 | [PR#2879](https://github.com/bbc/psammead/pull/2879) Bump browserslist and lerna |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2696,12 +2696,12 @@
       }
     },
     "@bbc/psammead-calendars": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.4.tgz",
-      "integrity": "sha512-H68v8DCtj7LtpwWNkjEDdOe+11ds1MwP85MxgUmGzmuho1VffGqI+KFugCRaSCTnVccnD5aObFqbh9jvl0sacA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-calendars/-/psammead-calendars-2.0.5.tgz",
+      "integrity": "sha512-FF4AurUVchkeIfBXxmGiyyihyEwuOhV2ScXyIEnN3V9rmPZhxRiotZ8OaKkJ3sAjBPe+dEnGXFwqH4Umhz154w==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-locales": "^4.1.0",
+        "@bbc/psammead-locales": "^4.1.1",
         "jalaali-js": "1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -51,7 +51,7 @@
     "@bbc/gel-foundations": "^3.4.1",
     "@bbc/psammead-assets": "^2.11.0",
     "@bbc/psammead-brand": "^5.0.11",
-    "@bbc/psammead-calendars": "^2.0.4",
+    "@bbc/psammead-calendars": "^2.0.5",
     "@bbc/psammead-caption": "^2.2.20",
     "@bbc/psammead-copyright": "^1.2.18",
     "@bbc/psammead-grid": "^1.1.0",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-calendars  ^2.0.4  →  ^2.0.5

| Version | Description |
|---------|-------------|
| 2.0.5 | [PR#2894](https://github.com/bbc/psammead/pull/2894) Talos - Bump Dependencies - @bbc/psammead-locales |
</details>

