### PR TITLE
Talos - Bump @bbc/psammead-script-link

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 5.1.1 | [PR#2919](https://github.com/bbc/psammead/pull/2919) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 5.1.0 | [PR#2917](https://github.com/bbc/psammead/pull/2917) Remove alpha tag from Brand component |
 | 5.1.0-alpha.10 | [PR#2863](https://github.com/bbc/psammead/pull/2863) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 5.1.0-alpha.9 | [PR#2833](https://github.com/bbc/psammead/pull/2833) Wrap `scriptLink` in a div to fix Read&Write issue in chrome |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-twwL0UcFrvq9w3O92PvkJRo+wThLqWLrxgFxxn8kwR1pni1wS6lhr3IwUPym4juS2hlTy/5C0/QiycB05IQhLg=="
     },
     "@bbc/psammead-script-link": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-script-link/-/psammead-script-link-1.0.0.tgz",
-      "integrity": "sha512-deGOWJLxQIPt6W5u+aqZRJvdpmu7AJqvOGInF4+Q2uYVSQVN3Ji/D9crNEdv9qK0si/AR9D0mfP8DAcpzzfi2Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-script-link/-/psammead-script-link-1.0.2.tgz",
+      "integrity": "sha512-8hRL/9JW1vRck3p0+KsJJzqMPSaOmoXeMZCBCglH1l96HVFOT2/KhDec2GoAv7pcL1ICvWDupcfSoy/YyVi6Cw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.1",

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-visually-hidden-text": "^1.2.3"
   },
   "devDependencies": {
-    "@bbc/psammead-script-link": "^1.0.0",
+    "@bbc/psammead-script-link": "^1.0.2",
     "@bbc/psammead-styles": "^4.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead-brand

<details>
<summary>Details</summary>
@bbc/psammead-script-link  ^1.0.0  →  ^1.0.2

| Version | Description |
|---------|-------------|
| 1.0.2 | [PR#2896](https://github.com/bbc/psammead/pull/2896) Only add border to the script link span rather than all child spans |
| 1.0.1 | [PR#2887](https://github.com/bbc/psammead/pull/2887) Update margins to be 0.5rem on top, bottom and left and 0rem on the right |
</details>

