### PR TITLE
Remove aria-hidden label from live label

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 5.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Live Label is no longer aria hidden |
+| 5.0.0 | [PR#3202](https://github.com/bbc/psammead/pull/3202) Live Label is no longer aria hidden |
 | 4.0.0 | [PR#3154](https://github.com/bbc/psammead/pull/3154) Remove alpha tag |
 | 4.0.0-alpha.13 | [PR#3150](https://github.com/bbc/psammead/pull/3150) Fix fallback width for Leading promo |
 | 4.0.0-alpha.12 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 5.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Live Label is no longer aria hidden |
 | 4.0.0 | [PR#3154](https://github.com/bbc/psammead/pull/3154) Remove alpha tag |
 | 4.0.0-alpha.13 | [PR#3150](https://github.com/bbc/psammead/pull/3150) Fix fallback width for Leading promo |
 | 4.0.0-alpha.12 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo/README.md
+++ b/packages/components/psammead-story-promo/README.md
@@ -143,7 +143,7 @@ const Image = <img src="https://foobar.com/image.jpg" />;
 
 const LiveComponent = ({ headline, service, dir }) => (
   <span role="text">
-    <LiveLabel service={service} dir={dir}>
+    <LiveLabel service={service} dir={dir} aria-hidden="true">
       LIVE
     </LiveLabel>
     <VisuallyHiddenText lang="en-GB">Live, </VisuallyHiddenText>
@@ -222,6 +222,8 @@ The `StoryPromo` component is designed to be used within a link element to allow
 This component uses full semantic markup for the `Headline`, `Summary`, and `Link`, using `h3`, `p` and `a` respectively. Other accessibility factors such as image alt text and time elements are passed in as props and aren't explicitly set in this component.
 
 The link is nested inside the `h3` for better support with VoiceOver Mac and Safari. We use the `faux block link` pattern which makes the entire block clickable, whilst also enabling links nested within in that block to also be clickable.
+
+The `LiveLabel` example above shows this component being hidden to screen readers, and has visually hidden text rendered alongside it. This is to ensure the screen reader announces the word 'Live' correctly. This does not need to be accounted for in other languages.
 
 ## Roadmap
 

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -2000,7 +2000,6 @@ exports[`StoryPromo should render Live promo correctly 1`] = `
           role="text"
         >
           <span
-            aria-hidden="true"
             class="c6"
             dir="ltr"
           >
@@ -2241,7 +2240,6 @@ exports[`StoryPromo should render a RTL Live promo correctly 1`] = `
           role="text"
         >
           <span
-            aria-hidden="true"
             class="c6"
             dir="rtl"
           >

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -227,7 +227,7 @@ export const Link = styled.a`
   }
 `;
 
-export const LiveLabel = styled.span.attrs({ 'aria-hidden': 'true' })`
+export const LiveLabel = styled.span`
   ${({ service }) => getSansBold(service)}
   color: ${C_POSTBOX};
   display: inline-block;


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/5749

**Overall change:** This removes the aria-hidden attribute from the live label. We don't want this to be hidden apart from the specific use case when the label is in english, in which case we can add this attribute when the component is used.

**Code changes:**

- Removes aria-hidden attribute from the live label

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
