### PR TITLE
Script Link - add wrapping span

### DIFF
--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.13 | [PR#3294](https://github.com/bbc/psammead/pull/3294) Wrap children in a styled `span` |
 | 1.0.12 | [PR#3294](https://github.com/bbc/psammead/pull/3294) Remove surrounding `span` from children  |
 | 1.0.11 | [PR#3245](https://github.com/bbc/psammead/pull/3245) Fix script link span spacing  |
 | 1.0.10 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.13 | [PR#3294](https://github.com/bbc/psammead/pull/3294) Wrap children in a styled `span` |
+| 1.0.13 | [PR#3299](https://github.com/bbc/psammead/pull/3299) Wrap children in a styled `span` |
 | 1.0.12 | [PR#3294](https://github.com/bbc/psammead/pull/3294) Remove surrounding `span` from children  |
 | 1.0.11 | [PR#3245](https://github.com/bbc/psammead/pull/3245) Fix script link span spacing  |
 | 1.0.10 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-script-link/package-lock.json
+++ b/packages/components/psammead-script-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-script-link/package.json
+++ b/packages/components/psammead-script-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-script-link/src/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScriptLink should render correctly 1`] = `
-.c0 {
+.c1 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -16,54 +16,59 @@ exports[`ScriptLink should render correctly 1`] = `
   margin: 0.5rem 0 0.5rem 0.5rem;
 }
 
-.c0 > span {
+.c2 {
   margin: 0.1875rem;
   display: inline-block;
   height: calc(100%);
   padding: 0 0.5rem;
 }
 
-.c0:hover > span,
-.c0:focus > span {
+.c0:hover .c2,
+.c0:focus .c2 {
   margin: 0;
   border: 0.1875rem solid #FFFFFF;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c0 {
+  .c1 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c0 {
+  .c1 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c0 {
+  .c1 {
     line-height: calc(2.25rem - 0.5rem);
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c0 {
+  .c1 {
     height: 2.5rem;
   }
+}
 
-  .c0 > span {
-    padding: 0 0.5rem;
+@media (max-width:37.4375rem) {
+  .c2 {
     line-height: calc(2.5rem - 0.5rem);
   }
 }
 
 <a
-  class="c0"
+  class="c0 c1"
   href="https://www.bbc.co.uk/news"
 >
-  Lat
+  <span
+    class="c2"
+  >
+    Lat
+  </span>
 </a>
 `;

--- a/packages/components/psammead-script-link/src/index.jsx
+++ b/packages/components/psammead-script-link/src/index.jsx
@@ -36,11 +36,14 @@ const StyledSpan = styled.span`
   height: calc(100%);
   padding: 0 ${GEL_SPACING};
 
+  /* stylelint-disable */
+  /* https://www.styled-components.com/docs/advanced#referring-to-other-components */
   ${StyledLink}:hover &,
   ${StyledLink}:focus & {
     margin: 0;
     border: 0.1875rem solid ${C_WHITE};
   }
+  /* stylelint-enable */
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {  
     line-height: calc(${GEL_SPACING_QUIN} - ${GEL_SPACING});    

--- a/packages/components/psammead-script-link/src/index.jsx
+++ b/packages/components/psammead-script-link/src/index.jsx
@@ -21,30 +21,29 @@ const StyledLink = styled.a`
   border: 0.0625rem solid ${C_WHITE};
   margin: ${GEL_SPACING} 0 ${GEL_SPACING} ${GEL_SPACING};
 
-  > span {
-    margin: 0.1875rem;
-    display: inline-block;
-    height: calc(100%);
-    padding: 0 ${GEL_SPACING};
-  }
-
-  &:hover > span,
-  &:focus > span {
-    margin: 0;
-    border: 0.1875rem solid ${C_WHITE};
-  }
-
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     line-height: calc(2.25rem - ${GEL_SPACING});
   }
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     height: ${GEL_SPACING_QUIN};
+  }
+`;
 
-    > span {
-      padding: 0 ${GEL_SPACING};
-      line-height: calc(${GEL_SPACING_QUIN} - ${GEL_SPACING});
-    }
+const StyledSpan = styled.span`
+  margin: 0.1875rem;
+  display: inline-block;
+  height: calc(100%);
+  padding: 0 ${GEL_SPACING};
+
+  ${StyledLink}:hover &,
+  ${StyledLink}:focus & {
+    margin: 0;
+    border: 0.1875rem solid ${C_WHITE};
+  }
+
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {  
+    line-height: calc(${GEL_SPACING_QUIN} - ${GEL_SPACING});    
   }
 `;
 
@@ -56,7 +55,7 @@ const ScriptLink = ({ children, script, service, href, variant, onClick }) => (
     data-variant={variant}
     onClick={onClick}
   >
-    {children}
+    <StyledSpan>{children}</StyledSpan>
   </StyledLink>
 );
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
In [this](https://github.com/bbc/psammead/pull/3294) PR we've removed the `span` that wrapped in the children from the `ScriptLink` as a consequence of [this](https://github.com/bbc/psammead/issues/3290) issue. However, the styles were applied to that `span` and in order to make it look as it was, it will require time to try to apply them directly to the `StyleLink`. For this reason, 
we've decided to put the `span` back.

Still, we'll make sure not to pass the `visually hidden text` and the `<span aria-hidden="true">` as children from Simorgh as done in [here](https://github.com/bbc/simorgh/pull/5962).

**Code changes:**
- Wrap children in a styled `span`
- Use a `StyledSpan` instead of using `> span`
- Remove repated `padding: 0 ${GEL_SPACING};` above `599px`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
