### PR TITLE
Story promo - visually hidden text update

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.0.0-alpha.11 | [PR#x](https://github.com/bbc/psammead/pull/x) Fix visually hidden text so it isn't split across multiple strings. |
 | 4.0.0-alpha.10 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.0-alpha.9 | [PR#3107](https://github.com/bbc/psammead/pull/3107) Pass in dir prop to MediaIndicator in IndexAlsosContainer. |
 | 4.0.0-alpha.8 | [PR#3073](https://github.com/bbc/psammead/pull/3073) Use new major version of MediaIndicator. StoryPromo has updated styling around the MediaIndicator. Index Alsos test helper now using prop `isInline` for the MediaIndicator. |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.0.0-alpha.11 | [PR#x](https://github.com/bbc/psammead/pull/x) Fix visually hidden text so it isn't split across multiple strings. |
+| 4.0.0-alpha.11 | [PR#3136](https://github.com/bbc/psammead/pull/3136) Fix visually hidden text so it isn't split across multiple strings. |
 | 4.0.0-alpha.10 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.0-alpha.9 | [PR#3107](https://github.com/bbc/psammead/pull/3107) Pass in dir prop to MediaIndicator in IndexAlsosContainer. |
 | 4.0.0-alpha.8 | [PR#3073](https://github.com/bbc/psammead/pull/3073) Use new major version of MediaIndicator. StoryPromo has updated styling around the MediaIndicator. Index Alsos test helper now using prop `isInline` for the MediaIndicator. |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0-alpha.10",
+  "version": "4.0.0-alpha.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0-alpha.10",
+  "version": "4.0.0-alpha.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -172,8 +172,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
           <span
             class="c1"
           >
-            video
-            , 
+            video, 
           </span>
           <span
             class="c8"
@@ -363,8 +362,7 @@ exports[`Index Alsos should render one correctly 1`] = `
         <span
           class="c1"
         >
-          video
-          , 
+          video, 
         </span>
         <span
           class="c7"

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -66,7 +66,7 @@ const IndexAlsosLink = ({
         <>
           {mediaIndicator}
           <RoleText>
-            <VisuallyHiddenText>{mediaType}, </VisuallyHiddenText>
+            <VisuallyHiddenText>{`${mediaType}, `}</VisuallyHiddenText>
             <IndexAlsosText>{children}</IndexAlsosText>
           </RoleText>
         </>

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1367,8 +1367,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
               <span
                 class="c8"
               >
-                video
-                , 
+                video, 
               </span>
               <span
                 class="c15"
@@ -1753,8 +1752,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
             <span
               class="c8"
             >
-              video
-              , 
+              video, 
             </span>
             <span
               class="c14"


### PR DESCRIPTION
Part of  #3125

**Overall change:** Update visually hidden text to prevent splitting over multiple strings in rendered output - this is useful for when screenreaders read offscreen text - there isn't a break in the text being read out. 

**Code changes:**

- Update visually hidden text string. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
