### PR TITLE
Update gradient on Scrollable Navigation for > 400px

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.2 | [PR#3059](https://github.com/bbc/psammead/pull/3059) Update gradient width on scrollable navigation |
 | 6.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles, @bbc/psammead-assets |
 | 6.0.0 | [PR#3028](https://github.com/bbc/psammead/pull/3028) Bring Navigation out of alpha |
 | 6.0.0-alpha.27 | [PR#2996](https://github.com/bbc/psammead/pull/2996) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.test.jsx
@@ -144,7 +144,7 @@ describe('Canonical', () => {
 describe('Dropdown navigation', () => {
   shouldMatchSnapshot(
     'should render correctly when closed',
-    <CanonicalDropdown>{dropdownList}</CanonicalDropdown>,
+    <CanonicalDropdown isOpen={false}>{dropdownList}</CanonicalDropdown>,
   );
 
   shouldMatchSnapshot(

--- a/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { node, oneOf } from 'prop-types';
 import { GEL_SPACING_SEXT } from '@bbc/gel-foundations/spacings';
-import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_2_SCREEN_WIDTH_MAX,
+} from '@bbc/gel-foundations/breakpoints';
 
 /* Convert C_POSTBOX to rgba as IE doesn't like 8 digit hex */
 const C_POSTBOX_TRANSPARENT = `rgba(184, 0, 0, 0)`;
@@ -26,6 +29,9 @@ const StyledScrollableNav = styled.div`
       content: ' ';
       height: 100%;
       width: ${GEL_SPACING_SEXT};
+      @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+        width: 6rem;
+      }
       position: absolute;
       ${({ dir }) => css`
         ${dir === 'ltr' ? 'right' : 'left'}: 0;


### PR DESCRIPTION
Resolves #3052

**Overall change:** 
Updated gradient to be 6rem on breakpoints above 400px.

**Code changes:**
- Updated gradient width
- Passed `isOpen` prop to one of the tests to remove the warning `Failed prop type: The prop isOpen is marked as required in CanonicalDropdown, but its value is undefined.`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
