### PR TITLE
Social Embed – add webpackChunkName

### DIFF
--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 | Version       | Description   |
 |---------------|---------------|
+| 0.1.0-alpha.2 | [PR#3298](https://github.com/bbc/psammead/pull/3298) Add webpackChunkName to dynamic import. |
 | 0.1.0-alpha.1 | [PR#3217](https://github.com/bbc/psammead/pull/3217) Initial creation of package. |

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -4,9 +4,12 @@ import { shape, string } from 'prop-types';
 import loadable from '@loadable/component';
 import styled, { css } from 'styled-components';
 
-const OEmbed = loadable(() => import('@bbc/psammead-oembed'), {
-  fallback: <p>Loading&hellip;</p>,
-});
+const OEmbed = loadable(
+  () => import(/* webpackChunkName: 'oembed' */ '@bbc/psammead-oembed'),
+  {
+    fallback: <p>Loading&hellip;</p>,
+  },
+);
 
 const LANDSCAPE_RATIO = '56.25%';
 


### PR DESCRIPTION
No issue.

### Overall change:
Adding a `webpackChunkName` to the dynamic import ensures that the separate bundle is named correctly when output by Webpack. This fixes a failure to load the OEmbed component within Simorgh.

### Code changes:

- Add `webpackChunkName` to the dynamic import of `@bbc/psammead-oembed`
- Bump alpha version
- Add changelog entry

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~~[ ] This PR requires manual testing~~
