### PR TITLE
Style most read wrapper

### DIFF
--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.3 | [PR#3068](https://github.com/bbc/psammead/pull/3068) Add ability to pass additional styles to wrapper component `MostReadSection` |
 | 1.0.2 | [PR#3033](https://github.com/bbc/psammead/pull/3033) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-section-label |
 | 1.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.0 | [PR#3021](https://github.com/bbc/psammead/pull/3021) Bring MostRead out of alpha |

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.3 | [PR#3068](https://github.com/bbc/psammead/pull/3068) Add ability to pass additional styles to wrapper component `MostReadSection` |
+| 1.0.3 | [PR#3068](https://github.com/bbc/psammead/pull/3068) Add ability to pass additional styles to wrapper component `StyledSection` |
 | 1.0.2 | [PR#3033](https://github.com/bbc/psammead/pull/3033) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-section-label |
 | 1.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.0 | [PR#3021](https://github.com/bbc/psammead/pull/3021) Bring MostRead out of alpha |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-most-read/src/index.jsx
+++ b/packages/components/psammead-most-read/src/index.jsx
@@ -19,8 +19,9 @@ const MostReadSection = ({
   service,
   header,
   children,
+  className,
 }) => (
-  <StyledSection labelId={labelId}>
+  <StyledSection labelId={labelId} className={className}>
     <SectionLabel
       script={script}
       dir={dir}
@@ -41,20 +42,31 @@ MostReadSection.propTypes = {
   dir: oneOf(['rtl', 'ltr']),
   service: string.isRequired,
   header: string.isRequired,
+  className: string,
 };
 
 MostReadSection.defaultProps = {
   labelId: 'Most-Read',
   dir: 'ltr',
+  className: null,
 };
 
-const MostRead = ({ items, script, service, header, dir, labelId }) => (
+const MostRead = ({
+  items,
+  script,
+  service,
+  header,
+  dir,
+  labelId,
+  className,
+}) => (
   <MostReadSection
     labelId={labelId}
     script={script}
     service={service}
     header={header}
     dir={dir}
+    className={className}
   >
     <MostReadList numberOfItems={items.length} dir={dir}>
       {items.map((item, i) => (
@@ -95,11 +107,13 @@ MostRead.propTypes = {
   script: shape(scriptPropType).isRequired,
   dir: oneOf(['rtl', 'ltr']),
   labelId: string,
+  className: string,
 };
 
 MostRead.defaultProps = {
   dir: 'ltr',
   labelId: 'Most-Read',
+  className: null,
 };
 
 export {


### PR DESCRIPTION
Partly resolves #3066

**Overall change:** Allows MostRead wrapper to by styled using styled-components

**Code changes:**

- Allow className to be passed to wrapper component

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
