### PR TITLE
Update bulletin to use new version of live label from story promo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.91 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update version of story promo in root dev dependencies |
 | 2.0.90 | [PR#3176](https://github.com/bbc/psammead/pull/3176) Bumping dependencies |
 | 2.0.89 | [PR#3164](https://github.com/bbc/psammead/pull/3164) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.88 | [PR#3161](https://github.com/bbc/psammead/pull/3161) Bumping yargs-parser to 17.0.0 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.90",
+  "version": "2.0.91",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2941,21 +2941,13 @@
       }
     },
     "@bbc/psammead-story-promo": {
-      "version": "4.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-4.0.0-alpha.8.tgz",
-      "integrity": "sha512-oF+Q9KrSU3eDI7Q45FLTItdfH6Uj0geOYwPXKLKdN7oYZcC10DKQFeTgPR5CT/D+3YNMDcWGgYrrQpxzkF/fBA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-5.1.0.tgz",
+      "integrity": "sha512-IUm7HDQUkQIJo2sXQtW2SvuJv27u/IswXq6lakX7FW9irlnkPOadN7kgsF1TvbygQuN4aCVt5TOWX2ZF2qhTTA==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^3.4.3",
+        "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-styles": "^4.3.0"
-      },
-      "dependencies": {
-        "@bbc/gel-foundations": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.4.3.tgz",
-          "integrity": "sha512-rOPuintdkftYDE0GcY8B5K/AR5tLAMv7E+jD0plk32aEBojTXgttSYW9Da4NBKxLw69N9Px29YEu1CU0is1j9w==",
-          "dev": true
-        }
       }
     },
     "@bbc/psammead-storybook-helpers": {
@@ -15900,7 +15892,7 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
@@ -15914,14 +15906,14 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -15939,7 +15931,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -15950,7 +15942,7 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
@@ -15978,14 +15970,14 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -15995,28 +15987,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -16026,14 +16018,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -16050,7 +16042,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -16065,14 +16057,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -16082,7 +16074,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -16092,7 +16084,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -16110,14 +16102,14 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -16127,14 +16119,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -16151,7 +16143,7 @@
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -16162,7 +16154,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -16172,7 +16164,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -16182,14 +16174,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -16201,7 +16193,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -16220,7 +16212,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -16231,14 +16223,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -16249,7 +16241,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -16269,14 +16261,14 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -16286,21 +16278,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -16311,21 +16303,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -16338,7 +16330,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -16347,7 +16339,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -16363,7 +16355,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -16380,42 +16372,42 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -16427,7 +16419,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -16437,7 +16429,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -16447,14 +16439,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -16470,14 +16462,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15892,7 +15892,7 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
@@ -15906,14 +15906,14 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -15931,7 +15931,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -15942,7 +15942,7 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
@@ -15970,14 +15970,14 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -15987,28 +15987,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -16018,14 +16018,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -16042,7 +16042,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -16057,14 +16057,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -16074,7 +16074,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -16084,7 +16084,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -16102,14 +16102,14 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -16119,14 +16119,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -16143,7 +16143,7 @@
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -16154,7 +16154,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -16164,7 +16164,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -16174,14 +16174,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -16193,7 +16193,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -16212,7 +16212,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -16223,14 +16223,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -16241,7 +16241,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -16261,14 +16261,14 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -16278,21 +16278,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -16303,21 +16303,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -16330,7 +16330,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -16339,7 +16339,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -16355,7 +16355,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -16372,42 +16372,42 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -16419,7 +16419,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -16429,7 +16429,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -16439,14 +16439,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -16462,14 +16462,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.90",
+  "version": "2.0.91",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -61,7 +61,7 @@
     "@bbc/psammead-locales": "^4.1.2",
     "@bbc/psammead-media-indicator": "^4.0.4",
     "@bbc/psammead-paragraph": "^2.2.26",
-    "@bbc/psammead-story-promo": "^4.0.0-alpha.8",
+    "@bbc/psammead-story-promo": "^5.1.0",
     "@bbc/psammead-storybook-helpers": "^8.2.5",
     "@bbc/psammead-styles": "^4.3.0",
     "@bbc/psammead-test-helpers": "^3.1.3",

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Update live label usage, update major version of story promo |
+| 3.0.0 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update live label usage, update major version of story promo |
 | 2.0.3 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Refactor visually hidden state label |
 | 2.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.0.1 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Update live label usage, update major version of story promo |
 | 2.0.3 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Refactor visually hidden state label |
 | 2.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 2.0.1 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -14,10 +14,24 @@
       "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.13.0.tgz",
       "integrity": "sha512-s/Gt06FMYY57m2uUVq2QaPm/ZBK4duO5NPmxjPLqyG4PKZbvV05XuFky9TrWuwYgJV4haPTMaI6JfT9tA4aGjw=="
     },
