### PR TITLE
Fix no image story styling

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.0.0-alpha.4 | [PR#3023](https://github.com/bbc/psammead/pull/3023) Refactor no image headline stylings |
 | 4.0.0-alpha.3 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING` constant in the `LiveLabel` component |
 | 4.0.0-alpha.2 | [PR#2989](https://github.com/bbc/psammead/pull/2989) Update snapshot |
 | 4.0.0-alpha.1 | [PR#2937](https://github.com/bbc/psammead/pull/2937) Add promoType prop, remove topStory prop, integrate Leading promo and move Image and Text styles into a separate file |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -23,14 +23,14 @@ exports[`StoryPromo - Leading Story should render correctly 1`] = `
 }
 
 .c2 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c4 {
@@ -244,14 +244,14 @@ exports[`StoryPromo - Leading Story should render with Media Indicator correctly
 }
 
 .c2 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c4 {
@@ -471,14 +471,14 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c6 {
@@ -713,14 +713,14 @@ exports[`StoryPromo - Top Story should render with Media Indicator correctly 1`]
 }
 
 .c9 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c11 {
@@ -974,14 +974,14 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c6 {
@@ -1336,14 +1336,14 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c6 {
@@ -1659,14 +1659,14 @@ exports[`StoryPromo should render Live promo correctly 1`] = `
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c8 {
@@ -1891,14 +1891,14 @@ exports[`StoryPromo should render a RTL Live promo correctly 1`] = `
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c8 {
@@ -2111,14 +2111,14 @@ exports[`StoryPromo should render correctly 1`] = `
 }
 
 .c4 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c6 {
@@ -2344,14 +2344,14 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
 }
 
 .c9 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c11 {

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -99,6 +99,13 @@ const headlineLeadingStoryTypography = script => getDoublePica(script);
 const headlineRegularTypography = script => {
   const fontSize = (type, group) => script[type][group].fontSize / 16;
   const lineHeight = (type, group) => script[type][group].lineHeight / 16;
+
+  const noImageFontStyling = `
+    @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+      font-size: ${fontSize('pica', 'groupD')}rem;
+      line-height: ${lineHeight('pica', 'groupD')}rem;
+    }`;
+
   return css`
     font-size: ${fontSize('pica', 'groupA')}rem;
     line-height: ${lineHeight('pica', 'groupA')}rem;
@@ -106,13 +113,7 @@ const headlineRegularTypography = script => {
       font-size: ${fontSize('greatPrimer', 'groupB')}rem;
       line-height: ${lineHeight('greatPrimer', 'groupB')}rem;
     }
-    ${({ promoHasImage }) =>
-      !promoHasImage &&
-      `
-      @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-        font-size: ${fontSize('pica', 'groupD')}rem;
-        line-height: ${lineHeight('pica', 'groupD')}rem;
-      `}
+    ${({ promoHasImage }) => !promoHasImage && noImageFontStyling}
   `;
 };
 
@@ -123,12 +124,11 @@ const headlineTypography = script => ({
 });
 
 export const Headline = styled.h3`
-  ${({ script, promoType }) => script && headlineTypography(script)[promoType]}
-  ${({ service }) => getSerifMedium(service)}
   color: ${C_EBON};
   margin: 0; /* Reset */
   padding-bottom: ${GEL_SPACING};
-  ${({ promoHasImage }) => !promoHasImage && `display: inline;`}
+  ${({ script, promoType }) => script && headlineTypography(script)[promoType]}
+  ${({ service }) => getSerifMedium(service)}
 `;
 
 Headline.propTypes = {


### PR DESCRIPTION
Resolves #3022 

**Overall change:**
Ensure all stylings are applied across all breakpoints for promos without an image, particularly padding and margin.

**Code changes:**

- Refactor the no image stylings into their own constant to reduce nesting
- Move important default resets to be first in the CSS so they can be easily overridden and applied even if an error occurs later in the CSS
- Remove `display: inline` as it prevents the padding from being applied properly and the case it was added in for (media indicators) will be solved as a result of #3019 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
