### PR TITLE
Change display of program cards in group3 & update stories to include 4 cards

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.15 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
 | 0.1.0-alpha.14 | [PR#3164](https://github.com/bbc/psammead/pull/3164) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.13 | [PR#3153](https://github.com/bbc/psammead/pull/3153) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 0.1.0-alpha.12 | [PR#3132](https://github.com/bbc/psammead/pull/3132) Render correct hidden `startTime` in RadioSchedule component |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -844,7 +844,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
 </div>
 `;
 
-exports[`ProgramCard should render correctly in RTL 1`] = `
+exports[`ProgramCard should render correctly for onDemand 2`] = `
 .c9 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -918,11 +918,11 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
 }
 
 .c2 {
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
   font-style: normal;
-  font-size: 1rem;
-  line-height: 1.625rem;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   color: #222222;
   margin: 0;
 }
@@ -931,26 +931,26 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 1rem;
-  line-height: 1.625rem;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
 }
 
 .c6 {
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   color: #6E6E73;
   padding-bottom: 1rem;
   margin: 0;
 }
 
 .c7 {
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
@@ -970,48 +970,48 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
 }
 
 .c10 {
-  padding-right: 0.5rem;
+  padding-left: 0.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c2 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c2 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c5 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c5 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c6 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c6 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
+    font-size: 0.875rem;
+    line-height: 1.125rem;
   }
 }
 
@@ -1040,20 +1040,20 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
     >
       <a
         class="c3"
-        href="/arabic/articles/c1er5mjnznzo"
+        href="/news/articles/cn7k01xp8kxo"
       >
         <span
           class=""
           role="text"
         >
           <span>
-            لماذا يخجل البعض من اسم قريته في مصر؟
+            Could a computer ever create better art than a human?
           </span>
           <span
             class="c4"
           >
             , 
-            ١٤:٥٤
+            14:54
             , 
           </span>
           <span
@@ -1067,7 +1067,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
     <p
       class="c6"
     >
-      هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
+      The critic, author, poet and TV host was known for his witty commentary on international television.
     </p>
   </div>
   <div
@@ -1095,10 +1095,315 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
     <time
       class="c10"
       datetime="PT30M"
-      dir="rtl"
+      dir="ltr"
     >
       <span
         class="c4"
+      >
+         Duration 30,00 
+      </span>
+      <span
+        aria-hidden="true"
+        class="Duration0 "
+      >
+        30:00
+      </span>
+    </time>
+  </div>
+</div>
+`;
+
+exports[`ProgramCard should render correctly in RTL 1`] = `
+.c10 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c3 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c3:hover,
+.c3:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c3:visited {
+  color: #6E6E73;
+}
+
+.c5 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c0 {
+  padding-top: 0.5rem;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 0.0625rem solid transparent;
+  height: 100%;
+}
+
+.c1 {
+  padding: 0 0.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c2 {
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
+  color: #222222;
+  margin: 0;
+}
+
+.c4 {
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
+  color: #B80000;
+}
+
+.c6 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: block;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
+}
+
+.c7 {
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  color: #6E6E73;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.c8 {
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.5rem;
+  background-color: #B80000;
+  color: #FFFFFF;
+  border-top: 1px solid transparent;
+}
+
+.c9 > svg {
+  color: #FFFFFF;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.c11 {
+  padding-right: 0.5rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c6 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <h3
+      class="c2"
+    >
+      <a
+        class="c3"
+        href="/arabic/articles/c1er5mjnznzo"
+      >
+        <span
+          class=""
+          role="text"
+        >
+          <span
+            aria-hidden="true"
+            class="c4"
+          >
+            مباشر
+          </span>
+          <span
+            class="c5"
+          >
+             مباشر
+            ,
+          </span>
+          <span>
+             
+            لماذا يخجل البعض من اسم قريته في مصر؟
+          </span>
+          <span
+            class="c5"
+          >
+            , 
+            ١٤:٥٤
+            , 
+          </span>
+          <span
+            class="c6"
+          >
+            29/01/1990
+          </span>
+        </span>
+      </a>
+    </h3>
+    <p
+      class="c7"
+    >
+      هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
+    </p>
+  </div>
+  <div
+    class="c8"
+  >
+    <span
+      class="c9"
+    >
+      <svg
+        aria-hidden="true"
+        class="c10"
+        focusable="false"
+        height="12px"
+        viewBox="0 0 13 12"
+        width="13px"
+      >
+        <path
+          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+        />
+        <path
+          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+        />
+      </svg>
+    </span>
+    <time
+      class="c11"
+      datetime="PT30M"
+      dir="rtl"
+    >
+      <span
+        class="c5"
       >
          المدة الزمنية 30,00 
       </span>

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.test.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.test.jsx
@@ -1,7 +1,9 @@
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { renderProgramCard, sentenceCase } from '../testHelpers/helper';
-
-const uniqueStates = ['live', 'onDemand', 'next'];
+import {
+  renderProgramCard,
+  sentenceCase,
+  uniqueStates,
+} from '../testHelpers/helper';
 
 describe('ProgramCard', () => {
   uniqueStates.forEach(state => {

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -560,10 +560,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 <ul
   class="c0 c1"
   dir="ltr"
+  role="list"
 >
   <li
     class="c2 c3"
     dir="ltr"
+    role="listitem"
   >
     <div
       class="c4"
@@ -705,6 +707,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="ltr"
+    role="listitem"
   >
     <div
       class="c4"
@@ -832,6 +835,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="ltr"
+    role="listitem"
   >
     <div
       class="c4"
@@ -959,6 +963,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="ltr"
+    role="listitem"
   >
     <div
       class="c4"
@@ -1652,10 +1657,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 <ul
   class="c0 c1"
   dir="rtl"
+  role="list"
 >
   <li
     class="c2 c3"
     dir="rtl"
+    role="listitem"
   >
     <div
       class="c4"
@@ -1797,6 +1804,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="rtl"
+    role="listitem"
   >
     <div
       class="c4"
@@ -1924,6 +1932,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="rtl"
+    role="listitem"
   >
     <div
       class="c4"
@@ -2051,6 +2060,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   <li
     class="c2 c3"
     dir="rtl"
+    role="listitem"
   >
     <div
       class="c4"

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -540,12 +540,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c2 {
-    visibility: visible;
-  }
-}
-
 @supports (display:grid) {
   .c2 {
     display: -webkit-box;
@@ -1630,12 +1624,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c7 > time {
     font-size: 0.75rem;
     line-height: 1rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c2 {
-    visibility: visible;
   }
 }
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c18 {
+.c19 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -48,7 +48,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c13 {
+.c14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -102,7 +102,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c20 {
+.c13 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -120,7 +120,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c14 {
+.c15 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -142,7 +142,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c15 {
+.c16 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -153,14 +153,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #B80000;
   color: #FFFFFF;
   border-top: 1px solid transparent;
 }
@@ -172,7 +172,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #222222;
   color: #FFFFFF;
   border-top: 1px solid transparent;
 }
@@ -189,7 +189,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c17 > svg {
+.c18 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -205,7 +205,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c19 {
+.c20 {
   padding-left: 0.5rem;
 }
 
@@ -316,14 +316,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c20 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c20 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -338,34 +338,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c23 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c14 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c14 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c24 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -373,27 +345,55 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c15 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c24 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c16 {
+  .c17 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c16 {
+  .c17 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -481,7 +481,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c1 {
-    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
     vertical-align: top;
@@ -537,6 +537,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   .c7 > time {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c2 {
+    visibility: visible;
   }
 }
 
@@ -617,18 +623,32 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               class=""
               role="text"
             >
+              <span
+                aria-hidden="true"
+                class="c13"
+              >
+                LIVE
+              </span>
+              <span
+                class="c14"
+                lang="en-GB"
+              >
+                 Live
+                ,
+              </span>
               <span>
+                 
                 Could a computer ever create better art than a human?
               </span>
               <span
-                class="c13"
+                class="c14"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c14"
+                class="c15"
               >
                 29/01/1990
               </span>
@@ -636,20 +656,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c16"
+        class="c17"
       >
         <span
-          class="c17"
+          class="c18"
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -664,12 +684,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="ltr"
         >
           <span
-            class="c13"
+            class="c14"
           >
              Duration 45,00 
           </span>
@@ -744,32 +764,18 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               class=""
               role="text"
             >
-              <span
-                aria-hidden="true"
-                class="c20"
-              >
-                LIVE
-              </span>
-              <span
-                class="c13"
-                lang="en-GB"
-              >
-                 Live
-                ,
-              </span>
               <span>
-                 
                 Could a computer ever create better art than a human?
               </span>
               <span
-                class="c13"
+                class="c14"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c14"
+                class="c15"
               >
                 29/01/1990
               </span>
@@ -777,7 +783,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
@@ -786,11 +792,11 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         class="c21"
       >
         <span
-          class="c17"
+          class="c18"
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -805,12 +811,139 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="ltr"
         >
           <span
-            class="c13"
+            class="c14"
+          >
+             Duration 45,00 
+          </span>
+          <span
+            aria-hidden="true"
+            class="Duration0 "
+          >
+            45:00
+          </span>
+        </time>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c1 c2"
+    dir="ltr"
+  >
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
+      >
+        <span
+          class="c5"
+          dir="ltr"
+        >
+          <svg
+            aria-hidden="true"
+            class="c6"
+            focusable="false"
+            height="13"
+            viewBox="0 0 13 13"
+            width="13"
+          >
+            <path
+              d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+            />
+            <path
+              d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+            />
+          </svg>
+        </span>
+        <span
+          aria-hidden="true"
+          class="c7"
+          dir="ltr"
+        >
+          <time
+            class="c8"
+            datetime="2019-08-27"
+          >
+            14:54
+          </time>
+        </span>
+      </div>
+    </div>
+    <div
+      class="c9"
+    >
+      <div
+        class="c10"
+      >
+        <h3
+          class="c11"
+        >
+          <a
+            class="c12"
+            href="/news/articles/cn7k01xp8kxo"
+          >
+            <span
+              class=""
+              role="text"
+            >
+              <span>
+                Could a computer ever create better art than a human?
+              </span>
+              <span
+                class="c14"
+              >
+                , 
+                14:54
+                , 
+              </span>
+              <span
+                class="c15"
+              >
+                29/01/1990
+              </span>
+            </span>
+          </a>
+        </h3>
+        <p
+          class="c16"
+        >
+          The critic, author, poet and TV host was known for his witty commentary on international television.
+        </p>
+      </div>
+      <div
+        class="c21"
+      >
+        <span
+          class="c18"
+        >
+          <svg
+            aria-hidden="true"
+            class="c19"
+            focusable="false"
+            height="12px"
+            viewBox="0 0 13 12"
+            width="13px"
+          >
+            <path
+              d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+            />
+            <path
+              d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+            />
+          </svg>
+        </span>
+        <time
+          class="c20"
+          datetime="PT45M"
+          dir="ltr"
+        >
+          <span
+            class="c14"
           >
              Duration 45,00 
           </span>
@@ -887,7 +1020,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               NEXT
             </span>
             <span
-              class="c13"
+              class="c14"
             >
               ,
             </span>
@@ -896,7 +1029,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               Could a computer ever create better art than a human?
             </span>
             <span
-              class="c13"
+              class="c14"
             >
               , 
               14:54
@@ -910,7 +1043,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </span>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
@@ -923,7 +1056,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -938,12 +1071,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="ltr"
         >
           <span
-            class="c13"
+            class="c14"
           >
              Duration 45,00 
           </span>
@@ -970,7 +1103,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c18 {
+.c19 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1008,7 +1141,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c13 {
+.c14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -1062,7 +1195,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c20 {
+.c13 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1080,7 +1213,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c14 {
+.c15 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -1102,7 +1235,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1.625rem;
 }
 
-.c15 {
+.c16 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1113,14 +1246,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #B80000;
   color: #FFFFFF;
   border-top: 1px solid transparent;
 }
@@ -1132,7 +1265,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #222222;
   color: #FFFFFF;
   border-top: 1px solid transparent;
 }
@@ -1149,7 +1282,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c17 > svg {
+.c18 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1165,7 +1298,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c19 {
+.c20 {
   padding-right: 0.5rem;
 }
 
@@ -1276,14 +1409,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c20 {
+  .c13 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c20 {
+  .c13 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1304,14 +1437,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c14 {
+  .c15 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c15 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1328,32 +1461,32 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c24 {
     font-size: 1.25rem;
     line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c15 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c15 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c16 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c17 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c16 {
+  .c17 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -1441,7 +1574,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c1 {
-    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
     vertical-align: top;
@@ -1497,6 +1630,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c7 > time {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c2 {
+    visibility: visible;
   }
 }
 
@@ -1577,18 +1716,32 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               class=""
               role="text"
             >
+              <span
+                aria-hidden="true"
+                class="c13"
+              >
+                LIVE
+              </span>
+              <span
+                class="c14"
+                lang="en-GB"
+              >
+                 Live
+                ,
+              </span>
               <span>
+                 
                 لماذا يخجل البعض من اسم قريته في مصر؟
               </span>
               <span
-                class="c13"
+                class="c14"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c14"
+                class="c15"
               >
                 29/01/1990
               </span>
@@ -1596,20 +1749,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c16"
+        class="c17"
       >
         <span
-          class="c17"
+          class="c18"
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1624,12 +1777,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="rtl"
         >
           <span
-            class="c13"
+            class="c14"
           >
              Duration 45,00 
           </span>
@@ -1704,32 +1857,18 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               class=""
               role="text"
             >
-              <span
-                aria-hidden="true"
-                class="c20"
-              >
-                LIVE
-              </span>
-              <span
-                class="c13"
-                lang="en-GB"
-              >
-                 Live
-                ,
-              </span>
               <span>
-                 
                 لماذا يخجل البعض من اسم قريته في مصر؟
               </span>
               <span
-                class="c13"
+                class="c14"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c14"
+                class="c15"
               >
                 29/01/1990
               </span>
@@ -1737,7 +1876,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
@@ -1746,11 +1885,11 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         class="c21"
       >
         <span
-          class="c17"
+          class="c18"
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1765,12 +1904,139 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="rtl"
         >
           <span
-            class="c13"
+            class="c14"
+          >
+             Duration 45,00 
+          </span>
+          <span
+            aria-hidden="true"
+            class="Duration0 "
+          >
+            45:00
+          </span>
+        </time>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c1 c2"
+    dir="rtl"
+  >
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
+      >
+        <span
+          class="c5"
+          dir="rtl"
+        >
+          <svg
+            aria-hidden="true"
+            class="c6"
+            focusable="false"
+            height="13"
+            viewBox="0 0 13 13"
+            width="13"
+          >
+            <path
+              d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+            />
+            <path
+              d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+            />
+          </svg>
+        </span>
+        <span
+          aria-hidden="true"
+          class="c7"
+          dir="rtl"
+        >
+          <time
+            class="c8"
+            datetime="2019-08-27"
+          >
+            ۱۴:۵۴
+          </time>
+        </span>
+      </div>
+    </div>
+    <div
+      class="c9"
+    >
+      <div
+        class="c10"
+      >
+        <h3
+          class="c11"
+        >
+          <a
+            class="c12"
+            href="/arabic/articles/c1er5mjnznzo"
+          >
+            <span
+              class=""
+              role="text"
+            >
+              <span>
+                لماذا يخجل البعض من اسم قريته في مصر؟
+              </span>
+              <span
+                class="c14"
+              >
+                , 
+                ۱۴:۵۴
+                , 
+              </span>
+              <span
+                class="c15"
+              >
+                29/01/1990
+              </span>
+            </span>
+          </a>
+        </h3>
+        <p
+          class="c16"
+        >
+          هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
+        </p>
+      </div>
+      <div
+        class="c21"
+      >
+        <span
+          class="c18"
+        >
+          <svg
+            aria-hidden="true"
+            class="c19"
+            focusable="false"
+            height="12px"
+            viewBox="0 0 13 12"
+            width="13px"
+          >
+            <path
+              d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+            />
+            <path
+              d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+            />
+          </svg>
+        </span>
+        <time
+          class="c20"
+          datetime="PT45M"
+          dir="rtl"
+        >
+          <span
+            class="c14"
           >
              Duration 45,00 
           </span>
@@ -1847,7 +2113,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               NEXT
             </span>
             <span
-              class="c13"
+              class="c14"
             >
               ,
             </span>
@@ -1856,7 +2122,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               لماذا يخجل البعض من اسم قريته في مصر؟
             </span>
             <span
-              class="c13"
+              class="c14"
             >
               , 
               ۱۴:۵۴
@@ -1870,7 +2136,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </span>
         </h3>
         <p
-          class="c15"
+          class="c16"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
@@ -1883,7 +2149,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="c18"
+            class="c19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1898,12 +2164,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c19"
+          class="c20"
           datetime="PT45M"
           dir="rtl"
         >
           <span
-            class="c13"
+            class="c14"
           >
              Duration 45,00 
           </span>

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+import {
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MAX,
+} from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import Grid from '@bbc/psammead-grid';
 import { arrayOf, number, oneOf, shape, string } from 'prop-types';
@@ -11,8 +15,12 @@ const StartTimeWrapper = styled.div`
   padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};
 `;
 
+// const isLastOnDemand = ({schedules, })
 // Using flex-box on browsers that do not support grid will break grid fallback defined in psammead-grid
 const StyledGrid = styled(Grid)`
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    visibility: visible;
+  }
   @supports (display: grid) {
     display: flex;
     flex-direction: column;
@@ -95,7 +103,7 @@ const programGridProps = {
     group0: 4,
     group1: 4,
     group2: 6,
-    group3: 2,
+    group3: 3,
     group4: 2,
     group5: 2,
   },
@@ -149,6 +157,7 @@ renderSchedule.propTypes = {
 
 RadioSchedule.propTypes = {
   schedules: arrayOf(programPropTypes).isRequired,
+  numberOfSchedules: number.isRequired,
   ...sharedProps,
 };
 

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -13,13 +13,17 @@ const StartTimeWrapper = styled.div`
 `;
 
 // Reset default of <ul> style
-const StyledGrid = styled(Grid)`
+const StyledGrid = styled(Grid).attrs({
+  role: 'list',
+})`
   padding: 0;
   margin: 0;
 `;
 
 // Using flex-box on browsers that do not support grid will break grid fallback defined in psammead-grid
-const StyledFlexGrid = styled(Grid)`
+const StyledFlexGrid = styled(Grid).attrs({
+  role: 'listitem',
+})`
   @supports (${grid}) {
     display: flex;
     flex-direction: column;

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import {
-  GEL_GROUP_3_SCREEN_WIDTH_MIN,
-  GEL_GROUP_3_SCREEN_WIDTH_MAX,
-} from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import Grid from '@bbc/psammead-grid';
 import { arrayOf, number, oneOf, shape, string } from 'prop-types';
@@ -15,12 +11,8 @@ const StartTimeWrapper = styled.div`
   padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};
 `;
 
-// const isLastOnDemand = ({schedules, })
 // Using flex-box on browsers that do not support grid will break grid fallback defined in psammead-grid
 const StyledGrid = styled(Grid)`
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    visibility: visible;
-  }
   @supports (display: grid) {
     display: flex;
     flex-direction: column;
@@ -157,7 +149,6 @@ renderSchedule.propTypes = {
 
 RadioSchedule.propTypes = {
   schedules: arrayOf(programPropTypes).isRequired,
-  numberOfSchedules: number.isRequired,
   ...sharedProps,
 };
 

--- a/packages/components/psammead-radio-schedule/src/index.stories.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.stories.jsx
@@ -9,7 +9,7 @@ import {
   renderProgramCard,
   renderRadioSchedule,
   sentenceCase,
-  stateTypes,
+  uniqueStates,
 } from './testHelpers/helper';
 import notes from '../README.md';
 import StartTime from './StartTime';
@@ -40,7 +40,7 @@ const programCardStories = storiesOf(PROGRAM_CARD_STORIES, module).addDecorator(
   withKnobs,
 );
 
-stateTypes.forEach(state => {
+uniqueStates.forEach(state => {
   programCardStories.add(
     `${state}`,
     ({ service }) =>
@@ -62,7 +62,7 @@ programCardStories.add(
 );
 
 buildRTLSubstories(PROGRAM_CARD_STORIES, {
-  include: [...stateTypes],
+  include: [...uniqueStates],
 });
 
 storiesOf('Components|RadioSchedule/StartTime', module)

--- a/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
+++ b/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
@@ -11,7 +11,7 @@ export const sentenceCase = text =>
     .charAt(0)
     .toUpperCase() + text.substring(1);
 
-export const stateTypes = ['onDemand', 'live', 'next'];
+export const stateTypes = ['live', 'onDemand', 'onDemand', 'next'];
 
 const getSchedule = (service, withLongSummary) => {
   const { text, articlePath, longText } = TEXT_VARIANTS[service];
@@ -80,5 +80,6 @@ export const renderRadioSchedule = ({
     script={script}
     service={service}
     dir={dir}
+    numberOfSchedules={getSchedule(service, withLongSummary).length}
   />
 );

--- a/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
+++ b/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
@@ -12,7 +12,9 @@ export const sentenceCase = text =>
     .charAt(0)
     .toUpperCase() + text.substring(1);
 
+// Will remove and clean up in future PRs
 export const stateTypes = ['live', 'onDemand', 'onDemand', 'next'];
+export const uniqueStates = ['live', 'onDemand', 'next'];
 
 const getSchedule = (service, withLongSummary) => {
   const { text, articlePath, longText } = TEXT_VARIANTS[service];

--- a/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
+++ b/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
@@ -80,6 +80,5 @@ export const renderRadioSchedule = ({
     script={script}
     service={service}
     dir={dir}
-    numberOfSchedules={getSchedule(service, withLongSummary).length}
   />
 );


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/3134

**Overall change:** 
Changes the grid layout of the component in group 3 from having the 4th card overflow to another row to having a 2x2 layout instead. Also updated stories to have 4 cards rather than 3.
Originally we were to hide a card so the layout would be:
![image](https://user-images.githubusercontent.com/53564281/75670743-39ddfd00-5c75-11ea-9d9d-339d410c7a41.png)
Now UX have agreed on this layout so we don't hide any information just on one breakpoint:
![image](https://user-images.githubusercontent.com/53564281/75670773-4e21fa00-5c75-11ea-9664-89f72b2cfaf7.png)


**Code changes:**

- Changed `group3` of `programCardGridProps` from 2 to 3 in order to make 2x2 layout.
- Just added `onDemand` twice to `stateTypes` to add another card easily to stories and changed the order to be correct.
- Updated tests to use just the 3 unique state types.
- Added roles to each grid from https://github.com/bbc/psammead/pull/3181#issuecomment-593337683
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
