### PR TITLE
Android talkback issue in Navigation

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 6.0.6 | [PR#3177](https://github.com/bbc/psammead/pull/3252) Remove `scroll-behavior: smooth;` to from StyledScrollableNav |
+| 6.0.6 | [PR#3252](https://github.com/bbc/psammead/pull/3252) Remove `scroll-behavior: smooth;` from StyledScrollableNav |
 | 6.0.5 | [PR#3177](https://github.com/bbc/psammead/pull/3177) Add `cursor: pointer` to Menu button |
 | 6.0.4 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 6.0.3 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.6 | [PR#3177](https://github.com/bbc/psammead/pull/3252) Remove `scroll-behavior: smooth;` to from StyledScrollableNav |
 | 6.0.5 | [PR#3177](https://github.com/bbc/psammead/pull/3177) Add `cursor: pointer` to Menu button |
 | 6.0.4 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 6.0.3 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
@@ -15,7 +15,9 @@ const StyledScrollableNav = styled.div`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     white-space: nowrap;
     overflow-x: scroll;
-    scroll-behavior: smooth;
+
+    /* Avoid using smooth scrolling as it causes accessbility issues */
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
 
     /* Hide scrollbar */

--- a/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/ScrollableNavigation/index.jsx
@@ -16,7 +16,7 @@ const StyledScrollableNav = styled.div`
     white-space: nowrap;
     overflow-x: scroll;
 
-    /* Avoid using smooth scrolling as it causes accessbility issues */
+    /* Avoid using smooth scrolling as it causes accessibility issues */
     scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
 

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -939,10 +939,10 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   .c0 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;


### PR DESCRIPTION
Resolves #2999 

**Overall change:** 
When using Android Talkback and moving between nav items `scroll-behavior: smooth;` was causing talkback to repeat the item 2-3 times because of the scroll speed. This change reverts it back to auto, with a comment to indicate it shouldn't be set to smooth.

A few other things that I checked and discovered
- This style is only applied in mobile view, so disabling it has no effect on Desktop.
- This style is not implemented in Safari, so there is no different in iOS Safari accessibility
- This style only has an effect when tabbing with accessibly settings, but generally it is considered back accessibility practice to enable it https://stackoverflow.com/questions/51152749/smooth-scrolling-while-navigating-with-tab-key

**Code changes:**

- CSS change to change `scroll-behavior: smooth;` to `scroll-behavior: auto;`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
