### PR TITLE
Fix script link span spacing

### DIFF
--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.11 | [PR#3135](https://github.com/bbc/psammead/pull/3xxx)  |
 | 1.0.10 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.9 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.8 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.11 | [PR#3135](https://github.com/bbc/psammead/pull/3xxx)  |
+| 1.0.11 | [PR#3245](https://github.com/bbc/psammead/pull/3245) Fix script link span spacing  |
 | 1.0.10 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.9 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.8 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-script-link/package-lock.json
+++ b/packages/components/psammead-script-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-script-link/package.json
+++ b/packages/components/psammead-script-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`ScriptLink should render correctly 1`] = `
   margin: 0.1875rem;
   display: inline-block;
   height: calc(100%);
-  padding: 0 1rem;
+  padding: 0 0.5rem;
 }
 
 .c0:hover > span,
@@ -55,7 +55,7 @@ exports[`ScriptLink should render correctly 1`] = `
   }
 
   .c0 > span {
-    padding: 0 0.75rem;
+    padding: 0 0.5rem;
     line-height: calc(2.5rem - 0.5rem);
   }
 }

--- a/packages/components/psammead-script-link/src/index.jsx
+++ b/packages/components/psammead-script-link/src/index.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {
-  GEL_SPACING,
-  GEL_SPACING_DBL,
-  GEL_SPACING_QUIN,
-} from '@bbc/gel-foundations/spacings';
+import { GEL_SPACING, GEL_SPACING_QUIN } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_2_SCREEN_WIDTH_MAX,
@@ -29,7 +25,7 @@ const StyledLink = styled.a`
     margin: 0.1875rem;
     display: inline-block;
     height: calc(100%);
-    padding: 0 ${GEL_SPACING_DBL};
+    padding: 0 ${GEL_SPACING};
   }
 
   &:hover > span,
@@ -46,7 +42,7 @@ const StyledLink = styled.a`
     height: ${GEL_SPACING_QUIN};
 
     > span {
-      padding: 0 0.75rem;
+      padding: 0 ${GEL_SPACING};
       line-height: calc(${GEL_SPACING_QUIN} - ${GEL_SPACING});
     }
   }


### PR DESCRIPTION
Resolves #3244 

**Overall change:** 
Updated script link span spacing from `1rem` to `0.5rem` for all breakpoints.

**Code changes:**
- Changed padding values in span from `GEL_SPACING_DBL` to `GEL_SPACING`

**Screenshots**
![image](https://user-images.githubusercontent.com/53564281/76511134-9944c580-644a-11ea-8d01-d834a01ae5fd.png)

Media Query:
![image](https://user-images.githubusercontent.com/53564281/76511075-8205d800-644a-11ea-9509-8b6f70b74eb6.png)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
