### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.73 | [PR#3083](https://github.com/bbc/psammead/pull/3083) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.72 | [PR#3038](https://github.com/bbc/psammead/pull/3038) Refactor no-JS scenarios for @bbc/psammead-media-player, adding jest-dom |
 | 2.0.71 | [PR#3051](https://github.com/bbc/psammead/pull/3051) Bumping dependencies |
 | 2.0.70 | [PR#2988](https://github.com/bbc/psammead/pull/2988) Add @bbc/psammead-timestamp-container to dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.72",
+  "version": "2.0.73",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2986,13 +2986,13 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.6.20.tgz",
-      "integrity": "sha512-d3lMn5q1+GlmPW+sb/4Cbka2TCSD3bzPuNRytJz8caS5JUCCFB26bPlGxp9Y2pB4KS7pNm8MalADYIHlHqGQFg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.0.tgz",
+      "integrity": "sha512-2ZQGmc273mKXor+tKnaFw1rmG679vvaQwpOEfYS3kOor/m9uQ89I2Lg8nWTZhBl/S2ZppDMbqBJpQ5K/jcKJ8g==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
-        "@bbc/psammead-timestamp": "^2.2.23",
+        "@bbc/psammead-timestamp": "^2.2.24",
         "moment-timezone": "^0.5.26"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.72",
+  "version": "2.0.73",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -66,7 +66,7 @@
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-test-helpers": "^3.1.2",
     "@bbc/psammead-timestamp": "^2.2.24",
-    "@bbc/psammead-timestamp-container": "^2.6.20",
+    "@bbc/psammead-timestamp-container": "^2.7.0",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@storybook/addon-a11y": "^5.3.9",
     "@storybook/addon-actions": "^5.3.9",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.4 | [PR#3083](https://github.com/bbc/psammead/pull/3083) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.3 | [PR#2988](https://github.com/BBC-News/psammead/pull/2988) Add start time of the radio program. |
 | 0.1.0-alpha.2 | [PR#2938](https://github.com/BBC-News/psammead/pull/2938) Add radio program card component. |
 | 0.1.0-alpha.1 | [PR#2979](https://github.com/BBC-News/psammead/pull/2979) Initial creation of package. |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.6.21.tgz",
-      "integrity": "sha512-OPICfkYhHGdO2e63rkXNuf0fa6WRE7dLYMFEFRMBcdxPcAs9m1lc0p6XyAzkLQ5hshFuJp0fgQkJ32VTMmbjAw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.0.tgz",
+      "integrity": "sha512-2ZQGmc273mKXor+tKnaFw1rmG679vvaQwpOEfYS3kOor/m9uQ89I2Lg8nWTZhBl/S2ZppDMbqBJpQ5K/jcKJ8g==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-timestamp": "^2.2.24",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "^3.4.3",
     "@bbc/psammead-styles": "^4.2.0",
     "@bbc/psammead-assets": "^2.12.0",
-    "@bbc/psammead-timestamp-container": "^2.6.20"
+    "@bbc/psammead-timestamp-container": "^2.7.0"
   },
   "peerDependencies": {
     "react": "^16.12.0"


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.6.20  →  ^2.7.0

| Version | Description |
|---------|-------------|
| 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |
| 2.6.21 | [PR#3033](https://github.com/bbc/psammead/pull/3033) Talos - Bump Dependencies - @bbc/psammead-timestamp |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.6.20  →  ^2.7.0

| Version | Description |
|---------|-------------|
| 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |
| 2.6.21 | [PR#3033](https://github.com/bbc/psammead/pull/3033) Talos - Bump Dependencies - @bbc/psammead-timestamp |
</details>

