### PR TITLE
Talos - Bump @bbc/psammead-media-indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.73 | [PR#3077](https://github.com/bbc/psammead/pull/3077) Talos - Bump Dependencies - @bbc/psammead-media-indicator |
 | 2.0.72 | [PR#3038](https://github.com/bbc/psammead/pull/3038) Refactor no-JS scenarios for @bbc/psammead-media-player, adding jest-dom |
 | 2.0.71 | [PR#3051](https://github.com/bbc/psammead/pull/3051) Bumping dependencies |
 | 2.0.70 | [PR#2988](https://github.com/bbc/psammead/pull/2988) Add @bbc/psammead-timestamp-container to dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.72",
+  "version": "2.0.73",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2920,9 +2920,9 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "2.6.27",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.27.tgz",
-      "integrity": "sha512-9Jl8RWRYM3HOhO8yX6L/4mfNZiqf7oj4O/rPYla47EyhsFKNBQ4mnJpdhid+jArz8oWau/TWvGH1OweI+yY7Jw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-4.0.1.tgz",
+      "integrity": "sha512-/2a1x4OE+JajNx3VvTymTUXfoFXNTQuf53aM1zdQO1qTMr2F5tiOvwid//Pd8DSj++5uYPWW+JlUSrVtaqxI7g==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.72",
+  "version": "2.0.73",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -59,7 +59,7 @@
     "@bbc/psammead-image-placeholder": "^1.2.33",
     "@bbc/psammead-inline-link": "^1.3.20",
     "@bbc/psammead-locales": "^4.1.1",
-    "@bbc/psammead-media-indicator": "^2.6.27",
+    "@bbc/psammead-media-indicator": "^4.0.1",
     "@bbc/psammead-paragraph": "^2.2.24",
     "@bbc/psammead-story-promo": "2.8.0-alpha.1",
     "@bbc/psammead-storybook-helpers": "^8.2.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-indicator  ^2.6.27  →  ^4.0.1

| Version | Description |
| ------- | ----------- |
| 4.0.1 | [PR#3075](https://github.com/bbc/psammead/pull/3075) Pass `script` to the `MediaIndicator`|
| 4.0.0 | [PR#3062](https://github.com/bbc/psammead/pull/3062) Pass Time element as a child and remove spacing from the `MediaIndicatorWrapper`|
| 3.0.0 | [PR#3029](https://github.com/bbc/psammead/pull/3029) Add prop `isInline` for displaying media indicator inline. Remove boolean prop `indexAlsos` since it should be replaced with `isInline` |
</details>