+    "@bbc/psammead-story-promo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-5.1.0.tgz",
+      "integrity": "sha512-IUm7HDQUkQIJo2sXQtW2SvuJv27u/IswXq6lakX7FW9irlnkPOadN7kgsF1TvbygQuN4aCVt5TOWX2ZF2qhTTA==",
+      "requires": {
+        "@bbc/gel-foundations": "^4.0.1",
+        "@bbc/psammead-styles": "^4.3.0"
+      }
+    },
     "@bbc/psammead-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.3.0.tgz",
       "integrity": "sha512-bgYd7pGMK7cbWsY2pq2nxbHWdPSW5ZIzEefDJ3xMi9FknwDQDO6m9OJ67TaovWNaPJvduVB9no7V+2eAuity7w=="
+    },
+    "@bbc/psammead-visually-hidden-text": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.2.3.tgz",
+      "integrity": "sha512-UtqVzp0onMnPvhxdOzTR6ej3UoAXzHMfIETZIo/HEOlbb0/V077MVulhBdZajBTJAwgqfZQTF+na1cC6vxMrDA=="
     }
   }
 }

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,7 +21,9 @@
   "dependencies": {
     "@bbc/gel-foundations": "^4.0.1",
     "@bbc/psammead-styles": "^4.3.0",
-    "@bbc/psammead-assets": "^2.13.0"
+    "@bbc/psammead-assets": "^2.13.0",
+    "@bbc/psammead-visually-hidden-text": "^1.2.3",
+    "@bbc/psammead-story-promo": "^5.1.0"
   },
   "peerDependencies": {
     "react": "^16.10.2",

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -206,7 +206,7 @@ const Bulletin = ({
                 </VisuallyHiddenText>
               )}
               {isLive && (
-                <LiveLabel service={service} dir={dir}>
+                <LiveLabel service={service} dir={dir} ariaHidden>
                   {`${liveText} `}
                 </LiveLabel>
               )}

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.11 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update direction in RTL story |
 | 1.1.10 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.1.9 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.1.8 | [PR#3107](https://github.com/bbc/psammead/pull/3107) Pass direction to Grid stories |

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/index.stories.jsx
+++ b/packages/components/psammead-grid/src/index.stories.jsx
@@ -1298,6 +1298,7 @@ storiesOf(STORY_KIND, module)
             image={Img}
             info={Info}
             promoType={promoType}
+            dir={dir}
             mediaIndicator={
               mediaType &&
               MediaIndicatorComponent({ script, service, mediaType })

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.0.5 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update snapshot test |
 | 4.0.4 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.3 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.2 | [PR#3107](https://github.com/bbc/psammead/pull/3107) Update snapshots using new version of story-promo at top level. |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -188,6 +188,7 @@ exports[`StoryPromo list should render correctly 1`] = `
     >
       <div
         class="c3"
+        dir="ltr"
       >
         <div
           class="c4"
@@ -200,6 +201,7 @@ exports[`StoryPromo list should render correctly 1`] = `
       </div>
       <div
         class="c5"
+        dir="ltr"
       >
         <h3
           class="c6"


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5749

**Overall change:**
We update the live label in story promos so we now have to explicitly state it should be aria hidden. This updates the bulletin to use this latest version.

This may not strictly be a major version change, but as I have added missing dependencies which differ by a major version to the ones currently in Simorgh, if this is a minor bump it will cause Simorgh builds to fail due to duplicate dependency versions if this is pulled in.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- Add missing dependencies to Bulletin package.json.
- Pass ariaHidden prop to live label in bulletin component.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
