### PR TITLE
Update version of mkdirp

### DIFF
--- a/packages/utilities/moment-timezone-include/CHANGELOG.md
+++ b/packages/utilities/moment-timezone-include/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.1.3 | [PR#3266](https://github.com/bbc/psammead/pull/3266) Update version `mkdirp` to remove `minimist` vulnerability |
 | 1.1.2 | [PR#1960](https://github.com/bbc/psammead/pull/1960) Use object spread syntax instead of object.assign |
 | 1.1.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |
 | 1.1.0 | [PR#1794](https://github.com/bbc/psammead/pull/1794) Add david dependency badges |

--- a/packages/utilities/moment-timezone-include/package-lock.json
+++ b/packages/utilities/moment-timezone-include/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/moment-timezone-include",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/moment-timezone-include/package-lock.json
+++ b/packages/utilities/moment-timezone-include/package-lock.json
@@ -44,19 +44,17 @@
         "semver": "^6.0.0"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "moment": {

--- a/packages/utilities/moment-timezone-include/package.json
+++ b/packages/utilities/moment-timezone-include/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "find-cache-dir": "^3.0.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.3",
     "object-hash": "^1.3.1",
     "moment-timezone": "^0.5.26"
   }

--- a/packages/utilities/moment-timezone-include/package.json
+++ b/packages/utilities/moment-timezone-include/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/moment-timezone-include",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Webpack plugin and timezone data includes to pull in specific timezone data into desired chunks.",
   "main": "./dist/index.js",
   "repository": {


### PR DESCRIPTION
Part of https://github.com/bbc/psammead/issues/3268
Part of https://github.com/bbc/simorgh/issues/5905

**Overall change:**
`mkdirp` had to be updated to pull in a new version of `minimist` because of a vulnerability.

**Code changes:**

- Update `mkdirp` to 0.5.3, which pulls in `minimist@1.2.5`


---

- [x] I have assigned myself to this PR and the corresponding issues
- ~~Automated jest tests added (for new features) or updated (for existing features)~~
- [ ] This PR requires manual testing
