### PR TITLE
Fix radio schedules duration formatting

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |
 | 0.1.0-alpha.22 | [PR#3274](https://github.com/bbc/psammead/pull/3274) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.24",
+  "version": "0.1.0-alpha.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.24",
+  "version": "0.1.0-alpha.25",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -280,7 +280,8 @@ exports[`ProgramCard should render correctly for live 1`] = `
       <span
         class="c5"
       >
-         Duration 30,00 
+         Duration 
+        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -544,7 +545,8 @@ exports[`ProgramCard should render correctly for next 1`] = `
       <span
         class="c4"
       >
-         Duration 30,00 
+         Duration 
+        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -811,7 +813,8 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
       <span
         class="c4"
       >
-         Duration 30,00 
+         Duration 
+        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1078,7 +1081,8 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
       <span
         class="c4"
       >
-         المدة الزمنية 30,00 
+         المدة الزمنية 
+        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1341,7 +1345,8 @@ exports[`ProgramCard should render correctly without summary 1`] = `
       <span
         class="c5"
       >
-         Duration 30,00 
+         Duration 
+        30,00 
       </span>
       <span
         aria-hidden="true"

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -188,6 +188,14 @@ const renderHeaderContent = ({
   return state === 'next' ? content : <Link href={link}>{content}</Link>;
 };
 
+const getDurationFormat = (duration, separator = ':') => {
+  const timeSections = ['mm', 'ss'];
+  if (duration.includes('H')) {
+    timeSections.unshift('h');
+  }
+  return timeSections.join(separator);
+};
+
 const ProgramCard = ({
   dir,
   service,
@@ -243,9 +251,12 @@ const ProgramCard = ({
       </IconWrapper>
       <DurationWrapper dir={dir} dateTime={duration}>
         <VisuallyHiddenText>
-          {` ${durationLabel} ${formatDuration(duration, 'mm,ss')} `}
+          {` ${durationLabel} `}
+          {`${formatDuration(duration, getDurationFormat(duration, ','))} `}
         </VisuallyHiddenText>
-        <DurationTextWrapper>{formatDuration(duration)}</DurationTextWrapper>
+        <DurationTextWrapper>
+          {formatDuration(duration, getDurationFormat(duration))}
+        </DurationTextWrapper>
       </DurationWrapper>
     </ButtonWrapper>
   </CardWrapper>

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -677,19 +677,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="ltr"
         >
           <span
             class="c15"
           >
-             Duration 45,00 
+             Duration 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -804,19 +805,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="ltr"
         >
           <span
             class="c15"
           >
-             Duration 45,00 
+             Duration 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -931,19 +933,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="ltr"
         >
           <span
             class="c15"
           >
-             Duration 45,00 
+             Duration 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -1059,19 +1062,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="ltr"
         >
           <span
             class="c15"
           >
-             Duration 45,00 
+             Duration 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -1750,19 +1754,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="rtl"
         >
           <span
             class="c15"
           >
-             المدة الزمنية 45,00 
+             المدة الزمنية 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -1877,19 +1882,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="rtl"
         >
           <span
             class="c15"
           >
-             المدة الزمنية 45,00 
+             المدة الزمنية 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -2004,19 +2010,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="rtl"
         >
           <span
             class="c15"
           >
-             المدة الزمنية 45,00 
+             المدة الزمنية 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>
@@ -2132,19 +2139,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         </span>
         <time
           class="c21"
-          datetime="PT45M"
+          datetime="PT1H"
           dir="rtl"
         >
           <span
             class="c15"
           >
-             المدة الزمنية 45,00 
+             المدة الزمنية 
+            1,00,00 
           </span>
           <span
             aria-hidden="true"
             class="Duration0 "
           >
-            45:00
+            1:00:00
           </span>
         </time>
       </div>

--- a/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
+++ b/packages/components/psammead-radio-schedule/src/testHelpers/helper.jsx
@@ -32,7 +32,7 @@ const getSchedule = (service, withLongSummary) => {
       withLongSummary && state === 'live'
         ? `${longText} ${longText}`
         : longText,
-    duration: 'PT45M',
+    duration: 'PT1H',
     durationLabel: programDurationLabel,
   }));
 };


### PR DESCRIPTION
Part of  https://github.com/bbc/simorgh/issues/5964

**Overall change:** _Format radio schedules duration past 1 hour._

**Code changes:**

- _Format radio schedules duration past 1 hour._
- _Update snapshots._

<img width="264" alt="Screen Shot 2020-03-25 at 4 48 43 PM" src="https://user-images.githubusercontent.com/21374761/77543337-9a4d0c80-6eb8-11ea-9d27-92182bfc38c6.png">


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
