### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.78 | [PR#3118](https://github.com/bbc/psammead/pull/3118) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.77 | [PR#3074](https://github.com/bbc/psammead/pull/3074) Bump @bbc/psammead-timestamp-container version |
 | 2.0.76 | [PR#3073](https://github.com/bbc/psammead/pull/3073) Update `@bbc/psammead-media-indicator` to major version 4 & update relevant usage in packages. |
 | 2.0.75 | [PR#3105](https://github.com/bbc/psammead/pull/3105) Use Node Image with version v12.15.0 & npm version 6.13.7 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.77",
+  "version": "2.0.78",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2986,9 +2986,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.2.tgz",
-      "integrity": "sha512-4X2pQgAZp5uVLNprayBnD1CHtP73Yc8yCM7d4VX/nAKbPYiIzeV+sgO9svglP899X+kgKlO/sP/85EuPCbKssQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.3.tgz",
+      "integrity": "sha512-p7zFKJ+fgYIdAbyH5BP00Fcv138USFs2KOp7kfY4/hdnPi1JnFiMAslyyYTEN1F/AADCh1Z3z9SlJtiLJ0JYIw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.77",
+  "version": "2.0.78",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -66,7 +66,7 @@
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-test-helpers": "^3.1.2",
     "@bbc/psammead-timestamp": "^2.2.24",
-    "@bbc/psammead-timestamp-container": "^2.7.2",
+    "@bbc/psammead-timestamp-container": "^2.7.3",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@storybook/addon-a11y": "^5.3.12",
     "@storybook/addon-actions": "^5.3.12",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.6 | [PR#3118](https://github.com/bbc/psammead/pull/3118) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.5 | [PR#3074](https://github.com/BBC-News/psammead/pull/3074) Format hidden start time in program card component. |
 | 0.1.0-alpha.4 | [PR#3082](https://github.com/bbc/psammead/pull/3082) Talos - Bump Dependencies - @bbc/psammead-styles, @bbc/psammead-assets, @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.3 | [PR#2988](https://github.com/BBC-News/psammead/pull/2988) Add start time of the radio program. |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.2.tgz",
-      "integrity": "sha512-4X2pQgAZp5uVLNprayBnD1CHtP73Yc8yCM7d4VX/nAKbPYiIzeV+sgO9svglP899X+kgKlO/sP/85EuPCbKssQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.3.tgz",
+      "integrity": "sha512-p7zFKJ+fgYIdAbyH5BP00Fcv138USFs2KOp7kfY4/hdnPi1JnFiMAslyyYTEN1F/AADCh1Z3z9SlJtiLJ0JYIw==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-timestamp": "^2.2.24",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "^3.4.3",
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-assets": "^2.13.0",
-    "@bbc/psammead-timestamp-container": "^2.7.2"
+    "@bbc/psammead-timestamp-container": "^2.7.3"
   },
   "peerDependencies": {
     "react": "^16.12.0"


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.7.2  →  ^2.7.3

| Version | Description |
|---------|-------------|
| 2.7.3 | [PR#3114](https://github.com/bbc/psammead/pull/3114) Added formatDuration function to timestampUtilities |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.7.2  →  ^2.7.3

| Version | Description |
|---------|-------------|
| 2.7.3 | [PR#3114](https://github.com/bbc/psammead/pull/3114) Added formatDuration function to timestampUtilities |
</details>

