### PR TITLE
Fix service variants breaking stories

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.19 | [PR#31xx](https://github.com/bbc/psammead/pull/31xx) Fix service variants breaking stories |
+| 0.1.0-alpha.19 | [PR#3196](https://github.com/bbc/psammead/pull/3196) Fix service variants breaking stories |
 | 0.1.0-alpha.18 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
 | 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label 
 | 0.1.0-alpha.16 | [PR#3179](https://github.com/bbc/psammead/pull/3179) Make summary not required for Program Card |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.19 | [PR#31xx](https://github.com/bbc/psammead/pull/31xx) Fix service variants breaking stories |
 | 0.1.0-alpha.18 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
 | 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label 
 | 0.1.0-alpha.16 | [PR#3179](https://github.com/bbc/psammead/pull/3179) Make summary not required for Program Card |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/index.stories.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.stories.jsx
@@ -12,6 +12,7 @@ import {
   uniqueStates,
 } from './testHelpers/helper';
 import notes from '../README.md';
+import { getServiceVariant } from '../../psammead-most-read/src/utilities/index';
 import StartTime from './StartTime';
 
 const storiesUnixTimestamp = 1566914061212;
@@ -21,14 +22,36 @@ const radioScheduleStories = storiesOf(RADIO_SCHEDULE_STORIES, module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob());
 
-radioScheduleStories.add('default', props => renderRadioSchedule(props), {
-  notes,
-});
+radioScheduleStories.add(
+  'default',
+  ({ service, script, dir, locale, timezone, variant }) =>
+    renderRadioSchedule({
+      service: getServiceVariant({ service, variant }),
+      locale,
+      timezone,
+      script,
+      dir,
+      withLongSummary: false,
+    }),
+  {
+    notes,
+  },
+);
 
 radioScheduleStories.add(
   'Schedule with different heights',
-  props => renderRadioSchedule({ ...props, withLongSummary: true }),
-  { notes },
+  ({ service, script, dir, locale, timezone, variant }) =>
+    renderRadioSchedule({
+      service: getServiceVariant({ service, variant }),
+      locale,
+      timezone,
+      script,
+      dir,
+      withLongSummary: true,
+    }),
+  {
+    notes,
+  },
 );
 
 buildRTLSubstories(RADIO_SCHEDULE_STORIES, {


### PR DESCRIPTION
Resolves #3183

**Overall change:**
Service variants in `TEXT_VARIANTS` were changed in https://github.com/bbc/psammead/pull/2940 which means a function to get the variants in the correct format is needed to make them work in storybook stories. This PR uses the same function made in MostRead to fix the broken stories. The `withServiceKnobs` can be refactored and fixed at a later date, this is just a quick fix to get stories working for RadioSchedules.

**Code changes:**
- Imported `getServiceVariant()` from MostRead and used it in relevant stories in RadioSchedules.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
