### PR TITLE
Update uk china key value

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 8.2.2 | [PR#2920](https://github.com/bbc/psammead/pull/2920) Remove camel casing from ukChina key value in TEXT-VARIANTS |
 | 8.2.1 | [PR#2920](https://github.com/bbc/psammead/pull/2920) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 8.2.0 | [PR#2765](https://github.com/bbc/psammead/pull/2765) Export articlePaths through service knobs |
 | 8.1.5 | [PR#2753](https://github.com/bbc/psammead/pull/2753) Add article paths to text-variants |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -300,7 +300,7 @@ const TEXT_VARIANTS = {
     locale: 'tr',
     articlePath: '/turkce/articles/c8q1ze59n25o',
   },
-  ukChinaSimp: {
+  ukchinaSimp: {
     service: 'ukchina',
     variant: 'simp',
     text: '该计划的批评者说，这个政策不能解决住房短缺的问题',
@@ -310,7 +310,7 @@ const TEXT_VARIANTS = {
     locale: 'zh-cn',
     articlePath: '/ukchina/articles/c0e8weny66ko/simp',
   },
-  ukChinaTrad: {
+  ukchinaTrad: {
     service: 'ukchina',
     variant: 'trad',
     text: '該計劃的批評者說，這個政策不能解決住房短缺的問題',

--- a/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
@@ -97,7 +97,7 @@ it('should pass the correct chosen service props to the story function', () => {
 
 it('should pass the correct chosen service props to the story function', () => {
   const mockStoryFn = jest.fn();
-  knobs.select = () => 'ukChinaSimp';
+  knobs.select = () => 'ukchinaSimp';
 
   withServicesKnob()(mockStoryFn);
 


### PR DESCRIPTION
Resolves n/a

**Overall change:** _updated ukChina to `ukchina`_
Allow us to remove this logic here: https://github.com/bbc/psammead/pull/2939/files#diff-62885fdcb2d1e5770f489c767120d6f6R28

**Code changes:**

- _I've made this change because in Most Read we are getting TEXT-VARIANTS by `service` and `ukchina` is passed as service and not `ukChina`_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
