### PR TITLE
Add prop to allow us to set aria-hidden on live label

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 5.1.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Add prop to toggle if live label is hidden, as styled components strips aria tag |
+| 5.1.0 | [PR#3206](https://github.com/bbc/psammead/pull/3206) Add prop to toggle if live label is hidden, as styled components strips aria tag |
 | 5.0.0 | [PR#3202](https://github.com/bbc/psammead/pull/3202) Live Label is no longer aria hidden |
 | 4.0.0 | [PR#3154](https://github.com/bbc/psammead/pull/3154) Remove alpha tag |
 | 4.0.0-alpha.13 | [PR#3150](https://github.com/bbc/psammead/pull/3150) Fix fallback width for Leading promo |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 5.1.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Add prop to toggle if live label is hidden, as styled components strips aria tag |
 | 5.0.0 | [PR#3202](https://github.com/bbc/psammead/pull/3202) Live Label is no longer aria hidden |
 | 4.0.0 | [PR#3154](https://github.com/bbc/psammead/pull/3154) Remove alpha tag |
 | 4.0.0-alpha.13 | [PR#3150](https://github.com/bbc/psammead/pull/3150) Fix fallback width for Leading promo |

--- a/packages/components/psammead-story-promo/README.md
+++ b/packages/components/psammead-story-promo/README.md
@@ -46,7 +46,7 @@ The `StoryPromo` component is designed to be used on 'index' pages, which are pa
 
 ## LiveLabel
 
-The `LiveLabel` component is to be used inside a `Link` in index pages to show a promo for a Live page.
+The `LiveLabel` component is to be used inside a `Link` in index pages to show a promo for a Live page. The ariaHidden prop is needed as styled components strips out aria tags on a server render.
 
 ### Props
 
@@ -55,6 +55,7 @@ The `LiveLabel` component is to be used inside a `Link` in index pages to show a
 | -------- | ------ | -------- | ------- | -------- |
 | service  | string | yes      | N/A     | `'news'` |
 | dir      | string | no       | `'ltr'` | `'rtl'`  |
+| ariaHidden | bool | no       | `false` | `true`  |
 
 ## IndexAlsos
 
@@ -143,7 +144,7 @@ const Image = <img src="https://foobar.com/image.jpg" />;
 
 const LiveComponent = ({ headline, service, dir }) => (
   <span role="text">
-    <LiveLabel service={service} dir={dir} aria-hidden="true">
+    <LiveLabel service={service} dir={dir} ariaHidden>
       LIVE
     </LiveLabel>
     <VisuallyHiddenText lang="en-GB">Live, </VisuallyHiddenText>

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -2000,6 +2000,7 @@ exports[`StoryPromo should render Live promo correctly 1`] = `
           role="text"
         >
           <span
+            aria-hidden="true"
             class="c6"
             dir="ltr"
           >
@@ -2240,6 +2241,7 @@ exports[`StoryPromo should render a RTL Live promo correctly 1`] = `
           role="text"
         >
           <span
+            aria-hidden="true"
             class="c6"
             dir="rtl"
           >

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -227,7 +227,9 @@ export const Link = styled.a`
   }
 `;
 
-export const LiveLabel = styled.span`
+export const LiveLabel = styled.span.attrs(
+  props => props.ariaHidden && { 'aria-hidden': 'true' },
+)`
   ${({ service }) => getSansBold(service)}
   color: ${C_POSTBOX};
   display: inline-block;
@@ -240,10 +242,12 @@ export const LiveLabel = styled.span`
 LiveLabel.propTypes = {
   service: string.isRequired,
   dir: oneOf(['rtl', 'ltr']),
+  ariaHidden: bool,
 };
 
 LiveLabel.defaultProps = {
   dir: 'ltr',
+  ariaHidden: false,
 };
 
 const StoryPromo = ({

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -228,7 +228,7 @@ export const Link = styled.a`
 `;
 
 export const LiveLabel = styled.span.attrs(
-  props => props.ariaHidden && { 'aria-hidden': 'true' },
+  ({ ariaHidden }) => ariaHidden && { 'aria-hidden': 'true' },
 )`
   ${({ service }) => getSansBold(service)}
   color: ${C_POSTBOX};

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -56,7 +56,7 @@ const MediaIndicatorComponent = ({
 const LiveComponent = ({ headline, service, dir }) => (
   /* eslint-disable-next-line jsx-a11y/aria-role */
   <span role="text">
-    <LiveLabel service={service} dir={dir}>
+    <LiveLabel service={service} dir={dir} ariaHidden>
       LIVE
     </LiveLabel>
     <VisuallyHiddenText lang="en-GB">{` Live, `}</VisuallyHiddenText>

--- a/packages/components/psammead-story-promo/src/index.test.jsx
+++ b/packages/components/psammead-story-promo/src/index.test.jsx
@@ -17,7 +17,7 @@ const Image = <img src="https://foobar.com/image.png" alt="Alt text" />;
 const LiveComponent = ({ headline, dir, service }) => (
   /* eslint-disable-next-line jsx-a11y/aria-role */
   <span role="text">
-    <LiveLabel dir={dir} service={service}>
+    <LiveLabel dir={dir} service={service} ariaHidden>
       LIVE
     </LiveLabel>
     <VisuallyHiddenText lang="en-GB">Live, </VisuallyHiddenText>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5749

**Overall change:**
Styled components strips out 'aria-hidden' when rendering on the server. Will look into this, but in the meantime we can pass a prop to the live label that lets us set this attribute.

**Code changes:**

- Add prop to live label to set ariaHidden to true or false

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
