### PR TITLE
Bump yargs-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.87 | [PR#](https://github.com/bbc/psammead/pull/) Bumping yargs-parser to 17.0.0 |
 | 2.0.86 | [PR#3158](https://github.com/bbc/psammead/pull/3158) Talos - Bump Dependencies - @bbc/psammead-calendars |
 | 2.0.85 | [PR#3157](https://github.com/bbc/psammead/pull/3157) Bumping dependencies |
 | 2.0.84 | [PR#3153](https://github.com/bbc/psammead/pull/3153) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-timestamp-container |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.86",
+  "version": "2.0.87",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19781,6 +19781,18 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^16.1.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -21289,6 +21301,18 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^16.1.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -29095,6 +29119,18 @@
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.8.1",
             "yargs-parser": "^16.1.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "minimist-options": {
@@ -30276,6 +30312,18 @@
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.8.1",
             "yargs-parser": "^16.1.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "merge2": {
@@ -33605,9 +33653,9 @@
       }
     },
     "yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-17.0.0.tgz",
+      "integrity": "sha512-Fl4RBJThsWeJl3cRZeGuolcuH78/foVUAYIUpKn8rkCnjn23ilZvJyEZJjnlzoG/+EJKPb1RggD4xS/Jie2nxg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.86",
+  "version": "2.0.87",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -121,7 +121,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-csstree-validator": "^1.8.0",
     "stylelint-processor-styled-components": "^1.10.0",
-    "yargs-parser": "^16.1.0",
+    "yargs-parser": "^17.0.0",
     "yeoman-generator": "^4.5.0",
     "yo": "^3.1.1"
   },


### PR DESCRIPTION
**Overall change:** Bumping the yargs-parser dev dep to a major version 17.0.0
[https://github.com/yargs/yargs-parser/releases/tag/v17.0.0](https://github.com/yargs/yargs-parser/releases/tag/v17.0.0)

**Code changes:**

- Updated the version of yargs-parser in package.json and package-lock.json

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
