### PR TITLE
Fix spacing for pidgin on group2 breakpoint for MostRead

### DIFF
--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.1 | [PR#3175](https://github.com/bbc/psammead/pull/3175) Fix spacing for pidgin on group2 breakpoint for MostRead |
 | 2.0.0 | [PR#3120](https://github.com/bbc/psammead/pull/3120) Remove `MostRead` and `MostReadSection` as well as other cleanup |
 | 1.1.1 | [PR#3151](https://github.com/bbc/psammead/pull/3151) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-section-label |
 | 1.1.0 | [PR#3116](https://github.com/bbc/psammead/pull/3116) Added `maxTwoColumns` prop to conditionally render GEL_GROUP_5_SCREEN_WIDTH_MIN media queries |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-most-read/src/utilities/doubleDigitOverride.js
+++ b/packages/components/psammead-most-read/src/utilities/doubleDigitOverride.js
@@ -109,7 +109,7 @@ export const doubleDigitOverride = {
   },
   pidgin: {
     group0: '2rem',
-    group1: '2rem',
+    group1: '2.6rem',
     group2: '2.75rem',
     group3: '3.75rem',
     group5: '3.9rem',


### PR DESCRIPTION
Resolves #3174 

**Overall change:**
Fixed 10th item moving around due to not having enough spacing in Pidgin.
Online storybook link for convenience:
https://bbc.github.io/psammead/?path=/story/components-mostread-list--news-ltr
You can see that the 10th item moves around a bit when you move the slider to change the breakpoint when it goes to 1 column. Please compare this to http://localhost:8180/?path=/story/components-mostread-list--news-ltr

**Code changes:**
- Changed `group2` value for Pidgin in `doubleDigitOverride`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
