### PR TITLE
Talos - Bump @bbc/psammead-story-promo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.89 | [PR#3165](https://github.com/bbc/psammead/pull/3165) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 2.0.88 | [PR#3161](https://github.com/bbc/psammead/pull/3161) Bumping yargs-parser to 17.0.0 |
 | 2.0.87 | [PR#3159](https://github.com/bbc/psammead/pull/3159) Talos - Bump Dependencies - @bbc/psammead-test-helpers |
 | 2.0.86 | [PR#3158](https://github.com/bbc/psammead/pull/3158) Talos - Bump Dependencies - @bbc/psammead-calendars |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.88",
+  "version": "2.0.89",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2941,21 +2941,13 @@
       }
     },
     "@bbc/psammead-story-promo": {
-      "version": "4.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-4.0.0-alpha.8.tgz",
-      "integrity": "sha512-oF+Q9KrSU3eDI7Q45FLTItdfH6Uj0geOYwPXKLKdN7oYZcC10DKQFeTgPR5CT/D+3YNMDcWGgYrrQpxzkF/fBA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-4.0.0.tgz",
+      "integrity": "sha512-yJNBWf+46XN/cN472rKuJ5ZVa3+WkalJ+ubRwzIGkjgQlXO35Nk0J3ZCr1VOuilZrNj1bc8mMiOXMH6O6/LkBw==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^3.4.3",
+        "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-styles": "^4.3.0"
-      },
-      "dependencies": {
-        "@bbc/gel-foundations": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.4.3.tgz",
-          "integrity": "sha512-rOPuintdkftYDE0GcY8B5K/AR5tLAMv7E+jD0plk32aEBojTXgttSYW9Da4NBKxLw69N9Px29YEu1CU0is1j9w==",
-          "dev": true
-        }
       }
     },
     "@bbc/psammead-storybook-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.88",
+  "version": "2.0.89",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -61,7 +61,7 @@
     "@bbc/psammead-locales": "^4.1.2",
     "@bbc/psammead-media-indicator": "^4.0.4",
     "@bbc/psammead-paragraph": "^2.2.26",
-    "@bbc/psammead-story-promo": "^4.0.0-alpha.8",
+    "@bbc/psammead-story-promo": "^4.0.0",
     "@bbc/psammead-storybook-helpers": "^8.2.5",
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-test-helpers": "^3.1.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-story-promo  ^4.0.0-alpha.8  →  ^4.0.0

| Version | Description |
| ------- | ----------- |
| 4.0.0 | [PR#3154](https://github.com/bbc/psammead/pull/3154) Remove alpha tag |
| 4.0.0-alpha.13 | [PR#3150](https://github.com/bbc/psammead/pull/3150) Fix fallback width for Leading promo |
| 4.0.0-alpha.12 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
| 4.0.0-alpha.11 | [PR#3136](https://github.com/bbc/psammead/pull/3136) Fix visually hidden text so it isn't split across multiple strings. |
| 4.0.0-alpha.10 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
| 4.0.0-alpha.9 | [PR#3107](https://github.com/bbc/psammead/pull/3107) Pass in dir prop to MediaIndicator in IndexAlsosContainer. |
</details>

