### PR TITLE
Program Card styling fixes

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.26 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -123,14 +123,13 @@ exports[`ProgramCard should render correctly for live 1`] = `
   padding: 0.5rem;
   background-color: #B80000;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c9 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -390,14 +389,13 @@ exports[`ProgramCard should render correctly for next 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   color: #11708C;
-  border-top: 1px solid transparent;
 }
 
 .c8 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -673,14 +671,13 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   padding: 0.5rem;
   background-color: #222222;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c8 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -941,14 +938,13 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   padding: 0.5rem;
   background-color: #222222;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c8 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -1207,14 +1203,13 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   padding: 0.5rem;
   background-color: #B80000;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c8 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
   padding-bottom: 1rem;
@@ -168,15 +168,15 @@ exports[`ProgramCard should render correctly for live 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c7 {
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c7 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
+    font-size: 0.8125rem;
+    line-height: 1rem;
   }
 }
 
@@ -374,7 +374,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
   padding-bottom: 1rem;
@@ -449,15 +449,15 @@ exports[`ProgramCard should render correctly for next 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c6 {
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c6 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
+    font-size: 0.8125rem;
+    line-height: 1rem;
   }
 }
 
@@ -657,7 +657,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
   padding-bottom: 1rem;
@@ -718,15 +718,15 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c6 {
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c6 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
+    font-size: 0.8125rem;
+    line-height: 1rem;
   }
 }
 
@@ -925,8 +925,8 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.25rem;
   color: #6E6E73;
   padding-bottom: 1rem;
   margin: 0;

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -87,7 +87,6 @@ const ButtonWrapper = styled.div`
   padding: ${GEL_SPACING};
   background-color: ${({ backgroundColor }) => backgroundColor};
   color: ${({ durationColor }) => durationColor};
-  border-top: 1px solid transparent;
 `;
 
 const IconWrapper = styled.span`
@@ -95,7 +94,7 @@ const IconWrapper = styled.span`
     color: ${({ durationColor }) => durationColor};
     fill: currentColor;
     width: 1.0625rem;
-    height: ${GEL_SPACING_DBL};
+    height: 0.75rem;
     margin: 0;
   }
 `;

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -16,7 +16,7 @@ import {
   getSerifMedium,
 } from '@bbc/psammead-styles/font-styles';
 import {
-  getLongPrimer,
+  getBrevier,
   getMinion,
   getPica,
 } from '@bbc/gel-foundations/typography';
@@ -75,7 +75,7 @@ const TitleWrapper = styled.span`
 
 const SummaryWrapper = styled.p`
   ${({ service }) => service && getSansRegular(service)};
-  ${({ script }) => script && getLongPrimer(script)};
+  ${({ script }) => script && getBrevier(script)};
   color: ${C_METAL};
   padding-bottom: ${GEL_SPACING_DBL};
   margin: 0; /* Reset */

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -164,7 +164,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #B80000;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c22 {
@@ -176,7 +175,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #222222;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c26 {
@@ -188,14 +186,13 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   color: #11708C;
-  border-top: 1px solid transparent;
 }
 
 .c19 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -203,7 +200,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -1248,7 +1245,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #B80000;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c22 {
@@ -1260,7 +1256,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #222222;
   color: #FFFFFF;
-  border-top: 1px solid transparent;
 }
 
 .c26 {
@@ -1272,14 +1267,13 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   color: #11708C;
-  border-top: 1px solid transparent;
 }
 
 .c19 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 
@@ -1287,7 +1281,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
-  height: 1rem;
+  height: 0.75rem;
   margin: 0;
 }
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -148,7 +148,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
   padding-bottom: 1rem;
@@ -367,15 +367,15 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c17 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
+    font-size: 0.8125rem;
+    line-height: 1rem;
   }
 }
 
@@ -1232,8 +1232,8 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.25rem;
   color: #6E6E73;
   padding-bottom: 1rem;
   margin: 0;


### PR DESCRIPTION
Resolves #3300

**Overall change:** 
Fixed styling bugs in Program Cards that were found during accessibility swarm.

**Code changes:**
- Changed Radio Program Card summary to use Brevier instead of Long primer.
- Removed an extra 1px border from Duration button.
- Made sound icon to be 12px high.
- Updated snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
