### PR TITLE
Update most read rank for Persian and Pashto

### DIFF
--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.4 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Update rank min-width for persian and pashto |
+| 4.0.4 | [PR#3317](https://github.com/bbc/psammead/pull/3317) Update rank min-width for persian and pashto |
 | 4.0.3 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 4.0.2 | [PR#3243](https://github.com/bbc/psammead/pull/3243) Fixes most-read IE11 `oneColumn` layout bugs |
 | 4.0.1 | [PR#3237](https://github.com/bbc/psammead/pull/3237) Fixed most-read IE layout bug |

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.4 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Update rank min-width for persian and pashto |
 | 4.0.3 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 4.0.2 | [PR#3243](https://github.com/bbc/psammead/pull/3243) Fixes most-read IE11 `oneColumn` layout bugs |
 | 4.0.1 | [PR#3237](https://github.com/bbc/psammead/pull/3237) Fixed most-read IE layout bug |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
@@ -842,25 +842,25 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c3 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c3 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c3 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c3 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -878,31 +878,31 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c7 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c7 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c7 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c7 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c7 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -914,25 +914,25 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c8 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c8 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c8 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c8 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -944,37 +944,37 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:80rem) {
   .c8 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c9 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c9 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c9 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -986,25 +986,25 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c10 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -1022,37 +1022,37 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (max-width:14.9375rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c11 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c11 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c11 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c11 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
@@ -848,7 +848,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c3 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -884,7 +884,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c7 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -920,7 +920,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c8 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -956,7 +956,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -992,7 +992,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -1028,7 +1028,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c11 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
@@ -4503,7 +4503,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c5 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -4539,7 +4539,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -4575,7 +4575,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -4611,7 +4611,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c11 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -4647,7 +4647,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c12 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -4683,7 +4683,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c13 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
@@ -4497,25 +4497,25 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c5 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c5 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -4533,31 +4533,31 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c9 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c9 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c9 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c9 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -4569,25 +4569,25 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c10 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c10 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -4599,37 +4599,37 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (min-width:80rem) {
   .c10 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (max-width:14.9375rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c11 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c11 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c11 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c11 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -4641,25 +4641,25 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c12 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c12 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c12 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c12 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
@@ -4677,37 +4677,37 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 @media (max-width:14.9375rem) {
   .c13 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c13 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c13 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c13 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c13 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c13 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c13 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
@@ -246,7 +246,7 @@ exports[`MostReadRank should render rtl with double digits correctly 1`] = `
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c0 {
-    min-width: 1rem;
+    min-width: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Rank/__snapshots__/index.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`MostReadRank should render ltr correctly 1`] = `
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: 2rem;
+    min-width: auto;
   }
 }
 
@@ -195,7 +195,7 @@ exports[`MostReadRank should render rtl correctly 1`] = `
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: 1.5rem;
+    min-width: auto;
   }
 }
 
@@ -240,37 +240,37 @@ exports[`MostReadRank should render rtl with double digits correctly 1`] = `
 
 @media (max-width:14.9375rem) {
   .c0 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .c0 {
-    min-width: 2rem;
+    min-width: 1rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .c0 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c0 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c0 {
-    min-width: 3rem;
+    min-width: 2rem;
   }
 }
 

--- a/packages/components/psammead-most-read/src/Rank/index.jsx
+++ b/packages/components/psammead-most-read/src/Rank/index.jsx
@@ -25,10 +25,13 @@ import { grid } from '@bbc/psammead-styles/detection';
 import { getSerifLight } from '@bbc/psammead-styles/font-styles';
 import {
   doubleDigitDefault,
-  doubleDigitThin,
+  doubleDigitMedium,
+  doubleDigitSmall,
   singleDigitDefault,
-  singleDigitThin,
-  thinFontServices,
+  singleDigitMedium,
+  singleDigitSmall,
+  mediumFontServices,
+  smallFontServices,
 } from '../utilities/rankMinWidth';
 
 // For additional spacing for numerals in the right column because of '10' being double digits
@@ -43,25 +46,31 @@ const columnIncludesDoubleDigits = (props, supportsGrid) =>
   listHasDoubleDigits(props.numberOfItems);
 
 // Returns a min width for the rank wrapper depending on if the list contains 10 items
-// and if the numeral is considered thin.
+// and if the numeral is considered medium/small.
 const getRankMinWidth = ({ service, numberOfItems }) => {
   const singleDigitMinWidth = {
     default: singleDigitDefault,
-    thin: singleDigitThin,
+    medium: singleDigitMedium,
+    small: singleDigitSmall,
   };
 
   const doubleDigitMinWidth = {
     default: doubleDigitDefault,
-    thin: doubleDigitThin,
+    medium: doubleDigitMedium,
+    small: doubleDigitSmall,
   };
 
   const rankMinWidth = listHasDoubleDigits(numberOfItems)
     ? doubleDigitMinWidth
     : singleDigitMinWidth;
 
-  return thinFontServices.includes(service)
-    ? rankMinWidth.thin
-    : rankMinWidth.default;
+  if (mediumFontServices.includes(service)) {
+    return rankMinWidth.medium;
+  }
+  if (smallFontServices.includes(service)) {
+    return rankMinWidth.small;
+  }
+  return rankMinWidth.default;
 };
 
 // Ensures the 5th and 10th rank aligns with each other
@@ -132,9 +141,7 @@ const MultiColumnWrapper = styled(TwoColumnWrapper)`
   /* 5 columns of items at viewport 1280px and above */
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     min-width: ${props =>
-      listHasDoubleDigits(props.numberOfItems)
-        ? isFiveOrTen(props)
-        : getRankMinWidth(props).group5};
+      listHasDoubleDigits(props.numberOfItems) ? isFiveOrTen(props) : 'auto'};
   }
 `;
 

--- a/packages/components/psammead-most-read/src/index.stories.jsx
+++ b/packages/components/psammead-most-read/src/index.stories.jsx
@@ -11,8 +11,10 @@ const newsServiceDecorator = withServicesKnob({
   defaultService: 'news',
 });
 const listIndexRange = {
+  range: true,
   min: 1,
   max: 10,
+  step: 1,
 };
 
 const pageTypes = ['oneColumn', 'twoColumn', 'multiColumn'];
@@ -116,7 +118,7 @@ storiesOf('Components|MostRead/List', module)
     () =>
       newsServiceDecorator(({ dir, script, selectedService }) =>
         renderList({
-          numberOfItems: 10,
+          numberOfItems: number('Number (1 - 10)', 10, listIndexRange),
           columnLayout: select('Page Type (columns)', pageTypes, 'multiColumn'),
           withTimestamp: boolean('Timestamp', false),
           service: selectedService,

--- a/packages/components/psammead-most-read/src/utilities/rankMinWidth.js
+++ b/packages/components/psammead-most-read/src/utilities/rankMinWidth.js
@@ -70,7 +70,7 @@ export const doubleDigitSmall = {
   group5: GEL_SPACING_TRPL,
   // These values are used to align the rank when a double digit exists in the column
   group0WithOneColumn: GEL_SPACING_DBL,
-  group1WithOneColumn: GEL_SPACING_DBL,
+  group1WithOneColumn: GEL_SPACING_TRPL,
   group2WithOneColumn: GEL_SPACING_TRPL,
   group3WithOneColumn: GEL_SPACING_QUAD,
   group3WithTwoColumns: GEL_SPACING_QUAD,

--- a/packages/components/psammead-most-read/src/utilities/rankMinWidth.js
+++ b/packages/components/psammead-most-read/src/utilities/rankMinWidth.js
@@ -8,15 +8,15 @@ import {
 
 // Services with fonts that have glyphs thinner than the majority of other fonts.
 // This was mainly based on the old overrides (ie. Any group0 value < 2rem).
-export const thinFontServices = [
+export const mediumFontServices = [
   'arabic',
   'bengali',
-  'pashto',
-  'persian',
   'tamil',
   'telegu',
   'urdu',
 ];
+
+export const smallFontServices = ['persian', 'pashto'];
 
 // If numberOfItems < 10, no extra spacing needs to be accounted for.
 export const singleDigitDefault = {
@@ -24,7 +24,6 @@ export const singleDigitDefault = {
   group1: GEL_SPACING_TRPL,
   group2: GEL_SPACING_TRPL,
   group3: GEL_SPACING_QUAD,
-  group5: GEL_SPACING_QUAD,
 };
 
 // If numberOfItems >= 10, extra spacing needs to be accounted for.
@@ -40,15 +39,14 @@ export const doubleDigitDefault = {
   group5WithFiveColumns: '4rem',
 };
 
-export const singleDigitThin = {
+export const singleDigitMedium = {
   group0: GEL_SPACING_DBL,
   group1: GEL_SPACING_DBL,
   group2: GEL_SPACING_DBL,
   group3: GEL_SPACING_TRPL,
-  group5: GEL_SPACING_TRPL,
 };
 
-export const doubleDigitThin = {
+export const doubleDigitMedium = {
   group3: GEL_SPACING_TRPL,
   group5: GEL_SPACING_TRPL,
   // These values are used to align the rank when a double digit exists in the column
@@ -58,4 +56,23 @@ export const doubleDigitThin = {
   group3WithOneColumn: GEL_SPACING_SEXT,
   group3WithTwoColumns: GEL_SPACING_SEXT,
   group5WithFiveColumns: GEL_SPACING_SEXT,
+};
+
+export const singleDigitSmall = {
+  group0: GEL_SPACING_DBL,
+  group1: GEL_SPACING_DBL,
+  group2: GEL_SPACING_DBL,
+  group3: GEL_SPACING_TRPL,
+};
+
+export const doubleDigitSmall = {
+  group3: GEL_SPACING_TRPL,
+  group5: GEL_SPACING_TRPL,
+  // These values are used to align the rank when a double digit exists in the column
+  group0WithOneColumn: GEL_SPACING_DBL,
+  group1WithOneColumn: GEL_SPACING_DBL,
+  group2WithOneColumn: GEL_SPACING_TRPL,
+  group3WithOneColumn: GEL_SPACING_QUAD,
+  group3WithTwoColumns: GEL_SPACING_QUAD,
+  group5WithFiveColumns: GEL_SPACING_QUAD,
 };


### PR DESCRIPTION
Resolves #3233

**Overall change:** _Update the width of most read's rank for Persian and Pashto._

**Code changes:**

- _Add a separate minWidth config for Persian and Pashto_
- _Updated `thinFontServices` to `mediumFontService` and added `smallFontService`._
- _Update snapshots_

**After:**
![image](https://user-images.githubusercontent.com/30599794/77920205-17e89200-7296-11ea-86b3-889b0dc1ecf5.png)
![image](https://user-images.githubusercontent.com/30599794/77921607-e7095c80-7297-11ea-8237-3903ac7cf9fc.png)
![image](https://user-images.githubusercontent.com/30599794/77922343-d4435780-7298-11ea-8eb7-f3bffc96f065.png)

**Before:**
![image](https://user-images.githubusercontent.com/30599794/77920161-099a7600-7296-11ea-865d-3e9f915fe15d.png)
![image](https://user-images.githubusercontent.com/30599794/77921648-f25c8800-7297-11ea-92e3-49f6511c6b9c.png)
![image](https://user-images.githubusercontent.com/30599794/77921688-01433a80-7298-11ea-92a0-ebeb42ad2de5.png)
![image](https://user-images.githubusercontent.com/30599794/77922399-e4f3cd80-7298-11ea-968e-b193eb5014e9.png)



---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
