### PR TITLE
Allow parent components to style OEmbed content

### DIFF
--- a/packages/components/psammead-oembed/CHANGELOG.md
+++ b/packages/components/psammead-oembed/CHANGELOG.md
@@ -1,5 +1,6 @@
 # OEmbed Changelog
 
-| Version       | Description   |
-|---------------|---------------|
-| 0.1.0-alpha.1 | [PR#3215](https://github.com/bbc/psammead/pull/3215) Initial creation of package. |
+| Version       | Description                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 0.1.0-alpha.2 | [PR#3278](https://github.com/bbc/psammead/pull/3278) Enable styling of OEmbed content with 'component selector' pattern. |
+| 0.1.0-alpha.1 | [PR#3215](https://github.com/bbc/psammead/pull/3215) Initial creation of package.                                        |

--- a/packages/components/psammead-oembed/README.md
+++ b/packages/components/psammead-oembed/README.md
@@ -16,36 +16,38 @@ npm install @bbc/psammead-oembed --save
 
 ## Props
 
-| Argument  | Type   | Required | Default | Example    |
-| --------- | ------ | -------- | ------- | ---------- |
-| `oEmbed`  | Object | Yes      | n/a     | See below. |
+| Argument    | Type   | Required | Default | Example                |
+| ----------- | ------ | -------- | ------- | ---------------------- |
+| `oEmbed`    | Object | Yes      | n/a     | See below.             |
+| `className` | String | No       | `null`  | `parent-applied-class` |
 
 ### oEmbed
 
-| Argument  | Type   | Required | Default | Example                |
-| --------- | ------ | -------- | ------- | ---------------------- |
-| `html`    | String | Yes      | n/a     | `<p>Hello, World!</p>` |
+| Argument | Type   | Required | Default | Example                |
+| -------- | ------ | -------- | ------- | ---------------------- |
+| `html`   | String | Yes      | n/a     | `<p>Hello, World!</p>` |
 
 ## Usage
 
 ```jsx
-import OEmbed from "@bbc/psammead-oembed"
+import OEmbed from '@bbc/psammead-oembed';
 
 const oEmbedResponse = {
-  "url": "https://twitter.com/SonyPictures/status/1164036827667238912",
-  "author_name": "Sony Pictures",
-  "author_url": "https://twitter.com/SonyPictures",
-  "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Much of today’s news about Spider-Man has mischaracterized recent discussions about Kevin Feige’s involvement in the franchise. We are disappointed, but respect Disney’s decision not to have him continue as a lead producer of our next live action Spider-Man film. (1/3)</p>&mdash; Sony Pictures (@SonyPictures) <a href=\"https://twitter.com/SonyPictures/status/1164036827667238912?ref_src=twsrc%5Etfw\">August 21, 2019</a></blockquote>",
-  "width": 550,
-  "height": null,
-  "type": "rich",
-  "cache_age": "3153600000",
-  "provider_name": "Twitter",
-  "provider_url": "https://twitter.com",
-  "version": "1.0"
+  url: 'https://twitter.com/SonyPictures/status/1164036827667238912',
+  author_name: 'Sony Pictures',
+  author_url: 'https://twitter.com/SonyPictures',
+  html:
+    '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Much of today’s news about Spider-Man has mischaracterized recent discussions about Kevin Feige’s involvement in the franchise. We are disappointed, but respect Disney’s decision not to have him continue as a lead producer of our next live action Spider-Man film. (1/3)</p>&mdash; Sony Pictures (@SonyPictures) <a href="https://twitter.com/SonyPictures/status/1164036827667238912?ref_src=twsrc%5Etfw">August 21, 2019</a></blockquote>',
+  width: 550,
+  height: null,
+  type: 'rich',
+  cache_age: '3153600000',
+  provider_name: 'Twitter',
+  provider_url: 'https://twitter.com',
+  version: '1.0',
 };
 
-<OEmbed oEmbed={oEmbedResponse} />
+<OEmbed oEmbed={oEmbedResponse} />;
 ```
 
 ### When to use this component

--- a/packages/components/psammead-oembed/package-lock.json
+++ b/packages/components/psammead-oembed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-oembed",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-oembed/package.json
+++ b/packages/components/psammead-oembed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-oembed",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-oembed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-oembed/src/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OEmbed should be styleable 1`] = `
+<div
+  class="parent-component-applied-class"
+>
+  <p>
+    Hello, World.
+  </p>
+</div>
+`;
+
 exports[`OEmbed should render oEmbed HTML from Instagram 1`] = `
 <div>
   <blockquote

--- a/packages/components/psammead-oembed/src/index.jsx
+++ b/packages/components/psammead-oembed/src/index.jsx
@@ -6,18 +6,28 @@ const DOMPURIFY_CONFIG = {
   ADD_TAGS: ['iframe'],
 };
 
-const OEmbed = ({ oEmbed }) => {
+const OEmbed = ({ oEmbed, className }) => {
   const { html } = oEmbed;
   const sanitizedHtml = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
 
-  // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
+  return (
+    <div
+      className={className}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  );
+};
+
+OEmbed.defaultProps = {
+  className: null,
 };
 
 OEmbed.propTypes = {
   oEmbed: shape({
     html: string.isRequired,
   }).isRequired,
+  className: string,
 };
 
 export default OEmbed;

--- a/packages/components/psammead-oembed/src/index.test.jsx
+++ b/packages/components/psammead-oembed/src/index.test.jsx
@@ -19,6 +19,14 @@ describe('OEmbed', () => {
     );
   });
 
+  shouldMatchSnapshot(
+    `should be styleable`,
+    <OEmbed
+      className="parent-component-applied-class"
+      oEmbed={{ html: '<p>Hello, World.</p>' }}
+    />,
+  );
+
   it('should clean an XSS attack from oEmbed HTML', () => {
     const { container } = render(<OEmbed oEmbed={OEMBED_ATTACK} />);
     expect(container.firstChild.innerHTML).toEqual('<math><mi></mi></math>');


### PR DESCRIPTION
No Issue.

### Overall change:

Avoid fragile parent styles by enabling the use of [styled-components' 'component selector' pattern](https://styled-components.com/docs/advanced#referring-to-other-components).

This allows a parent component to pass a class name to the OEmbed container for targetted styling. We also do this already in `psammead-play-button`.

### Code changes:

- Add `className` prop
- Add test case
- Update README
- Update CHANGELOG

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~~[ ] This PR requires manual testing~~
