### PR TITLE
add data-e2e attribute to radio schedule item

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,8 +3,9 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.19 | [PR#3197](https://github.com/bbc/psammead/pull/3197) Add data-e2e attribute to program card element to contain the state of the program |
 | 0.1.0-alpha.18 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
-| 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label 
+| 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label |
 | 0.1.0-alpha.16 | [PR#3179](https://github.com/bbc/psammead/pull/3179) Make summary not required for Program Card |
 | 0.1.0-alpha.15 | [PR#3181](https://github.com/bbc/psammead/pull/3181) Alias radio schedule parent grid to be a `ul` with grid items aliased as `li` |
 | 0.1.0-alpha.14 | [PR#3164](https://github.com/bbc/psammead/pull/3164) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -564,6 +564,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 >
   <li
     class="c2 c3"
+    data-e2e="live"
     dir="ltr"
     role="listitem"
   >
@@ -706,6 +707,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="onDemand"
     dir="ltr"
     role="listitem"
   >
@@ -834,6 +836,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="onDemand"
     dir="ltr"
     role="listitem"
   >
@@ -962,6 +965,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="next"
     dir="ltr"
     role="listitem"
   >
@@ -1661,6 +1665,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 >
   <li
     class="c2 c3"
+    data-e2e="live"
     dir="rtl"
     role="listitem"
   >
@@ -1801,6 +1806,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="onDemand"
     dir="rtl"
     role="listitem"
   >
@@ -1929,6 +1935,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="onDemand"
     dir="rtl"
     role="listitem"
   >
@@ -2057,6 +2064,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   </li>
   <li
     class="c2 c3"
+    data-e2e="next"
     dir="rtl"
     role="listitem"
   >

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -21,9 +21,10 @@ const StyledGrid = styled(Grid).attrs({
 `;
 
 // Using flex-box on browsers that do not support grid will break grid fallback defined in psammead-grid
-const StyledFlexGrid = styled(Grid).attrs({
+const StyledFlexGrid = styled(Grid).attrs(({ state }) => ({
   role: 'listitem',
-})`
+  'data-e2e': state,
+}))`
   @supports (${grid}) {
     display: flex;
     flex-direction: column;
@@ -127,6 +128,7 @@ const RadioSchedule = ({ schedules, dir, ...props }) => (
         {...programGridProps}
         key={id}
         forwardedAs="li"
+        state={program.state}
       >
         {renderSchedule({ ...props, dir, program })}
       </StyledFlexGrid>


### PR DESCRIPTION
Resolves: n/a

**Overall change:** _To be able to easily test the state order of the radio schedules, I've added an attribute that contains the current state of the program._

![image](https://user-images.githubusercontent.com/30599794/75686240-d1524880-5c93-11ea-8024-4f0aa61c79b9.png)


**Code changes:**

- _add `data-e2e` attribute to the radio schedule item to be the program's state_
- _updated snapshots_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
