### PR TITLE
Fix ProgramCard styling bug in Windows High Contrast Mode

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.26 | [PR#]() Fix `ProgramCard` border on Windows High Contrast Mode |
+| 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.26 | [PR#]() Fix `ProgramCard` border on Windows High Contrast Mode |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -72,7 +72,6 @@ exports[`ProgramCard should render correctly for live 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -192,6 +191,12 @@ exports[`ProgramCard should render correctly for live 1`] = `
   .c8 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c8 {
+    background-color: transparent;
   }
 }
 
@@ -329,7 +334,6 @@ exports[`ProgramCard should render correctly for next 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -474,6 +478,12 @@ exports[`ProgramCard should render correctly for next 1`] = `
   .c7 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c7 {
+    background-color: transparent;
   }
 }
 
@@ -624,7 +634,6 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -744,6 +753,12 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   .c7 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c7 {
+    background-color: transparent;
   }
 }
 
@@ -893,7 +908,6 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -1013,6 +1027,12 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   .c7 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c7 {
+    background-color: transparent;
   }
 }
 
@@ -1171,7 +1191,6 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -1266,6 +1285,12 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   .c7 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c7 {
+    background-color: transparent;
   }
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -328,6 +329,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -622,6 +624,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -890,6 +893,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c1 {
@@ -1167,6 +1171,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c1 {

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -37,6 +37,7 @@ const CardWrapper = styled.div`
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent; /* Needed by IE11 */
 `;
 
 const TextWrapper = styled.div`

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -37,7 +37,6 @@ const CardWrapper = styled.div`
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent; /* Needed by IE11 */
 `;
 
 const TextWrapper = styled.div`
@@ -89,6 +88,9 @@ const ButtonWrapper = styled.div`
   background-color: ${({ backgroundColor }) => backgroundColor};
   color: ${({ durationColor }) => durationColor};
   border-top: 1px solid transparent;
+  @media screen and (-ms-high-contrast: active) {
+    background-color: transparent;
+  }
 `;
 
 const IconWrapper = styled.span`

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -81,6 +81,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c11 {
@@ -1165,6 +1166,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
+  outline: 1px solid transparent;
 }
 
 .c11 {

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -81,7 +81,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c11 {
@@ -394,6 +393,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active) {
+  .c18 {
+    background-color: transparent;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c22 {
     font-size: 0.75rem;
@@ -408,6 +413,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active) {
+  .c22 {
+    background-color: transparent;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c26 {
     font-size: 0.75rem;
@@ -419,6 +430,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c26 {
+    background-color: transparent;
   }
 }
 
@@ -1166,7 +1183,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   flex-direction: column;
   border: 0.0625rem solid transparent;
   height: 100%;
-  outline: 1px solid transparent;
 }
 
 .c11 {
@@ -1479,6 +1495,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active) {
+  .c18 {
+    background-color: transparent;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c22 {
     font-size: 0.75rem;
@@ -1493,6 +1515,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active) {
+  .c22 {
+    background-color: transparent;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c26 {
     font-size: 0.75rem;
@@ -1504,6 +1532,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c26 {
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
Resolves #3310

**Overall change:** _Add styling to make backgroundColor of the `ButtonWrapper` transparent when in high contrast mode._

_The side border of the Button disappearing appears to be caused by the `ButtonWrapper`'s backgroundColor somehow covering the border while in high contrast mode. Made `ButtonWrapper` colour transparent in high contrast mode (as opposed to the black (`#222222`) it becomes) so that the border remains visible in all the different high contrast mode themes._

**Before**
<img width="255" alt="Screenshot 2020-03-27 at 19 09 20" src="https://user-images.githubusercontent.com/12303856/77776057-7f1c0180-705e-11ea-87d9-a7856a832598.png">

**After**
<img width="285" alt="Screenshot 2020-03-30 at 10 32 43" src="https://user-images.githubusercontent.com/12303856/77887548-751f1c00-7273-11ea-8849-371851b1b46d.png">

**Code changes:**

- _Add `@media screen and (-ms-high-contrast: active)` styling block to `ButtonWrapper` component._
- _Update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
