### PR TITLE
Remove styling in timestamp for Simorgh a11y issue

### DIFF
--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.26 | [PR#XXXX](https://github.com/bbc/psammead/pull/1938) Removed display:block styling |
 | 2.2.25 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.24 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.23 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.2.26 | [PR#XXXX](https://github.com/bbc/psammead/pull/XXXX) Removed display:block styling |
+| 2.2.27 | [PR#3148](https://github.com/bbc/psammead/pull/3148) Removed display:block styling |
 | 2.2.26 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.25 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.2.24 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.25",
+  "version": "2.2.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.25",
+  "version": "2.2.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`Timestamp should render Timestamp correctly 1`] = `
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
-  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -43,7 +42,6 @@ exports[`Timestamp should render Timestamp with a prefix 1`] = `
   font-size: 0.9375rem;
   line-height: 1.25rem;
   color: #6E6E73;
-  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -81,7 +79,6 @@ exports[`Timestamp should render Timestamp without padding 1`] = `
   font-size: 0.9375rem;
   line-height: 1.25rem;
   color: #6E6E73;
-  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -114,7 +111,6 @@ exports[`Timestamp should render with the correct typography style applied 1`] =
   font-size: 0.9375rem;
   line-height: 1.25rem;
   color: #6E6E73;
-  display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -21,7 +21,6 @@ const StyledTimestamp = styled.time`
   ${({ script, typographyFunc }) =>
     script && typographyFunc && typographyFunc(script)}
   color: ${C_METAL};
-  display: block;
   ${({ service }) => getSansRegular(service)}
   ${props => props.padding && PADDING}
 `;


### PR DESCRIPTION
Resolves no issue

**Overall change:** Removed `display: block` styling for timestamp to support an a11y change in Simorgh https://github.com/bbc/simorgh/pull/5554.

**Code changes:**

- Removed `display: block`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
