### PR TITLE
Update GEL_GROUP_4_SCREEN_WIDTH_MAX breakpoint

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
+| 4.0.0 | [PR#3128](https://github.com/bbc/psammead/pull/3128) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
 | 3.4.3 | [PR#2947](https://github.com/bbc/psammead/pull/2947) Added additional rem sizing for 40px - 58px spacing according to new MAP and OD Radio designs. |
 | 3.4.2 | [PR#2858](https://github.com/bbc/psammead/pull/2858) Update line heights for Tamil and Devanagari & Gurmukhi scripts (Long Primer and Body Copy types). |
 | 3.4.1 | [PR#2462](https://github.com/bbc/psammead/pull/2462) Update line heights for Latin with Diacritics. |

--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.0 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
 | 3.4.3 | [PR#2947](https://github.com/bbc/psammead/pull/2947) Added additional rem sizing for 40px - 58px spacing according to new MAP and OD Radio designs. |
 | 3.4.2 | [PR#2858](https://github.com/bbc/psammead/pull/2858) Update line heights for Tamil and Devanagari & Gurmukhi scripts (Long Primer and Body Copy types). |
 | 3.4.1 | [PR#2462](https://github.com/bbc/psammead/pull/2462) Update line heights for Latin with Diacritics. |

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "3.4.3",
+  "version": "4.0.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "3.4.3",
+  "version": "4.0.0",
   "sideEffects": false,
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {

--- a/packages/utilities/gel-foundations/src/breakpoints.js
+++ b/packages/utilities/gel-foundations/src/breakpoints.js
@@ -26,7 +26,7 @@ export const GEL_GROUP_3_SCREEN_WIDTH_MIN = `37.5rem`; // 600px
 export const GEL_GROUP_3_SCREEN_WIDTH_MAX = `62.9375rem`; // 1007px
 
 export const GEL_GROUP_4_SCREEN_WIDTH_MIN = `63rem`; // 1008px
-export const GEL_GROUP_4_SCREEN_WIDTH_MAX = `80rem`; // 1279px
+export const GEL_GROUP_4_SCREEN_WIDTH_MAX = `79.9375rem`; // 1279px
 
 export const GEL_GROUP_5_SCREEN_WIDTH_MIN = `80rem`; // 1280px
 


### PR DESCRIPTION
Part of #3124

**Overall change:** 
The `GEL_GROUP_4_SCREEN_WIDTH_MAX` value has been all this time wrong (equivalent of 1280px instead of 1279px), so it is the same as `GEL_GROUP_5_SCREEN_WIDTH_MIN`.

**Code changes:**
- Update it from `80rem` to `79.9375rem`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
