### PR TITLE
(POC) MostRead ItemWrapper Refactor

### DIFF
--- a/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
@@ -168,13 +168,13 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c3 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c3 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -204,7 +204,7 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:80rem) {
   .c7 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -228,13 +228,13 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c8 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c8 {
-    min-width: 4.18rem;
+    min-width: 4rem;
   }
 }
 
@@ -264,7 +264,7 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:80rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -288,13 +288,13 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -324,7 +324,7 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 @media (min-width:80rem) {
   .c11 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 
@@ -806,151 +806,181 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c3 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c3 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c3 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c3 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c3 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c7 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c7 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c7 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c7 {
-    min-width: 1.9rem;
+    min-width: 3.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c7 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c8 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c8 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c8 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c8 {
-    min-width: 1.9rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c8 {
-    min-width: 2rem;
+    min-width: 3.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c9 {
-    min-width: auto;
+    min-width: 3.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: 1.9rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c11 {
+    min-width: 2rem;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c11 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c11 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:80rem) {
+  .c11 {
+    min-width: 3.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    min-width: 3.5rem;
   }
 }
 
@@ -1102,7 +1132,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c3"
+        class="c8"
         dir="rtl"
       >
         <span
@@ -1133,7 +1163,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c8"
+        class="c9"
         dir="rtl"
       >
         <span
@@ -1164,7 +1194,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c9"
+        class="c10"
         dir="rtl"
       >
         <span
@@ -1195,7 +1225,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c8"
+        class="c9"
         dir="rtl"
       >
         <span
@@ -1226,7 +1256,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c9"
+        class="c10"
         dir="rtl"
       >
         <span
@@ -1257,7 +1287,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
       class="c2"
     >
       <div
-        class="c10"
+        class="c11"
         dir="rtl"
       >
         <span

--- a/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
@@ -178,181 +178,181 @@ exports[`MostReadList should render with ltr bengali items with correct dir 1`] 
 
 @media (max-width:14.9375rem) {
   .c5 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c5 {
-    min-width: 2.1rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c5 {
-    min-width: 2.1rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c5 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c9 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c9 {
-    min-width: 2.1rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c9 {
-    min-width: 2.1rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:80rem) {
-  .c9 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:80rem) {
   .c9 {
     min-width: 2rem;
   }
 }
 
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c9 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c9 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:80rem) {
+  .c9 {
+    min-width: 4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c9 {
+    min-width: 2.5rem;
+  }
+}
+
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 2.1rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 2.1rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 2.95rem;
+    min-width: 4rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c11 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c11 {
-    min-width: 2.1rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c11 {
-    min-width: 2.1rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:80rem) {
-  .c11 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:80rem) {
   .c11 {
     min-width: 2rem;
   }
 }
 
-@media (max-width:14.9375rem) {
-  .c12 {
-    min-width: 3rem;
-  }
-}
-
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c12 {
-    min-width: 2.1rem;
+  .c11 {
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c12 {
-    min-width: 2.1rem;
+  .c11 {
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
-  .c12 {
-    min-width: auto;
+  .c11 {
+    min-width: 4rem;
   }
 }
 
 @media (min-width:80rem) {
+  .c11 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
   .c12 {
     min-width: 2rem;
   }
 }
 
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c12 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c12 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:80rem) {
+  .c12 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c12 {
+    min-width: 2.5rem;
+  }
+}
+
 @media (max-width:14.9375rem) {
   .c13 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c13 {
-    min-width: 2.1rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c13 {
-    min-width: 2.1rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c13 {
-    min-width: 3rem;
+    min-width: 4rem;
   }
 }
 
 @media (min-width:80rem) {
   .c13 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 
@@ -884,13 +884,13 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c5 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -920,7 +920,37 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 @media (min-width:80rem) {
   .c9 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c10 {
     min-width: 2rem;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c10 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c10 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:80rem) {
+  .c10 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c10 {
+    min-width: 4rem;
   }
 }
 
@@ -950,7 +980,7 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 @media (min-width:80rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -974,13 +1004,13 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c12 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c12 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -1010,37 +1040,7 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 @media (min-width:80rem) {
   .c13 {
-    min-width: auto;
-  }
-}
-
-@media (max-width:14.9375rem) {
-  .c10 {
-    min-width: 2rem;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c10 {
-    min-width: 2.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c10 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:80rem) {
-  .c10 {
-    min-width: auto;
-  }
-}
-
-@media (min-width:80rem) {
-  .c10 {
-    min-width: 3.95rem;
+    min-width: 4rem;
   }
 }
 
@@ -1572,13 +1572,13 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c5 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -1608,7 +1608,7 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -1632,13 +1632,13 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 4.18rem;
+    min-width: 4rem;
   }
 }
 
@@ -1668,7 +1668,7 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -1692,13 +1692,13 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c12 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c12 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -1728,7 +1728,7 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c13 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 
@@ -2242,151 +2242,181 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c5 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c5 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c5 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c5 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c9 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c9 {
-    min-width: 1.9rem;
+    min-width: 3.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: 1.9rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 3.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c11 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c11 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c11 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c11 {
-    min-width: auto;
+    min-width: 3.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c12 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c12 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c12 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c12 {
-    min-width: 1.9rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c12 {
-    min-width: auto;
+    min-width: 2.5rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c13 {
+    min-width: 2rem;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c13 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c13 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:80rem) {
+  .c13 {
+    min-width: 3.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c13 {
+    min-width: 3.5rem;
   }
 }
 
@@ -2542,7 +2572,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c5"
+        class="c10"
         dir="rtl"
       >
         <span
@@ -2573,7 +2603,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c10"
+        class="c11"
         dir="rtl"
       >
         <span
@@ -2604,7 +2634,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c11"
+        class="c12"
         dir="rtl"
       >
         <span
@@ -2635,7 +2665,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c10"
+        class="c11"
         dir="rtl"
       >
         <span
@@ -2666,7 +2696,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c11"
+        class="c12"
         dir="rtl"
       >
         <span
@@ -2697,7 +2727,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
       class="c4"
     >
       <div
-        class="c12"
+        class="c13"
         dir="rtl"
       >
         <span

--- a/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
@@ -15,31 +15,31 @@ exports[`MostReadRank should render ltr correctly 1`] = `
 
 @media (max-width:14.9375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 2rem;
   }
 }
 
@@ -108,7 +108,7 @@ exports[`MostReadRank should render ltr with double digits correctly 1`] = `
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 
@@ -153,31 +153,31 @@ exports[`MostReadRank should render rtl correctly 1`] = `
 
 @media (max-width:14.9375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c0 {
-    min-width: auto;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 2rem;
   }
 }
 
@@ -222,31 +222,31 @@ exports[`MostReadRank should render rtl with double digits correctly 1`] = `
 
 @media (max-width:14.9375rem) {
   .c0 {
-    min-width: 1.25rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c0 {
-    min-width: 1.25rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c0 {
-    min-width: 1.25rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c0 {
-    min-width: 1.9rem;
+    min-width: 3.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: auto;
+    min-width: 3.5rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/Rank/index.jsx
+++ b/packages/components/psammead-most-read/src/Rank/index.jsx
@@ -19,7 +19,12 @@ import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
 } from '@bbc/gel-foundations/breakpoints';
-import { GEL_SPACING_QUAD } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+  GEL_SPACING_QUAD,
+  GEL_SPACING_QUIN,
+} from '@bbc/gel-foundations/spacings';
 import { C_POSTBOX } from '@bbc/psammead-styles/colours';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { grid } from '@bbc/psammead-styles/detection';
@@ -27,6 +32,10 @@ import { getSerifLight } from '@bbc/psammead-styles/font-styles';
 import {
   doubleDigitDefault,
   doubleDigitOverride,
+  doubleDigitThin,
+  singleDigitDefault,
+  singleDigitThin,
+  thinFontServices,
 } from '../testHelpers/doubleDigitOverride';
 
 // For additional spacing for numerals in the right column because of '10' being double digits
@@ -46,22 +55,83 @@ const doubleDigitWidth = service => {
     : doubleDigitDefault;
 };
 
-const isFiveOrTen = ({ service, listIndex }) => {
-  return listIndex === 5 ? doubleDigitWidth(service).group5 : 'auto';
+const doubleDigitTest = service => {
+  return thinFontServices.includes(service)
+    ? doubleDigitThin
+    : doubleDigitDefault;
 };
 
-const bullshit = ({ listIndex }) => {
-  return listIndex === 10 ? '2rem' : '4rem';
+const doubleDigitCheck = numberOfItems => {
+  const singleDigitFunctions = {
+    default: singleDigitDefault,
+    thin: singleDigitThin,
+    name: 'single',
+  };
+  const doubleDigitFunctions = {
+    default: doubleDigitDefault,
+    thin: doubleDigitThin,
+    name: 'double',
+  };
+  return numberOfItems >= 9 ? doubleDigitFunctions : singleDigitFunctions;
 };
-const isTen = ({ listIndex }) => {
-  return listIndex === 10 ? '1rem' : '2rem';
+
+const fontWeight = ({ service, numberOfItems }) => {
+  // eslint-disable-next-line no-console
+  console.log(thinFontServices.includes(service));
+  // eslint-disable-next-line no-console
+  console.log(numberOfItems);
+  // eslint-disable-next-line no-console
+  console.log(doubleDigitCheck(numberOfItems));
+  return thinFontServices.includes(service)
+    ? doubleDigitCheck(numberOfItems).thin
+    : doubleDigitCheck(numberOfItems).default;
+};
+
+const isTen = (listIndex, yes, no) => {
+  return listIndex === 10 ? yes : no;
 };
 
 const StyledWrapper = styled.div`
-  min-width: ${props => (listHasDoubleDigits(props) ? isTen(props) : '2rem')};
+  @media (max-width: ${GEL_GROUP_0_SCREEN_WIDTH_MAX}) {
+    min-width: ${props =>
+      listHasDoubleDigits(props)
+        ? isTen(props.listIndex, '2rem', '2rem')
+        : fontWeight(props).group0};
+  }
+  @media (min-width: ${GEL_GROUP_1_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
+    min-width: ${props =>
+      listHasDoubleDigits(props)
+        ? isTen(props.listIndex, '3rem', '3rem')
+        : GEL_SPACING_TRPL};
+  }
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    min-width: ${props =>
+      listHasDoubleDigits(props)
+        ? isTen(props.listIndex, '3rem', '3rem')
+        : GEL_SPACING_QUAD};
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+    min-width: ${props =>
+      columnIncludesDoubleDigits(props, false)
+        ? isTen(props.listIndex, '4.5rem', '4.5rem')
+        : '5rem'};
+  }
 
-  max-width: ${props =>
-    listHasDoubleDigits(props) ? bullshit(props) : '4rem'};
+  @supports (${grid}) {
+    @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+      min-width: ${props =>
+        columnIncludesDoubleDigits(props, true)
+          ? isTen(props.listIndex, '4rem', '4rem')
+          : GEL_SPACING_QUIN};
+    }
+  }
+
+  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+    min-width: ${props =>
+      listHasDoubleDigits(props)
+        ? isTen(props.listIndex, '4rem', '4rem')
+        : '5rem'};
+  }
 `;
 
 const StyledSpan = styled.span`
@@ -91,6 +161,8 @@ const serviceNumerals = service => {
 const MostReadRank = ({ service, script, listIndex, numberOfItems, dir }) => {
   const numerals = serviceNumerals(service);
   const rank = numerals[listIndex];
+  // eslint-disable-next-line no-console
+  console.log(fontWeight({ service, numberOfItems }));
   return (
     <StyledWrapper
       listIndex={listIndex}

--- a/packages/components/psammead-most-read/src/Rank/index.jsx
+++ b/packages/components/psammead-most-read/src/Rank/index.jsx
@@ -19,20 +19,12 @@ import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
 } from '@bbc/gel-foundations/breakpoints';
-import {
-  GEL_SPACING,
-  GEL_SPACING_DBL,
-  GEL_SPACING_TRPL,
-  GEL_SPACING_QUAD,
-  GEL_SPACING_QUIN,
-} from '@bbc/gel-foundations/spacings';
 import { C_POSTBOX } from '@bbc/psammead-styles/colours';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { grid } from '@bbc/psammead-styles/detection';
 import { getSerifLight } from '@bbc/psammead-styles/font-styles';
 import {
   doubleDigitDefault,
-  doubleDigitOverride,
   doubleDigitThin,
   singleDigitDefault,
   singleDigitThin,
@@ -72,12 +64,10 @@ const fontWeight = ({ service, numberOfItems }) => {
     : doubleDigitCheck(numberOfItems).default;
 };
 
-const lastDigitCheck = (listIndex, yes, no) => {
-  return listIndex === 10 ? yes : no;
-};
-
-const isFiveOrTen = (listIndex, yes, no) => {
-  return listIndex === 10 || listIndex === 5 ? yes : no;
+const isFiveOrTen = ({ listIndex, service, numberOfItems }) => {
+  return listIndex === 5 || listIndex === 10
+    ? fontWeight({ service, numberOfItems }).group3_5_column
+    : doubleDigitThin.group5;
 };
 
 const StyledWrapper = styled.div`
@@ -90,13 +80,13 @@ const StyledWrapper = styled.div`
   @media (min-width: ${GEL_GROUP_1_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? fontWeight(props).group1_2_column
+        ? fontWeight(props).group1_column
         : fontWeight(props).group1};
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? fontWeight(props).group1_2_column
+        ? fontWeight(props).group2_column
         : fontWeight(props).group2};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
@@ -118,7 +108,7 @@ const StyledWrapper = styled.div`
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? isFiveOrTen(props.listIndex, '4rem', '4rem')
+        ? isFiveOrTen(props)
         : fontWeight(props).group5};
   }
 `;

--- a/packages/components/psammead-most-read/src/Rank/index.jsx
+++ b/packages/components/psammead-most-read/src/Rank/index.jsx
@@ -20,6 +20,7 @@ import {
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
 } from '@bbc/gel-foundations/breakpoints';
 import {
+  GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -48,19 +49,6 @@ const listHasDoubleDigits = ({ numberOfItems }) => numberOfItems >= 9;
 const columnIncludesDoubleDigits = (props, supportsGrid) =>
   isOnSecondColumn(props, supportsGrid) && listHasDoubleDigits(props);
 
-const doubleDigitWidth = service => {
-  const overrideService = Object.keys(doubleDigitOverride);
-  return overrideService.includes(service)
-    ? doubleDigitOverride[service]
-    : doubleDigitDefault;
-};
-
-const doubleDigitTest = service => {
-  return thinFontServices.includes(service)
-    ? doubleDigitThin
-    : doubleDigitDefault;
-};
-
 const doubleDigitCheck = numberOfItems => {
   const singleDigitFunctions = {
     default: singleDigitDefault,
@@ -72,65 +60,66 @@ const doubleDigitCheck = numberOfItems => {
     thin: doubleDigitThin,
     name: 'double',
   };
-  return numberOfItems >= 9 ? doubleDigitFunctions : singleDigitFunctions;
+
+  return listHasDoubleDigits({ numberOfItems })
+    ? doubleDigitFunctions
+    : singleDigitFunctions;
 };
 
 const fontWeight = ({ service, numberOfItems }) => {
-  // eslint-disable-next-line no-console
-  console.log(thinFontServices.includes(service));
-  // eslint-disable-next-line no-console
-  console.log(numberOfItems);
-  // eslint-disable-next-line no-console
-  console.log(doubleDigitCheck(numberOfItems));
   return thinFontServices.includes(service)
     ? doubleDigitCheck(numberOfItems).thin
     : doubleDigitCheck(numberOfItems).default;
 };
 
-const isTen = (listIndex, yes, no) => {
+const lastDigitCheck = (listIndex, yes, no) => {
   return listIndex === 10 ? yes : no;
+};
+
+const isFiveOrTen = (listIndex, yes, no) => {
+  return listIndex === 10 || listIndex === 5 ? yes : no;
 };
 
 const StyledWrapper = styled.div`
   @media (max-width: ${GEL_GROUP_0_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? isTen(props.listIndex, '2rem', '2rem')
+        ? fontWeight(props).group0_column
         : fontWeight(props).group0};
   }
   @media (min-width: ${GEL_GROUP_1_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? isTen(props.listIndex, '3rem', '3rem')
-        : GEL_SPACING_TRPL};
+        ? fontWeight(props).group1_2_column
+        : fontWeight(props).group1};
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? isTen(props.listIndex, '3rem', '3rem')
-        : GEL_SPACING_QUAD};
+        ? fontWeight(props).group1_2_column
+        : fontWeight(props).group2};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     min-width: ${props =>
       columnIncludesDoubleDigits(props, false)
-        ? isTen(props.listIndex, '4.5rem', '4.5rem')
-        : '5rem'};
+        ? fontWeight(props).group3_5_column
+        : fontWeight(props).group3};
   }
 
   @supports (${grid}) {
     @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
       min-width: ${props =>
         columnIncludesDoubleDigits(props, true)
-          ? isTen(props.listIndex, '4rem', '4rem')
-          : GEL_SPACING_QUIN};
+          ? fontWeight(props).group3_5_column
+          : fontWeight(props).group3};
     }
   }
 
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     min-width: ${props =>
       listHasDoubleDigits(props)
-        ? isTen(props.listIndex, '4rem', '4rem')
-        : '5rem'};
+        ? isFiveOrTen(props.listIndex, '4rem', '4rem')
+        : fontWeight(props).group5};
   }
 `;
 
@@ -162,7 +151,7 @@ const MostReadRank = ({ service, script, listIndex, numberOfItems, dir }) => {
   const numerals = serviceNumerals(service);
   const rank = numerals[listIndex];
   // eslint-disable-next-line no-console
-  console.log(fontWeight({ service, numberOfItems }));
+  console.log(fontWeight({ service, numberOfItems }).group0);
   return (
     <StyledWrapper
       listIndex={listIndex}

--- a/packages/components/psammead-most-read/src/Rank/index.jsx
+++ b/packages/components/psammead-most-read/src/Rank/index.jsx
@@ -50,53 +50,18 @@ const isFiveOrTen = ({ service, listIndex }) => {
   return listIndex === 5 ? doubleDigitWidth(service).group5 : 'auto';
 };
 
+const bullshit = ({ listIndex }) => {
+  return listIndex === 10 ? '2rem' : '4rem';
+};
+const isTen = ({ listIndex }) => {
+  return listIndex === 10 ? '1rem' : '2rem';
+};
+
 const StyledWrapper = styled.div`
-  @media (max-width: ${GEL_GROUP_0_SCREEN_WIDTH_MAX}) {
-    min-width: ${props =>
-      listHasDoubleDigits(props)
-        ? doubleDigitWidth(props.service).group0
-        : 'auto'};
-  }
+  min-width: ${props => (listHasDoubleDigits(props) ? isTen(props) : '2rem')};
 
-  @media (min-width: ${GEL_GROUP_1_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
-    min-width: ${props =>
-      listHasDoubleDigits(props)
-        ? doubleDigitWidth(props.service).group1
-        : 'auto'};
-  }
-
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    min-width: ${props =>
-      listHasDoubleDigits(props)
-        ? doubleDigitWidth(props.service).group2
-        : 'auto'};
-  }
-
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    min-width: ${props =>
-      columnIncludesDoubleDigits(props, false)
-        ? doubleDigitWidth(props.service).group3
-        : 'auto'};
-  }
-
-  /* different number order for when css grid is supported  */
-  @supports (${grid}) {
-    @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-      min-width: ${props =>
-        columnIncludesDoubleDigits(props, true)
-          ? doubleDigitWidth(props.service).group3
-          : GEL_SPACING_QUAD};
-    }
-  }
-
-  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    min-width: ${props =>
-      props.listIndex !== 10 &&
-      props.listIndex !== 5 &&
-      listHasDoubleDigits(props)
-        ? GEL_SPACING_QUAD
-        : isFiveOrTen(props)};
-  }
+  max-width: ${props =>
+    listHasDoubleDigits(props) ? bullshit(props) : '4rem'};
 `;
 
 const StyledSpan = styled.span`

--- a/packages/components/psammead-most-read/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/__snapshots__/index.test.jsx.snap
@@ -242,13 +242,13 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -278,7 +278,7 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c14 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -302,13 +302,13 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c15 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c15 {
-    min-width: 4.18rem;
+    min-width: 4rem;
   }
 }
 
@@ -338,7 +338,7 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c16 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -362,13 +362,13 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c17 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c17 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
@@ -398,7 +398,7 @@ exports[`MostRead should render with ltr most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c18 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 
@@ -1041,7 +1041,7 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1053,25 +1053,25 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c10 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c14 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1083,7 +1083,7 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c14 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
@@ -1095,13 +1095,13 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c14 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c15 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1113,25 +1113,25 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c15 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c15 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c15 {
-    min-width: 3.7rem;
+    min-width: 4rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c16 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1143,7 +1143,7 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c16 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
@@ -1155,13 +1155,13 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c16 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c17 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1173,25 +1173,25 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c17 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:80rem) {
   .c17 {
-    min-width: auto;
+    min-width: 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c17 {
-    min-width: 2rem;
+    min-width: 2.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c18 {
-    min-width: 2.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -1203,7 +1203,7 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c18 {
-    min-width: 2.5rem;
+    min-width: 3rem;
   }
 }
 
@@ -1215,7 +1215,7 @@ exports[`MostRead should render with rtl most read with correct dir 1`] = `
 
 @media (min-width:80rem) {
   .c18 {
-    min-width: auto;
+    min-width: 4rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
+++ b/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
@@ -1,5 +1,16 @@
 // These default measurements are to be used for 2nd column minimum width.
 // Services which use this default:
+export const thinFontServices = [
+  'thamil',
+  'pashto',
+  'persian',
+  'telegu',
+  'turkce',
+  'urdu',
+];
+
+// These default measurements are to be used for 2nd column minimum width.
+// Services which use this default:
 // afaanoromoo, afrique, amharic, gahuza, hausa, hindi, igbo, indonesia,
 // kyrgyz, serbian, somali, swahili, ukchina, zhongwen (14)
 export const doubleDigitDefault = {
@@ -10,6 +21,29 @@ export const doubleDigitDefault = {
   group5: '3.9rem',
 };
 
+export const singleDigitDefault = {
+  group0: '1rem',
+  group1: '1.5rem',
+  group2: '2rem',
+  group3: '5rem',
+  group5: '200rem',
+};
+
+export const singleDigitThin = {
+  group0: '1rem',
+  group1: '1.5rem',
+  group2: '20rem',
+  group3: '5rem',
+  group5: '2rem',
+};
+
+export const doubleDigitThin = {
+  group0: '20rem',
+  group1: '20rem',
+  group2: '30rem',
+  group3: '40rem',
+  group5: '30rem',
+};
 // These override measurements are for services with smaller characters and used for 2nd column minimum width.
 // Services which have unique overrides:
 // arabic, azeri, bengali, burmese, gahuza, gujarati, japanese, korean, marathi, mundo,

--- a/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
+++ b/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
@@ -1,32 +1,34 @@
-// These default measurements are to be used for 2nd column minimum width.
-// Services which use this default:
+import { GEL_SPACING, GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
+
+// Services with fonts that have glyphs thinner than the majority of other fonts.
+// This was mainly based on the old overrides (ie. Any group0 value < 2rem).
 export const thinFontServices = [
-  'thamil',
   'pashto',
   'persian',
+  'tamil',
   'telegu',
   'turkce',
   'urdu',
 ];
 
-// These default measurements are to be used for 2nd column minimum width.
-// Services which use this default:
-// afaanoromoo, afrique, amharic, gahuza, hausa, hindi, igbo, indonesia,
-// kyrgyz, serbian, somali, swahili, ukchina, zhongwen (14)
-export const doubleDigitDefault = {
-  group0: '2rem',
-  group1: '2.5rem',
-  group2: '3rem',
-  group3: '4rem',
-  group5: '3.9rem',
-};
-
+// If numberOfItems < 10, no extra spacing needs to be accounted for.
 export const singleDigitDefault = {
-  group0: '1rem',
+  group0: GEL_SPACING_TRPL,
   group1: '1.5rem',
   group2: '2rem',
-  group3: '5rem',
-  group5: '200rem',
+  group3: '2.5rem',
+  group5: '2rem',
+};
+
+export const doubleDigitDefault = {
+  group0: '2.5rem',
+  group1: '2.5rem',
+  group2: '3rem',
+  group3: '2.5rem',
+  group5: '3.9rem',
+  group0_column: '2rem',
+  group1_2_column: '3rem',
+  group3_5_column: '4rem',
 };
 
 export const singleDigitThin = {
@@ -39,211 +41,9 @@ export const singleDigitThin = {
 
 export const doubleDigitThin = {
   group0: '20rem',
-  group1: '20rem',
-  group2: '30rem',
-  group3: '40rem',
+  group1: '1.5rem',
+  group2: '1.5rem',
+  group3: '1.5rem',
   group5: '30rem',
-};
-// These override measurements are for services with smaller characters and used for 2nd column minimum width.
-// Services which have unique overrides:
-// arabic, azeri, bengali, burmese, gahuza, gujarati, japanese, korean, marathi, mundo,
-// nepali, news, pashto, persian, pidgin, portugeuese, punjabi, russian, sinhala, tamil,
-// telegu, thai, tigrinya, turkce, ukranian, urdu, uzbek, vietnamese, yoruba (29)
-export const doubleDigitOverride = {
-  arabic: {
-    group0: '2.5rem',
-    group1: '2.5rem',
-    group2: '2.5rem',
-    group3: '4rem',
-    group5: '3.7rem',
-  },
-  azeri: {
-    group0: '2.5rem',
-    group1: '2.5rem',
-    group2: '2.5rem',
-    group3: '4rem',
-    group5: '3.9rem',
-  },
-  bengali: {
-    group0: '3rem',
-    group1: '2.1rem',
-    group2: '2.1rem',
-    group3: '3rem',
-    group5: '2.95rem',
-  },
-  burmese: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '4rem',
-    group5: '3.95rem',
-  },
-  gujarati: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '5rem',
-    group5: '4.75rem',
-  },
-  japanese: {
-    group0: '2.5rem',
-    group1: '3.5rem',
-    group2: '3.5rem',
-    group3: '4.6rem',
-    group5: '4.6rem',
-  },
-  korean: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '3rem',
-    group3: '4rem',
-    group5: '3.45rem',
-  },
-  marathi: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.5rem',
-    group3: '3.5rem',
-    group5: '3.5rem',
-  },
-  mundo: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '4rem',
-    group5: '4.18rem',
-  },
-  nepali: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.5rem',
-    group3: '3.5rem',
-    group5: '3.3rem',
-  },
-  news: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '4rem',
-    group5: '4.18rem',
-  },
-  pashto: {
-    group0: '1.25rem',
-    group1: '1.5rem',
-    group2: '1.5rem',
-    group3: '2rem',
-    group5: '2.05rem',
-  },
-  persian: {
-    group0: '1.25rem',
-    group1: '1.25rem',
-    group2: '1.25rem',
-    group3: '1.9rem',
-    group5: '2rem',
-  },
-  pidgin: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.75rem',
-    group3: '3.75rem',
-    group5: '3.9rem',
-  },
-  portuguese: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '4.18rem',
-    group5: '4.18rem',
-  },
-  punjabi: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.75rem',
-    group3: '3.9rem',
-    group5: '3.9rem',
-  },
-  russian: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.75rem',
-    group3: '3.75rem',
-    group5: '4.16rem',
-  },
-  sinhala: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.5rem',
-    group3: '3.75rem',
-    group5: '3.5rem',
-  },
-  tamil: {
-    group0: '1.25rem',
-    group1: '1.5rem',
-    group2: '1.5rem',
-    group3: '2.5rem',
-    group5: '2.88rem',
-  },
-  telugu: {
-    group0: '1.5rem',
-    group1: '2rem',
-    group2: '2rem',
-    group3: '3.5rem',
-    group5: '3.58rem',
-  },
-  thai: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '2.5rem',
-    group3: '3.5rem',
-    group5: '3.4rem',
-  },
-  tigrinya: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '2.75rem',
-    group3: '4rem',
-    group5: '3.9rem',
-  },
-  turkce: {
-    group0: '1.5rem',
-    group1: '2.5rem',
-    group2: '2.75rem',
-    group3: '3.75rem',
-    group5: '4.17rem',
-  },
-  ukrainian: {
-    group0: '2rem',
-    group1: '2rem',
-    group2: '2.5rem',
-    group3: '4rem',
-    group5: '3.9rem',
-  },
-  urdu: {
-    group0: '1.25rem',
-    group1: '1.5rem',
-    group2: '1.5rem',
-    group3: '2rem',
-    group5: '2.07rem',
-  },
-  uzbek: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '2.5rem',
-    group3: '4rem',
-    group5: '3.9rem',
-  },
-  vietnamese: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '2.5rem',
-    group3: '4rem',
-    group5: '3.89rem',
-  },
-  yoruba: {
-    group0: '2rem',
-    group1: '2.5rem',
-    group2: '3rem',
-    group3: '4rem',
-    group5: '3.9rem',
-  },
+  group2_column: '3rem',
 };

--- a/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
+++ b/packages/components/psammead-most-read/src/testHelpers/doubleDigitOverride.js
@@ -1,4 +1,11 @@
-import { GEL_SPACING, GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+  GEL_SPACING_QUAD,
+  GEL_SPACING_QUIN,
+  GEL_SPACING_SEXT,
+  GEL_SPACING_SEPT,
+} from '@bbc/gel-foundations/spacings';
 
 // Services with fonts that have glyphs thinner than the majority of other fonts.
 // This was mainly based on the old overrides (ie. Any group0 value < 2rem).
@@ -14,36 +21,40 @@ export const thinFontServices = [
 // If numberOfItems < 10, no extra spacing needs to be accounted for.
 export const singleDigitDefault = {
   group0: GEL_SPACING_TRPL,
-  group1: '1.5rem',
-  group2: '2rem',
-  group3: '2.5rem',
-  group5: '2rem',
+  group1: GEL_SPACING_TRPL,
+  group2: GEL_SPACING_QUAD,
+  group3: GEL_SPACING_QUIN,
+  group5: GEL_SPACING_QUAD,
 };
 
 export const doubleDigitDefault = {
-  group0: '2.5rem',
-  group1: '2.5rem',
-  group2: '3rem',
-  group3: '2.5rem',
+  group0: GEL_SPACING_QUIN,
+  group1: GEL_SPACING_QUIN,
+  group2: GEL_SPACING_SEXT,
+  group3: GEL_SPACING_QUIN,
   group5: '3.9rem',
-  group0_column: '2rem',
-  group1_2_column: '3rem',
+  group0_column: GEL_SPACING_QUAD,
+  group1_column: GEL_SPACING_QUIN,
+  group2_column: GEL_SPACING_SEXT,
   group3_5_column: '4rem',
 };
 
 export const singleDigitThin = {
-  group0: '1rem',
-  group1: '1.5rem',
-  group2: '20rem',
-  group3: '5rem',
-  group5: '2rem',
+  group0: GEL_SPACING_DBL,
+  group1: GEL_SPACING_TRPL,
+  group2: GEL_SPACING_TRPL,
+  group3: GEL_SPACING_QUAD,
+  group5: GEL_SPACING_QUAD,
 };
 
 export const doubleDigitThin = {
-  group0: '20rem',
-  group1: '1.5rem',
-  group2: '1.5rem',
-  group3: '1.5rem',
-  group5: '30rem',
-  group2_column: '3rem',
+  group0: GEL_SPACING_DBL,
+  group1: GEL_SPACING_TRPL,
+  group2: GEL_SPACING_TRPL,
+  group3: GEL_SPACING_TRPL,
+  group5: GEL_SPACING_QUIN,
+  group0_column: GEL_SPACING_QUAD,
+  group1_column: GEL_SPACING_QUIN,
+  group2_column: GEL_SPACING_SEXT,
+  group3_5_column: GEL_SPACING_SEPT,
 };


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Potential way of refactoring `ItemWrapper` and `doubleDigitOverrides` to make it slightly more maintainable. 
Currently, the `doubleDigitOverrides` exists in order to add more spacing to all items in the second column except the tenth in the two column breakpoints as well as increase the spacing for all items except the fifth and the tenth in the largest breakpoint in order to match the spacing design requirements in zeplin. These tiny adjustments for each service were also mainly made because of the reliance on `auto` being the default value for the `min-width` leading to a very messy and hard to maintain file.

The method in this PR utilises the `ItemWrapper` a bit more by doing the reverse. Rather than adding specific padding to all items except the tenth to match it, it sets values that all items adhere to so that the wrapper is actually used as a wrapper. For single column break points, the function hasn't changed. For two column layouts, values have been set for all items in either the first or second column. For the last break point, the fifth and tenth items have the same spacing as each other which is different from every other item.

Another major change made is that some services have fonts decidedly 'thinner' than most others (only chosen via the original `doubleDigitOverrides` values which were <2rem). These fonts have their own values to compensate for the glyphs.

This reduces the total number of individual objects in this file from 30 to 5 and utilises GEL_SPACING values where possible which makes it easier to maintain.

**Code changes:**
- All changes only made in `Rank` and `doubleDigitOverride`
- Added `doubleDigitCheck` to decide if single digit or double digit values are to be used.
- Added `fontWeight` to decide if thin or default values are to be used.
- Added values such as `group0_column` in order to specify values for second column items.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
