### PR TITLE
Add formatDuration utility function to Timestamp-container package

### DIFF
--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.7.3 | [PR#3114](https://github.com/bbc/psammead/pull/3085) Added formatDuration function to timestampUtilities |
 | 2.7.2 | [PR#3085](https://github.com/bbc/psammead/pull/3085) Rename timestampUtilities with index |
 | 2.7.1 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.7.3 | [PR#3114](https://github.com/bbc/psammead/pull/3085) Added formatDuration function to timestampUtilities |
+| 2.7.3 | [PR#3114](https://github.com/bbc/psammead/pull/3114) Added formatDuration function to timestampUtilities |
 | 2.7.2 | [PR#3085](https://github.com/bbc/psammead/pull/3085) Rename timestampUtilities with index |
 | 2.7.1 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.7.0 | [PR#3078](https://github.com/bbc/psammead/pull/3078) Export timestamp utilities |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/containers/psammead-timestamp-container/src/utilities/index.js
+++ b/packages/containers/psammead-timestamp-container/src/utilities/index.js
@@ -21,6 +21,13 @@ moment.relativeTimeThreshold('M', 12);
 
 const defaultFormat = 'LL, LT z';
 
+export const formatDuration = (durationValue, format = 'mm:ss') => {
+  const durationInMilliseconds = moment
+    .duration(durationValue)
+    .asMilliseconds();
+  return moment.utc(durationInMilliseconds).format(format);
+};
+
 // if the date is invalid return false - https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#answer-1353711
 export const isValidDateTime = dateTime => {
   // eslint-disable-next-line no-restricted-globals

--- a/packages/containers/psammead-timestamp-container/src/utilities/index.test.js
+++ b/packages/containers/psammead-timestamp-container/src/utilities/index.test.js
@@ -1,5 +1,10 @@
 import moment from 'moment-timezone';
-import { unixTimestampToMoment, formatUnixTimestamp, isValidDateTime } from '.';
+import {
+  unixTimestampToMoment,
+  formatUnixTimestamp,
+  isValidDateTime,
+  formatDuration,
+} from '.';
 import timestampGenerator from '../helpers/testHelpers';
 
 const timezone = 'Europe/London';
@@ -7,6 +12,17 @@ const timestamp = 1539969006000; // 19 October 2018
 const locale = 'en-gb';
 
 describe('Timestamp utility functions', () => {
+  describe('formatDuration', () => {
+    it('should return duration in expected format', () => {
+      const durationInISO8601Format = 'PT30M'; // 30:00
+      expect(formatDuration(durationInISO8601Format)).toEqual('30:00');
+    });
+    it('should return duration in expected format when a format is passed in', () => {
+      const durationInISO8601Format = 'PT30M'; // 30:00
+      expect(formatDuration(durationInISO8601Format, 'mm,ss')).toEqual('30,00');
+    });
+  });
+
   describe('isValidDateTime', () => {
     it('should return true if timestamp is valid', () => {
       expect(isValidDateTime(timestamp)).toEqual(true);


### PR DESCRIPTION
Partially resolves #3065

**Overall change:** Created a utility function to convert ISO 8601 time to normal time duration_

**Code changes:**

- _Create the function formatDuration_
- _Added tests._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
