### PR TITLE
Add SSR support for components using Loadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.112 | [PR#3311](https://github.com/bbc/psammead/pull/3311) Install @loadable/babel-plugin to support components using Loadable. |
 | 2.0.111 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Bump `@psammead-storybook-helpers` |
 | 2.0.110 | [PR#3264](https://github.com/bbc/psammead/pull/3264) Add @bbc/psammead-live-label to dependencies |
 | 2.0.109 | [PR#3292](https://github.com/bbc/psammead/pull/3292) Talos - Bump Dependencies - @bbc/psammead-navigation, @bbc/psammead-section-label |

--- a/babel.config.js
+++ b/babel.config.js
@@ -34,6 +34,7 @@ module.exports = {
       },
     ],
     '@babel/plugin-proposal-export-default-from',
+    '@loadable/babel-plugin',
   ],
   presets,
   env: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.111",
+  "version": "2.0.112",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5601,6 +5601,15 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "@loadable/babel-plugin": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@loadable/babel-plugin/-/babel-plugin-5.12.0.tgz",
+      "integrity": "sha512-hb4TDUalaGogsCASEi0fD9Jn0Y2nQybupGgJQAxmx2KrLKxRoWfg78bJMabvownonsq3MEWgUWqb0c3m0uX9vQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
+      }
+    },
     "@loadable/component": {
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.111",
+  "version": "2.0.112",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@bbc/psammead-timestamp-container": "^2.7.9",
     "@bbc/psammead-useful-links": "^1.0.16",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
+    "@loadable/babel-plugin": "^5.12.0",
     "@loadable/component": "^5.12.0",
     "@storybook/addon-a11y": "^5.3.17",
     "@storybook/addon-actions": "^5.3.17",

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version       | Description   |
 |---------------|---------------|
+| 0.1.0-alpha.3 | [PR#3311](https://github.com/bbc/psammead/pull/3311) Transpile with @loadable/babel-plugin. |
 | 0.1.0-alpha.2 | [PR#3298](https://github.com/bbc/psammead/pull/3298) Add webpackChunkName to dynamic import. |
 | 0.1.0-alpha.1 | [PR#3217](https://github.com/bbc/psammead/pull/3217) Initial creation of package. |

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "publishConfig": {
     "tag": "alpha"
   },


### PR DESCRIPTION
No issue.

### Overall change:
Components, like `psammead-social-embed`, that use Loadable to dynamically load dependencies are failing SSR within Simorgh, because they haven't been [transpiled using `@loadable/babel-plugin`](https://loadable-components.com/docs/babel-plugin/#transformation). 

### Code changes:

- Install `@loadable/babel-plugin`
- Bump Psammead and package versions
- Add changelog entries

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~~[ ] This PR requires manual testing~~
