### PR TITLE
Update Story Promo List border-bottom

### DIFF
--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 2.1.27 | [PR#x](https://github.com/bbc/psammead/pull/x) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |
 | 2.1.25 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.1.24 | [PR#2973](https://github.com/bbc/psammead/pull/2973) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.1.27 | [PR#x](https://github.com/bbc/psammead/pull/x) Ensure border-bottom on list items is only applied for groups 0-3. |
+| 2.1.27 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |
 | 2.1.25 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.1.24 | [PR#2973](https://github.com/bbc/psammead/pull/2973) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 2.1.27 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
+| 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |
 | 2.1.25 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.1.24 | [PR#2973](https://github.com/bbc/psammead/pull/2973) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.26",
+  "version": "2.1.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.27",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.27",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "2.1.26",
+  "version": "2.1.27",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -46,7 +46,6 @@ exports[`StoryPromo list should render correctly 1`] = `
 }
 
 .c1 {
-  border-bottom: 0.0625rem solid #F2F2F2;
   padding: 0.5rem 0 1rem;
 }
 
@@ -157,6 +156,12 @@ exports[`StoryPromo list should render correctly 1`] = `
   .c7 {
     display: none;
     visibility: hidden;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c1 {
+    border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -8,13 +8,16 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MAX,
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 
 export const StoryPromoLi = styled.li.attrs({
   role: 'listitem',
 })`
-  border-bottom: 0.0625rem solid ${C_LUNAR};
+  @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    border-bottom: 0.0625rem solid ${C_LUNAR};
+  }
   padding: ${GEL_SPACING} 0 ${GEL_SPACING_DBL};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/4562

**Overall change:** Update Story Promo List to only apply border-bottom for below 1008px (groups 0-3)

**Code changes:**

- Update styling to only apply border-bottom for less than 1008px (groups 0-3)
- Major version increase since we do not want to automatically pull in the changes in our application. We should only pull in the changes as part of introducing the Desktop Layout in the application.

Screenshot of Storybook story (http://localhost:8180/?path=/story/components-storypromo-storypromolist--default) shows that above 1008px, there is no border bottom on the List Item.

<img width="1029" alt="Screenshot 2020-01-27 at 11 14 43" src="https://user-images.githubusercontent.com/3028997/73170438-457a5900-40f6-11ea-9b07-a9e7c6622733.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
