### PR TITLE
Spacing updates on the Story Promo List and Section Label

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.14 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add margin bottom to the Section Label above 1008px  |
 | 3.0.13 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.12 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` constant |
 | 3.0.11 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.14 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add margin bottom to the Section Label above 1008px  |
+| 3.0.14 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Add margin bottom to the Section Label above 1008px  |
 | 3.0.13 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.12 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` constant |
 | 3.0.11 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.14 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Add margin bottom to the Section Label above 1008px  |
+| 4.0.0 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Add margin bottom to the Section Label above 1008px  |
 | 3.0.13 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.12 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` constant |
 | 3.0.11 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.14",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.13",
+  "version": "3.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.15",
+  "version": "3.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.14",
+  "version": "4.0.0",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.15",
+  "version": "3.0.14",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "3.0.13",
+  "version": "3.0.15",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -109,6 +109,12 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -305,6 +311,12 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -524,6 +536,12 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -737,6 +755,12 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -956,6 +980,12 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -1119,6 +1149,12 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -1265,6 +1301,12 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -1417,6 +1459,12 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -1563,6 +1611,12 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -1745,6 +1799,12 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -1941,6 +2001,12 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -2134,6 +2200,12 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -2274,6 +2346,12 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -2400,6 +2478,12 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   }
 }
 
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 <div
   class="c0"
 >
@@ -2523,6 +2607,12 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 @media (min-width:37.5rem) {
   .c0 {
     margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { bool, oneOf, shape, string } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
-import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_4_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -18,7 +21,7 @@ const Bar = styled.div`
     border-color: windowText;
   }
 
-  ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     position: absolute;
     left: 0;
     right: 0;
@@ -34,8 +37,12 @@ const SectionLabelWrapper = styled.div`
 
   margin-top: ${GEL_SPACING_QUAD};
 
-  ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     margin-top: ${GEL_SPACING_TRPL};
+  }
+
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    margin-bottom: ${GEL_SPACING_TRPL};
   }
 
   ${({ visuallyHidden }) =>

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 3.0.2 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Update `StoryPromoLi` padding top above 1008px |
+| 4.0.0 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Update `StoryPromoLi` padding top above 1008px |
 | 3.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 3.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update `StoryPromoLi` padding top above 1008px |
+| 3.0.2 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Update `StoryPromoLi` padding top above 1008px |
 | 3.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 3.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update `StoryPromoLi` padding top above 1008px |
 | 3.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -173,7 +173,7 @@ exports[`StoryPromo list should render correctly 1`] = `
 
 @media (min-width:63rem) {
   .c1 {
-    padding: 1.5rem 0 1.5rem;
+    padding: 0 0 1.5rem;
   }
 }
 

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -25,7 +25,7 @@ export const StoryPromoLi = styled.li.attrs({
   }
 
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    padding: ${GEL_SPACING_TRPL} 0 ${GEL_SPACING_TRPL};
+    padding: 0 0 ${GEL_SPACING_TRPL};
   }
 
   &:first-child {


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/3055

**Overall change:**
Update Story Promo List and Section Label spacings, raised as a part of the Desktop Front Page UX review.

**Code changes:**
- Update `StoryPromoList` padding-top to 0 above 1008px
- Add a margin-top of 1.5rem to the `SectionLabel` above 1008px

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
