### PR TITLE
Story Promo List - Add border prop

### DIFF
--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.0.6 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Add `border` prop to be able to hide the border |
+| 4.0.6 | [PR#3315](https://github.com/bbc/psammead/pull/3315) Add `border` prop to be able to hide the border |
 | 4.0.5 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update snapshot test |
 | 4.0.4 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.3 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.0.6 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Add `border` prop to be able to hide the border |
 | 4.0.5 | [PR#3208](https://github.com/bbc/psammead/pull/3208) Update snapshot test |
 | 4.0.4 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.3 | [PR#3129](https://github.com/bbc/psammead/pull/3129) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-story-promo-list/README.md
+++ b/packages/components/psammead-story-promo-list/README.md
@@ -14,7 +14,7 @@ The `@bbc/psammead-story-promo-list` package is a set of two components, `StoryP
 | Argument | Type | Required | Default | Example        |
 | -------- | ---- | -------- | ------- | -------------- |
 | children | node | yes      | N/A     | `<StoryPromoLi><StoryPromo image={Image} info={Info} /></StoryPromoLi>` |
-| border   | bool | no       | true    | `false` |
+| border   | bool | no       | `true`    | `false` |
 
 ## Usage
 

--- a/packages/components/psammead-story-promo-list/README.md
+++ b/packages/components/psammead-story-promo-list/README.md
@@ -13,7 +13,8 @@ The `@bbc/psammead-story-promo-list` package is a set of two components, `StoryP
 <!-- prettier-ignore -->
 | Argument | Type | Required | Default | Example        |
 | -------- | ---- | -------- | ------- | -------------- |
-| children | node | Yes      | N/A     | `<StoryPromoLi><StoryPromo image={Image} info={Info} /></StoryPromoLi>` |
+| children | node | yes      | N/A     | `<StoryPromoLi><StoryPromo image={Image} info={Info} /></StoryPromoLi>` |
+| border   | bool | no       | true    | `false` |
 
 ## Usage
 

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -221,3 +221,231 @@ exports[`StoryPromo list should render correctly 1`] = `
   </li>
 </ul>
 `;
+
+exports[`StoryPromo list should render correctly without border 1`] = `
+.c3 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c5 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c2 {
+  position: relative;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c6 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c7 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c1 {
+  padding: 0.5rem 0 1rem;
+}
+
+.c1:first-child {
+  padding-top: 0;
+}
+
+.c1:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c0 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width:63rem) {
+  .c3 {
+    display: block;
+    width: 100%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c3 {
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c5 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c5 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c5 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c2 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c7 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:63rem) {
+  .c7 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c1 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c1 {
+    border-bottom: none;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c1 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c1:first-child {
+    padding-top: 1rem;
+  }
+}
+
+<ul
+  class="c0"
+  role="list"
+>
+  <li
+    class="c1"
+    role="listitem"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+        dir="ltr"
+      >
+        <div
+          class="c4"
+        >
+          <img
+            alt="Alt text"
+            src="https://foobar.com/image.png"
+          />
+        </div>
+      </div>
+      <div
+        class="c5"
+        dir="ltr"
+      >
+        <h3
+          class="c6"
+        >
+          The headline of the promo
+        </h3>
+        <p
+          class="c7"
+        >
+          The summary of the promo
+        </p>
+        <time>
+          12 March 2019
+        </time>
+      </div>
+    </div>
+  </li>
+</ul>
+`;

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -17,7 +17,7 @@ export const StoryPromoLi = styled.li.attrs({
 })`
 
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-      border-bottom: 0.0625rem solid ${C_LUNAR};
+    border-bottom: 0.0625rem solid ${C_LUNAR};
   }
 
   ${({ border }) =>

--- a/packages/components/psammead-story-promo-list/src/index.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { node } from 'prop-types';
+import { node, bool } from 'prop-types';
 import { C_LUNAR } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING,
@@ -15,9 +15,19 @@ import {
 export const StoryPromoLi = styled.li.attrs({
   role: 'listitem',
 })`
+
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    border-bottom: 0.0625rem solid ${C_LUNAR};
+      border-bottom: 0.0625rem solid ${C_LUNAR};
   }
+
+  ${({ border }) =>
+    !border &&
+    `
+      @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+          border-bottom: none;
+      }
+    `}
+
   padding: ${GEL_SPACING} 0 ${GEL_SPACING_DBL};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
@@ -56,4 +66,9 @@ StoryPromoUl.propTypes = {
 
 StoryPromoLi.propTypes = {
   children: node.isRequired,
+  border: bool,
+};
+
+StoryPromoLi.defaultProps = {
+  border: true,
 };

--- a/packages/components/psammead-story-promo-list/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.stories.jsx
@@ -4,6 +4,7 @@ import Timestamp from '@bbc/psammead-timestamp';
 import Image from '@bbc/psammead-image';
 import { latin } from '@bbc/gel-foundations/scripts';
 import StoryPromo, { Headline, Summary, Link } from '@bbc/psammead-story-promo';
+import Grid from '@bbc/psammead-grid';
 import { StoryPromoLi, StoryPromoUl } from './index';
 import storyPromoData from '../testHelpers/fixtureData';
 import notes from '../README.md';
@@ -33,31 +34,81 @@ const InfoComponent = ({ headlineText, summaryText, datetime, dateformat }) => (
   </>
 );
 
-storiesOf('Components|StoryPromo/StoryPromoList', module).add(
-  'default',
-  () => (
-    <StoryPromoUl>
-      {storyPromoData.map(item => {
-        const ImagePromo = (
-          <ImageComponent src={item.image.src} alt={item.image.alt} />
-        );
+storiesOf('Components|StoryPromo/StoryPromoList', module)
+  .add(
+    'default',
+    () => (
+      <StoryPromoUl>
+        {storyPromoData.map(item => {
+          const ImagePromo = (
+            <ImageComponent src={item.image.src} alt={item.image.alt} />
+          );
 
-        const InfoPromo = (
-          <InfoComponent
-            headlineText={item.info.headline}
-            summaryText={item.info.summary}
-            datetime={item.info.datetime}
-            dateformat={item.info.dateformat}
-          />
-        );
+          const InfoPromo = (
+            <InfoComponent
+              headlineText={item.info.headline}
+              summaryText={item.info.summary}
+              datetime={item.info.datetime}
+              dateformat={item.info.dateformat}
+            />
+          );
 
-        return (
-          <StoryPromoLi key={item.info.headline}>
-            <StoryPromo image={ImagePromo} info={InfoPromo} />
-          </StoryPromoLi>
-        );
-      })}
-    </StoryPromoUl>
-  ),
-  { notes },
-);
+          return (
+            <StoryPromoLi key={item.info.headline}>
+              <StoryPromo image={ImagePromo} info={InfoPromo} />
+            </StoryPromoLi>
+          );
+        })}
+      </StoryPromoUl>
+    ),
+    { notes },
+  )
+  .add('Example with promos without image', ({ dir }) => {
+    const parentGridColumns = {
+      group0: 6,
+      group1: 6,
+      group2: 6,
+      group3: 6,
+      group4: 8,
+      group5: 8,
+    };
+
+    const noImageStoryColumns = {
+      group0: 6,
+      group1: 6,
+      group2: 6,
+      group3: 3,
+      group4: 2,
+      group5: 2,
+    };
+
+    const renderGridItem = border => (
+      <Grid
+        dir={dir}
+        item
+        columns={noImageStoryColumns}
+        parentColumns={parentGridColumns}
+        as={StoryPromoLi}
+        border={border}
+      >
+        <p>
+          The critic, author, poet and TV host was known for his witty
+          commentary on international television.
+        </p>
+      </Grid>
+    );
+
+    return (
+      <Grid
+        dir={dir}
+        columns={parentGridColumns}
+        enableGelGutters
+        as={StoryPromoUl}
+      >
+        {renderGridItem()}
+        {renderGridItem()}
+        {renderGridItem(false)}
+        {renderGridItem()}
+      </Grid>
+    );
+  });

--- a/packages/components/psammead-story-promo-list/src/index.test.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.test.jsx
@@ -27,4 +27,13 @@ describe('StoryPromo list', () => {
       </StoryPromoLi>
     </StoryPromoUl>,
   );
+
+  shouldMatchSnapshot(
+    'should render correctly without border',
+    <StoryPromoUl>
+      <StoryPromoLi border={false}>
+        <StoryPromo image={Image} info={Info} />
+      </StoryPromoLi>
+    </StoryPromoUl>,
+  );
 });


### PR DESCRIPTION
Partly Resolves https://github.com/bbc/simorgh/issues/5594

**Overall change:** 
Add `border` prop to the Story Promo List component to be able to hide the `border-bottom` when needed.

After this gets merged, we will have to pass the `border` as false to the penultimate promo without an image to fix the issue happening on the Front Page.

**Code changes:**
- Add `border` prop to `StoryPromoLi` and set the default to `true`.
- Do not apply the `border` between `600px` and `1007px` when the `border` prop is `false`
- Add a new story using `Grid` to show an example of removing the border from the penultimate promo
- Add new snapshot passing border as `false`
- Update README

**Before**:
<img width="744" alt="border-false" src="https://user-images.githubusercontent.com/46446236/77908638-ccc58380-7283-11ea-9294-2377938c94f4.png">

**After**:
<img width="748" alt="border-true" src="https://user-images.githubusercontent.com/46446236/77908650-d222ce00-7283-11ea-9abd-f6750f0c6d8e.png">

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
