### PR TITLE
Add SectionLabel `backgroundColor` prop

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.2 | [#PR]() Add `backgroundColor` prop |
 | 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper  |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |
 | 4.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.2 | [#PR]() Add `backgroundColor` prop |
+| 5.0.2 | [#PR3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
 | 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper  |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |
 | 4.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,12 +3,12 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.2 | [#PR3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
-| 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper  |
+| 5.0.2 | [PR#3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
+| 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |
 | 4.0.2 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.1 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |
-| 4.0.0 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Add margin bottom to the Section Label above 1008px  |
+| 4.0.0 | [PR#3058](https://github.com/bbc/psammead/pull/3058) Add margin bottom to the Section Label above 1008px |
 | 3.0.13 | [PR#3030](https://github.com/bbc/psammead/pull/3030) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.12 | [PR#2990](https://github.com/bbc/psammead/pull/2990) Use `GEL_SPACING_DBL` constant |
 | 3.0.11 | [PR#2978](https://github.com/bbc/psammead/pull/2978) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-section-label/README.md
+++ b/packages/components/psammead-section-label/README.md
@@ -26,7 +26,7 @@ The only provided child should be the title for the section, provided as a _stri
 | linkText | string | no | `null` | `'See More'` |
 | script | object | yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36' }, groupD: { fontSize: '44', lineHeight: '48' } }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24' }, groupB: { fontSize: '24', lineHeight: '28' }, groupD: { fontSize: '32', lineHeight: '36' } } } |
 | service | string | yes | N/A | `'news'` |
-| backgroundColor | string | no | `null` | `C_GHOST` |
+| backgroundColor | string | no | `C_GHOST` | `C_LUNAR` |
 
 ## Usage
 

--- a/packages/components/psammead-section-label/README.md
+++ b/packages/components/psammead-section-label/README.md
@@ -26,6 +26,7 @@ The only provided child should be the title for the section, provided as a _stri
 | linkText | string | no | `null` | `'See More'` |
 | script | object | yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36' }, groupD: { fontSize: '44', lineHeight: '48' } }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24' }, groupB: { fontSize: '24', lineHeight: '28' }, groupD: { fontSize: '32', lineHeight: '36' } } } |
 | service | string | yes | N/A | `'news'` |
+| backgroundColor | string | no | `null` | `C_GHOST` |
 
 ## Usage
 

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -10,7 +10,7 @@ import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
-import { C_PEBBLE } from '@bbc/psammead-styles/colours';
+import { C_PEBBLE, C_GHOST } from '@bbc/psammead-styles/colours';
 import { PlainTitle, LinkTitle } from './titles';
 
 const Bar = styled.div`
@@ -118,7 +118,7 @@ SectionLabel.defaultProps = {
   href: null,
   linkText: null,
   visuallyHidden: false,
-  backgroundColor: null,
+  backgroundColor: C_GHOST,
 };
 
 SectionLabel.propTypes = {

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -79,6 +79,7 @@ const SectionLabel = ({
   script,
   service,
   visuallyHidden,
+  backgroundColor,
   ...props
 }) => (
   <SectionLabelWrapper visuallyHidden={visuallyHidden} {...props}>
@@ -92,6 +93,7 @@ const SectionLabel = ({
           linkText={linkText}
           script={script}
           service={service}
+          backgroundColor={backgroundColor}
         >
           {title}
         </LinkTitle>
@@ -101,6 +103,7 @@ const SectionLabel = ({
           labelId={labelId}
           script={script}
           service={service}
+          backgroundColor={backgroundColor}
         >
           {title}
         </PlainTitle>
@@ -115,6 +118,7 @@ SectionLabel.defaultProps = {
   href: null,
   linkText: null,
   visuallyHidden: false,
+  backgroundColor: null,
 };
 
 SectionLabel.propTypes = {
@@ -127,6 +131,7 @@ SectionLabel.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   visuallyHidden: bool,
+  backgroundColor: string,
 };
 
 export default SectionLabel;

--- a/packages/components/psammead-section-label/src/titles.jsx
+++ b/packages/components/psammead-section-label/src/titles.jsx
@@ -71,13 +71,11 @@ const titleMargins = `
   }
 `;
 
-const Title = styled.span(props => ({
-  'background-color': props.backgroundColor,
-}))`
+const Title = styled.span`
   ${({ script }) => script && getDoublePica(script)};
   ${({ service }) => getSansRegular(service)}
   color: ${C_EBON};
-
+  background-color: ${props => props.backgroundColor};
   ${titleMargins};
 
   ${paddingDir}: ${GEL_SPACING};
@@ -161,7 +159,7 @@ PlainTitle.propTypes = {
 };
 
 PlainTitle.defaultProps = {
-  backgroundColor: null,
+  backgroundColor: C_GHOST,
 };
 
 export const LinkTitle = ({
@@ -206,5 +204,5 @@ LinkTitle.propTypes = {
 };
 
 LinkTitle.defaultProps = {
-  backgroundColor: null,
+  backgroundColor: C_GHOST,
 };

--- a/packages/components/psammead-section-label/src/titles.jsx
+++ b/packages/components/psammead-section-label/src/titles.jsx
@@ -71,11 +71,12 @@ const titleMargins = `
   }
 `;
 
-const Title = styled.span`
+const Title = styled.span(props => ({
+  'background-color': props.backgroundColor,
+}))`
   ${({ script }) => script && getDoublePica(script)};
   ${({ service }) => getSansRegular(service)}
   color: ${C_EBON};
-  background-color: ${C_GHOST};
 
   ${titleMargins};
 
@@ -95,6 +96,11 @@ Title.propTypes = {
   id: string.isRequired,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  backgroundColor: string,
+};
+
+Title.defaultProps = {
+  backgroundColor: C_GHOST,
 };
 
 const IndexLinkCta = styled.span.attrs({
@@ -128,10 +134,17 @@ export const PlainTitle = ({
   labelId,
   script,
   service,
+  backgroundColor,
 }) => (
   <FlexColumn>
     <FlexRow>
-      <Title script={script} dir={dir} id={labelId} service={service}>
+      <Title
+        script={script}
+        dir={dir}
+        id={labelId}
+        service={service}
+        backgroundColor={backgroundColor}
+      >
         {title}
       </Title>
     </FlexRow>
@@ -144,6 +157,11 @@ PlainTitle.propTypes = {
   labelId: string.isRequired,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  backgroundColor: string,
+};
+
+PlainTitle.defaultProps = {
+  backgroundColor: null,
 };
 
 export const LinkTitle = ({
@@ -154,11 +172,18 @@ export const LinkTitle = ({
   linkText,
   script,
   service,
+  backgroundColor,
 }) => (
   <SectionLabelLink href={href} labelId={labelId}>
     <FlexColumn>
       <FlexTextRow>
-        <Title id={labelId} dir={dir} script={script} service={service}>
+        <Title
+          id={labelId}
+          dir={dir}
+          script={script}
+          service={service}
+          backgroundColor={backgroundColor}
+        >
           {title}
         </Title>
         <IndexLinkCta dir={dir} script={script} service={service}>
@@ -177,4 +202,9 @@ LinkTitle.propTypes = {
   linkText: string.isRequired,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  backgroundColor: string,
+};
+
+LinkTitle.defaultProps = {
+  backgroundColor: null,
 };


### PR DESCRIPTION
Resolves #3263 

**Overall change:** _Add a `backgroundColor` prop to SectionLabel to allow for background color of the Title to be changed._

**Code changes:**

- _Add `backgroundColor` prop to `<SectionLabel />` , `<PlainTitle />` and `<LinkTitle />`._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
