### PR TITLE
Fix padding on program card

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.20 | [PR#3197](https://github.com/bbc/psammead/pull/3197) Add padding bottom to program cards  |
+| 0.1.0-alpha.20 | [PR#3242](https://github.com/bbc/psammead/pull/3242) Add padding bottom to program cards  |
 | 0.1.0-alpha.19 | [PR#3197](https://github.com/bbc/psammead/pull/3197) Add data-e2e attribute to program card element to contain the state of the program |
 | 0.1.0-alpha.18 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
 | 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.20 | [PR#3197](https://github.com/bbc/psammead/pull/3197) Add padding bottom to program cards  |
 | 0.1.0-alpha.19 | [PR#3197](https://github.com/bbc/psammead/pull/3197) Add data-e2e attribute to program card element to contain the state of the program |
 | 0.1.0-alpha.18 | [PR#3184](https://github.com/bbc/psammead/pull/3184) Change display of program cards in group3 & update stories to include 4 cards |
 | 0.1.0-alpha.17 | [PR#3160](https://github.com/bbc/psammead/pull/3160) Uniformise visually-hidden state label |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -280,7 +280,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 .c4 {
-  padding: 1rem 0 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .c1 {
@@ -290,6 +290,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 .c3 {
   position: relative;
+  padding-bottom: 1rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -1381,7 +1382,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 .c4 {
-  padding: 1rem 0 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .c1 {
@@ -1391,6 +1392,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 .c3 {
   position: relative;
+  padding-bottom: 1rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -9,7 +9,7 @@ import ProgramCard from './ProgramCard';
 import StartTime from './StartTime';
 
 const StartTimeWrapper = styled.div`
-  padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING};
+  padding-bottom: ${GEL_SPACING};
 `;
 
 // Reset default of <ul> style
@@ -30,6 +30,7 @@ const StyledFlexGrid = styled(Grid).attrs(({ state }) => ({
     flex-direction: column;
   }
   position: relative;
+  padding-bottom: ${GEL_SPACING_DBL};
 `;
 
 const renderSchedule = ({


### PR DESCRIPTION
Resolves #3241

**Overall change:** _Remove top padding from `StartTimeWrapper` and add as bottom padding to `ProgramCard` in Radio Schedule ._

**Code changes:**

- _Remove top padding from StartTimeWrapper and add as bottom padding to ProgramCard in Radio Schedule._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
