### PR TITLE
Define z-index on section-label wrapper

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.1 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Define `z-index` on section-label wrapper  |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |
 | 4.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.1 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.1 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Define `z-index` on section-label wrapper  |
+| 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper  |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |
 | 4.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.1 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -52,6 +52,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -230,6 +231,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -452,6 +454,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -674,6 +677,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -896,6 +900,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1085,6 +1090,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1240,6 +1246,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1395,6 +1402,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1550,6 +1558,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1733,6 +1742,7 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -1932,6 +1942,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -2131,6 +2142,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -2297,6 +2309,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -2429,6 +2442,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 
@@ -2561,6 +2575,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 
 .c0 {
   position: relative;
+  z-index: 0;
   margin-top: 2rem;
 }
 

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -34,6 +34,7 @@ const Bar = styled.div`
 
 const SectionLabelWrapper = styled.div`
   position: relative;
+  z-index: 0;
 
   margin-top: ${GEL_SPACING_QUAD};
 


### PR DESCRIPTION
Relates to  https://github.com/bbc/simorgh/pull/5727

**Overall change:** 
_The horizontal bar on the section-label component has a `z-index` of `-1`, this causes it to be hidden behind when the parent component has a `background-color`, this PR adds a `z-index` of `0` to the section-label wrapper to fix this issue._

**Section label inside a div with a white background-color**
<img width="1076" alt="Screen Shot 2020-03-02 at 2 32 29 PM" src="https://user-images.githubusercontent.com/21374761/75675403-2b550d00-5c98-11ea-909f-6ea5cd940084.png">

**Section label with `z-index:0` applied to the wrapper**
![Screen Shot 2020-03-02 at 3 13 51 PM](https://user-images.githubusercontent.com/21374761/75675611-88e95980-5c98-11ea-8b6b-672b731c957a.png)


**Code changes:**

- _Add `z-index` to the section-label wrapper._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
