### PR TITLE
Story Promo List - Padding update

### DIFF
--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 3.0.2 | [PR#x](https://github.com/bbc/psammead/pull/x) Padding fix - update padding-top to not be applied on first li at 1008px+. |
+| 3.0.2 | [PR#3070](https://github.com/bbc/psammead/pull/3070) Padding fix - update padding-top to not be applied on first li at 1008px+. |
 | 3.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 3.0.2 | [PR#x](https://github.com/bbc/psammead/pull/x) Padding fix - update padding-top to not be applied on first li at 1008px+. |
 | 3.0.1 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.0 | [PR#3014](https://github.com/bbc/psammead/pull/3014) Ensure border-bottom on list items is only applied for groups 0-3. |
 | 2.1.26 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` and `GEL_SPACING_TRPL` constants |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -177,15 +177,9 @@ exports[`StoryPromo list should render correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c1:first-child {
     padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c1:first-child {
-    padding-top: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -31,12 +31,8 @@ export const StoryPromoLi = styled.li.attrs({
   &:first-child {
     padding-top: 0;
 
-    @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
       padding-top: ${GEL_SPACING_DBL};
-    }
-
-    @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-      padding-top: ${GEL_SPACING_TRPL};
     }
   }
 


### PR DESCRIPTION
Part of #3055

**Overall change:** Padding fix - update padding-top to not be applied on first li at 1008px+. 

**Code changes:**

- Padding fix - update padding-top to not be applied on first li at 1008px+. 

Fix can be seen in this storybook story:
http://localhost:8181/?path=/story/components-storypromo-storypromolist--default

<img width="984" alt="Screenshot 2020-02-06 at 09 55 32" src="https://user-images.githubusercontent.com/3028997/73926012-d99eaa00-48c6-11ea-9399-23416a710a05.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
