### PR TITLE
feat: add matchSnapshotAsync method to README

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.3 | [PR#3155](https://github.com/bbc/psammead/pull/3155) add matchSnapshotAsync method to README |
 | 3.1.2 | [PR#2405](https://github.com/bbc/psammead/pull/2405) remove react-test-renderer from package.json |
 | 3.1.1 | [PR#2421](https://github.com/bbc/psammead/pull/2421) Removes done from `matchSnapshotAsync` and minor refactors |
 | 3.1.0 | [PR#2416](https://github.com/bbc/psammead/pull/2416) Adds `matchSnapshotAsync` export |

--- a/packages/utilities/psammead-test-helpers/README.md
+++ b/packages/utilities/psammead-test-helpers/README.md
@@ -8,6 +8,7 @@ This package provides a collection of helper methods for implementing Jest snaps
 | Name | Arguments | Description |
 | :---------- | :-------------- | :--------------- |
 | shouldMatchSnapshot | title, component | Renders the component using @testing-library/react, converts it to JSON and asserts that it matches the given snapshot, which will be saved in the `__snapshots__` directory. The first argument `title` is the title for the test. |
+| matchSnapshotAsync | component | Renders the component using @testing-library/react, converts it to JSON and asserts that it matches the given snapshot, which will be saved in the `__snapshots__` directory. Unlike `shouldMatchSnapshot`, it does not create a test, so can be used within any `it(...)` test. |
 | isNull | title, component | Renders the component using @testing-library/react, converts it to JSON and asserts that it is null. The first argument `title` is the title for the test. |
 | testUtilityPackages | actualExports, expectedExports, utilityName | Validates an imported utility package's exported values against an object of key-value pairs in the form `{ name_of_export: 'type of export' }`, e.g. `{ shouldMatchSnapshot: 'function' }`. |
 | setWindowValue | key, value | Allows you to set variables on the window (eg. location) that are normally not writable |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
for psammead-test-helpers

Resolves #3156

**Overall change:** _Adds `matchSnapshotAsync` to README for `@bbc/psammead-test-helpers`._

**Code changes:**

- _Adds `matchSnapshotAsync` to README for `@bbc/psammead-test-helpers`._
- _Update package*.json, CHANGELOG.md._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
