### PR TITLE
Removing isRequired from mediaInfo prop

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.7.4 | [PR#3205](https://github.com/bbc/psammead/pull/3205) Removed isRequired from mediaInfo prop as not always required |
 | 2.7.3 | [PR#3151](https://github.com/bbc/psammead/pull/3151) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.7.2 | [PR#3113](https://github.com/bbc/psammead/pull/3113) Added bottom margin padding for live radio audio player  |
 | 2.7.1 | [PR#3060](https://github.com/bbc/psammead/pull/3060) Refactored Message component to display message for Expired AV Stream  |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/index.jsx
+++ b/packages/components/psammead-media-player/src/index.jsx
@@ -119,13 +119,13 @@ CanonicalMediaPlayer.propTypes = {
   noJsClassName: string,
   noJsMessage: string.isRequired,
   mediaInfo: shape({
-    title: string.isRequired,
+    title: string,
     datetime: string,
     duration: string,
     durationSpoken: string,
     type: oneOf(['video', 'audio']),
     guidanceMessage: string,
-  }).isRequired,
+  }),
 };
 
 CanonicalMediaPlayer.defaultProps = {
@@ -135,6 +135,7 @@ CanonicalMediaPlayer.defaultProps = {
   placeholderSrc: null,
   placeholderSrcset: null,
   noJsClassName: null,
+  mediaInfo: {},
 };
 
 MediaMessage.propTypes = {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Removed isRequired from a prop that is not always required

**Code changes:**

- Removed isRequired from the mediaInfo prop for Canonical Media Player
- Set the default value for mediaInfo as empty object

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
