### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.74 | [PR#3100](https://github.com/bbc/psammead/pull/3100) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.73 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-locales, @bbc/psammead-timestamp-container |
 | 2.0.72 | [PR#3038](https://github.com/bbc/psammead/pull/3038) Refactor no-JS scenarios for @bbc/psammead-media-player, adding jest-dom |
 | 2.0.71 | [PR#3051](https://github.com/bbc/psammead/pull/3051) Bumping dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.73",
+  "version": "2.0.74",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2986,9 +2986,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.6.21.tgz",
-      "integrity": "sha512-OPICfkYhHGdO2e63rkXNuf0fa6WRE7dLYMFEFRMBcdxPcAs9m1lc0p6XyAzkLQ5hshFuJp0fgQkJ32VTMmbjAw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.2.tgz",
+      "integrity": "sha512-4X2pQgAZp5uVLNprayBnD1CHtP73Yc8yCM7d4VX/nAKbPYiIzeV+sgO9svglP899X+kgKlO/sP/85EuPCbKssQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.73",
+  "version": "2.0.74",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -66,7 +66,7 @@
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-test-helpers": "^3.1.2",
     "@bbc/psammead-timestamp": "^2.2.24",
-    "@bbc/psammead-timestamp-container": "^2.6.21",
+    "@bbc/psammead-timestamp-container": "^2.7.2",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@storybook/addon-a11y": "^5.3.9",
     "@storybook/addon-actions": "^5.3.9",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.5 | [PR#3100](https://github.com/bbc/psammead/pull/3100) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.4 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-styles, @bbc/psammead-assets, @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.3 | [PR#2988](https://github.com/BBC-News/psammead/pull/2988) Add start time of the radio program. |
 | 0.1.0-alpha.2 | [PR#2938](https://github.com/BBC-News/psammead/pull/2938) Add radio program card component. |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.6.21.tgz",
-      "integrity": "sha512-OPICfkYhHGdO2e63rkXNuf0fa6WRE7dLYMFEFRMBcdxPcAs9m1lc0p6XyAzkLQ5hshFuJp0fgQkJ32VTMmbjAw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.2.tgz",
+      "integrity": "sha512-4X2pQgAZp5uVLNprayBnD1CHtP73Yc8yCM7d4VX/nAKbPYiIzeV+sgO9svglP899X+kgKlO/sP/85EuPCbKssQ==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-timestamp": "^2.2.24",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "^3.4.3",
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-assets": "^2.13.0",
-    "@bbc/psammead-timestamp-container": "^2.6.21"
+    "@bbc/psammead-timestamp-container": "^2.7.2"
   },
   "peerDependencies": {
     "react": "^16.12.0"


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.6.21  →  ^2.7.2

| Version | Description |
|---------|-------------|
| 2.7.2 | [PR#3085](https://github.com/bbc/psammead/pull/3085) Rename timestampUtilities with index |
| 2.7.1 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-locales |
| 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.6.21  →  ^2.7.2

| Version | Description |
|---------|-------------|
| 2.7.2 | [PR#3085](https://github.com/bbc/psammead/pull/3085) Rename timestampUtilities with index |
| 2.7.1 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-locales |
| 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |
</details>

