### PR TITLE
Talos - Bump @bbc/psammead-media-indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.77 | [PR#3110](https://github.com/bbc/psammead/pull/3110) Talos - Bump Dependencies - @bbc/psammead-media-indicator |
 | 2.0.76 | [PR#3073](https://github.com/bbc/psammead/pull/3073) Update `@bbc/psammead-media-indicator` to major version 4 & update relevant usage in packages. |
 | 2.0.75 | [PR#3105](https://github.com/bbc/psammead/pull/3105) Use Node Image with version v12.15.0 & npm version 6.13.7 |
 | 2.0.74 | [PR#3104](https://github.com/bbc/psammead/pull/3104) Bumping dependencies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.76",
+  "version": "2.0.77",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2920,9 +2920,9 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-4.0.1.tgz",
-      "integrity": "sha512-/2a1x4OE+JajNx3VvTymTUXfoFXNTQuf53aM1zdQO1qTMr2F5tiOvwid//Pd8DSj++5uYPWW+JlUSrVtaqxI7g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-4.0.2.tgz",
+      "integrity": "sha512-kyQB/65F5/F63FzpfQZluf4HgQOgeKlUFPQ33No5ZJr5sQqYbpQGZZIZP4DAQ1dg1jtVVh65gi/+6koNlZtpcA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.76",
+  "version": "2.0.77",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -59,7 +59,7 @@
     "@bbc/psammead-image-placeholder": "^1.2.33",
     "@bbc/psammead-inline-link": "^1.3.20",
     "@bbc/psammead-locales": "^4.1.2",
-    "@bbc/psammead-media-indicator": "^4.0.1",
+    "@bbc/psammead-media-indicator": "^4.0.2",
     "@bbc/psammead-paragraph": "^2.2.24",
     "@bbc/psammead-story-promo": "2.8.0-alpha.1",
     "@bbc/psammead-storybook-helpers": "^8.2.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-indicator  ^4.0.1  →  ^4.0.2

| Version | Description |
| ------- | ----------- |
| 4.0.2 | [PR#3109](https://github.com/bbc/psammead/pull/3109) Pass `dir` to the `MediaIndicator`|
</details>

