### PR TITLE
Replace aria label with text for nav button

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.0-alpha.22 | [PR#XXXX](https://github.com/bbc/psammead/pull/XXXX) Use visually hidden text instead of aria label in nav button |
 | 6.0.0-alpha.21 | [PR#2923](https://github.com/bbc/psammead/pull/2923) Update padding between navigation items |
 | 6.0.0-alpha.20 | [PR#2920](https://github.com/bbc/psammead/pull/2920) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 6.0.0-alpha.19 | [PR#2875](https://github.com/bbc/psammead/pull/2875) Remove aria-hidden from the scrollable navigation |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.0-alpha.22 | [PR#XXXX](https://github.com/bbc/psammead/pull/XXXX) Use visually hidden text instead of aria label in nav button |
+| 6.0.0-alpha.22 | [PR#2951](https://github.com/bbc/psammead/pull/2951) Use visually hidden text instead of aria label in nav button |
 | 6.0.0-alpha.21 | [PR#2923](https://github.com/bbc/psammead/pull/2923) Update padding between navigation items |
 | 6.0.0-alpha.20 | [PR#2920](https://github.com/bbc/psammead/pull/2920) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 6.0.0-alpha.19 | [PR#2875](https://github.com/bbc/psammead/pull/2875) Remove aria-hidden from the scrollable navigation |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.21",
+  "version": "6.0.0-alpha.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.0-alpha.21",
+  "version": "6.0.0-alpha.22",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AMP Menu Button should render correctly 1`] = `
+.c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c1 {
   color: #fff;
   fill: currentColor;
@@ -72,7 +84,6 @@ exports[`AMP Menu Button should render correctly 1`] = `
       </amp-state>
       <button
         aria-expanded="false"
-        aria-label="Menu"
         class="c0"
         data-amp-bind-aria-expanded="menuState.expanded ? \\"true\\" : \\"false\\""
         dir="ltr"
@@ -107,6 +118,11 @@ exports[`AMP Menu Button should render correctly 1`] = `
             fill-rule="evenodd"
           />
         </svg>
+        <span
+          class="c2"
+        >
+          Menu
+        </span>
       </button>
     </div>
   </body>
@@ -123,7 +139,19 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
     />
   </head>
   <body>
-    .c1 {
+    .c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c1 {
   color: #fff;
   fill: currentColor;
 }
@@ -185,7 +213,6 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
       </amp-state>
       <button
         aria-expanded="false"
-        aria-label="Menu"
         class="c0"
         data-amp-bind-aria-expanded="menuState.expanded ? \\"true\\" : \\"false\\""
         dir="rtl"
@@ -220,6 +247,11 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
             fill-rule="evenodd"
           />
         </svg>
+        <span
+          class="c2"
+        >
+          Menu
+        </span>
       </button>
     </div>
   </body>
@@ -227,6 +259,18 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
 `;
 
 exports[`Canonical Closed menu button should render correctly 1`] = `
+.c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c1 {
   color: #fff;
   fill: currentColor;
@@ -279,7 +323,6 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
 
 <button
   aria-expanded="false"
-  aria-label="Menu"
   class="c0"
   dir="ltr"
   type="button"
@@ -296,10 +339,27 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
       d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
     />
   </svg>
+  <span
+    class="c2"
+  >
+    Menu
+  </span>
 </button>
 `;
 
 exports[`Canonical Closed menu button should render rtl correctly 1`] = `
+.c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c1 {
   color: #fff;
   fill: currentColor;
@@ -352,7 +412,6 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
 
 <button
   aria-expanded="false"
-  aria-label="Menu"
   class="c0"
   dir="rtl"
   type="button"
@@ -369,10 +428,27 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
       d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
     />
   </svg>
+  <span
+    class="c2"
+  >
+    Menu
+  </span>
 </button>
 `;
 
 exports[`Canonical Open menu button should render correctly 1`] = `
+.c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c1 {
   color: #fff;
   fill: currentColor;
@@ -425,7 +501,6 @@ exports[`Canonical Open menu button should render correctly 1`] = `
 
 <button
   aria-expanded="true"
-  aria-label="Menu"
   class="c0"
   dir="ltr"
   type="button"
@@ -443,10 +518,27 @@ exports[`Canonical Open menu button should render correctly 1`] = `
       fill-rule="evenodd"
     />
   </svg>
+  <span
+    class="c2"
+  >
+    Menu
+  </span>
 </button>
 `;
 
 exports[`Canonical Open menu button should render rtl correctly 1`] = `
+.c2 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c1 {
   color: #fff;
   fill: currentColor;
@@ -499,7 +591,6 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
 
 <button
   aria-expanded="true"
-  aria-label="Menu"
   class="c0"
   dir="rtl"
   type="button"
@@ -517,6 +608,11 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
       fill-rule="evenodd"
     />
   </svg>
+  <span
+    class="c2"
+  >
+    Menu
+  </span>
 </button>
 `;
 

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -223,13 +223,13 @@ export const CanonicalMenuButton = ({
   script,
 }) => (
   <MenuButton
-    aria-label={announcedText}
     onClick={onClick}
     aria-expanded={isOpen ? 'true' : 'false'}
     dir={dir}
     script={script}
   >
     {isOpen ? navigationIcons.cross : navigationIcons.hamburger}
+    <VisuallyHiddenText>{announcedText}</VisuallyHiddenText>
   </MenuButton>
 );
 
@@ -271,7 +271,6 @@ export const AmpMenuButton = ({ announcedText, onToggle, dir, script }) => (
       />
     </amp-state>
     <MenuButton
-      aria-label={announcedText}
       aria-expanded="false"
       data-amp-bind-aria-expanded='menuState.expanded ? "true" : "false"'
       on={`tap:${expandedHandler},${onToggle}`}
@@ -285,6 +284,7 @@ export const AmpMenuButton = ({ announcedText, onToggle, dir, script }) => (
         hidden: true,
         'data-amp-bind-hidden': '!menuState.expanded',
       })}
+      <VisuallyHiddenText>{announcedText}</VisuallyHiddenText>
     </MenuButton>
   </>
 );


### PR DESCRIPTION
Resolves #2950

**Overall change:**
The BBC a11y check on CI is failing with the following error:

 * Forms: Labelling form controls: Fields must have labels or titles
    - Button has no text: //div[@id='root']/header/nav/div/div[1]/button

This is because the button contains no text, and relies instead on an aria-label. We can use the VisuallyHiddenText component instead, which will pass the a11y acceptance criteria.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
