### PR TITLE
Fix StartTime styling bugs

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.26 | [PR#]() Fix `StartTime` styling |
+| 0.1.0-alpha.26 | [PR#3318](https://github.com/bbc/psammead/pull/3318) Fix `StartTime` styling |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.28 | [PR#3318](https://github.com/bbc/psammead/pull/3318) Fix `StartTime` styling |
+| 0.1.0-alpha.28 | [PR#3318](https://github.com/bbc/psammead/pull/3318) Fix `StartTime` clock icon styling in Safari |
 | 0.1.0-alpha.27 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.26 | [PR#]() Fix `StartTime` styling |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
@@ -46,6 +46,7 @@ exports[`StartTime should render LTR correctly 1`] = `
 .c1 > svg {
   color: #5A5A5A;
   margin: 0;
+  overflow: visible;
 }
 
 .c3 {
@@ -195,6 +196,7 @@ exports[`StartTime should render RTL correctly 1`] = `
 .c1 > svg {
   color: #5A5A5A;
   margin: 0;
+  overflow: visible;
 }
 
 .c3 {

--- a/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
@@ -64,13 +64,6 @@ exports[`StartTime should render LTR correctly 1`] = `
   width: 100%;
 }
 
-.c3::after {
-  content: '',border-top:0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-left: 0.625rem;
-  width: 100%;
-}
-
 .c3 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -78,6 +71,14 @@ exports[`StartTime should render LTR correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
+}
+
+.c3::after {
+  content: '';
+  border-top: 0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-left: 0.625rem;
+  width: 100%;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -210,13 +211,6 @@ exports[`StartTime should render RTL correctly 1`] = `
   width: 100%;
 }
 
-.c3::after {
-  content: '',border-top:0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-right: 0.625rem;
-  width: 100%;
-}
-
 .c3 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -224,6 +218,14 @@ exports[`StartTime should render RTL correctly 1`] = `
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
+}
+
+.c3::after {
+  content: '';
+  border-top: 0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-right: 0.625rem;
+  width: 100%;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
@@ -64,6 +64,13 @@ exports[`StartTime should render LTR correctly 1`] = `
   width: 100%;
 }
 
+.c3::after {
+  content: '',border-top:0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-left: 0.625rem;
+  width: 100%;
+}
+
 .c3 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -71,13 +78,6 @@ exports[`StartTime should render LTR correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-}
-
-.c5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-left: 0.625rem;
-  width: 100%;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -142,10 +142,6 @@ exports[`StartTime should render LTR correctly 1`] = `
     >
       14:54
     </time>
-    <span
-      class="c5"
-      dir="ltr"
-    />
   </span>
 </div>
 `;
@@ -214,6 +210,13 @@ exports[`StartTime should render RTL correctly 1`] = `
   width: 100%;
 }
 
+.c3::after {
+  content: '',border-top:0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-right: 0.625rem;
+  width: 100%;
+}
+
 .c3 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -221,13 +224,6 @@ exports[`StartTime should render RTL correctly 1`] = `
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-}
-
-.c5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-right: 0.625rem;
-  width: 100%;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -292,10 +288,6 @@ exports[`StartTime should render RTL correctly 1`] = `
     >
       ۱۴:۵۴
     </time>
-    <span
-      class="c5"
-      dir="rtl"
-    />
   </span>
 </div>
 `;

--- a/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/StartTime/__snapshots__/index.test.jsx.snap
@@ -72,8 +72,7 @@ exports[`StartTime should render LTR correctly 1`] = `
   font-style: normal;
 }
 
-.c3::after {
-  content: '';
+.c5 {
   border-top: 0.0625rem solid #AEAEB5;
   top: 1rem;
   margin-left: 0.625rem;
@@ -142,6 +141,10 @@ exports[`StartTime should render LTR correctly 1`] = `
     >
       14:54
     </time>
+    <span
+      class="c5"
+      dir="ltr"
+    />
   </span>
 </div>
 `;
@@ -218,8 +221,7 @@ exports[`StartTime should render RTL correctly 1`] = `
   font-style: normal;
 }
 
-.c3::after {
-  content: '';
+.c5 {
   border-top: 0.0625rem solid #AEAEB5;
   top: 1rem;
   margin-right: 0.625rem;
@@ -288,6 +290,10 @@ exports[`StartTime should render RTL correctly 1`] = `
     >
       ۱۴:۵۴
     </time>
+    <span
+      class="c5"
+      dir="rtl"
+    />
   </span>
 </div>
 `;

--- a/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
@@ -24,6 +24,7 @@ const StyledClock = styled.span`
   > svg {
     color: ${C_RHINO};
     margin: 0;
+    overflow: visible;
   }
 `;
 

--- a/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
@@ -46,19 +46,19 @@ const StyledTimestamp = styled.span`
   flex-direction: row;
   width: 100%;
 
+  > time {
+    color: ${C_RHINO};
+    ${({ script }) => script && getMinion(script)}
+    ${({ service }) => service && getSansRegular(service)}
+  }
+
   &::after {
-    content: '',
+    content: '';
     border-top: 0.0625rem solid ${C_PEBBLE};
     top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
     ${({ dir }) =>
       dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}
     width: 100%;
-  }
-
-  > time {
-    color: ${C_RHINO};
-    ${({ script }) => script && getMinion(script)}
-    ${({ service }) => service && getSansRegular(service)}
   }
 `;
 

--- a/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
@@ -46,19 +46,20 @@ const StyledTimestamp = styled.span`
   flex-direction: row;
   width: 100%;
 
+  &::after {
+    content: '',
+    border-top: 0.0625rem solid ${C_PEBBLE};
+    top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
+    ${({ dir }) =>
+      dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}
+    width: 100%;
+  }
+
   > time {
     color: ${C_RHINO};
     ${({ script }) => script && getMinion(script)}
     ${({ service }) => service && getSansRegular(service)}
   }
-`;
-
-const Bar = styled.span`
-  border-top: 0.0625rem solid ${C_PEBBLE};
-  top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
-  ${({ dir }) =>
-    dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}
-  width: 100%;
 `;
 
 export const StartTimestamp = ({
@@ -87,7 +88,6 @@ export const StartTimestamp = ({
         locale={locale}
         service={service}
       />
-      <Bar script={script} dir={dir} />
     </StyledTimestamp>
   );
 };

--- a/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
@@ -54,7 +54,6 @@ const StyledTimestamp = styled.span`
 
 const Bar = styled.span`
   border-top: 0.0625rem solid ${C_PEBBLE};
-  z-index: -1;
   top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
   ${({ dir }) =>
     dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}

--- a/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/StartTime/index.jsx
@@ -50,15 +50,15 @@ const StyledTimestamp = styled.span`
     ${({ script }) => script && getMinion(script)}
     ${({ service }) => service && getSansRegular(service)}
   }
+`;
 
-  &::after {
-    content: '';
-    border-top: 0.0625rem solid ${C_PEBBLE};
-    top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
-    ${({ dir }) =>
-      dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}
-    width: 100%;
-  }
+const Bar = styled.span`
+  border-top: 0.0625rem solid ${C_PEBBLE};
+  z-index: -1;
+  top: ${({ script }) => 0.5 + script.minion.groupA.lineHeight / 2 / 16}rem;
+  ${({ dir }) =>
+    dir === 'ltr' ? `margin-left: 0.625rem;` : `margin-right: 0.625rem;`}
+  width: 100%;
 `;
 
 export const StartTimestamp = ({
@@ -87,6 +87,7 @@ export const StartTimestamp = ({
         locale={locale}
         service={service}
       />
+      <Bar script={script} dir={dir} />
     </StyledTimestamp>
   );
 };

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -363,14 +363,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -391,7 +391,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c18 {
+  .c19 {
     background-color: transparent;
   }
 }
@@ -411,7 +411,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c22 {
+  .c23 {
     background-color: transparent;
   }
 }
@@ -431,7 +431,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     background-color: transparent;
   }
 }
@@ -1506,7 +1506,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c18 {
+  .c19 {
     background-color: transparent;
   }
 }
@@ -1526,7 +1526,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c22 {
+  .c23 {
     background-color: transparent;
   }
 }
@@ -1546,7 +1546,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     background-color: transparent;
   }
 }

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -247,6 +247,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 .c6 > svg {
   color: #5A5A5A;
   margin: 0;
+  overflow: visible;
 }
 
 .c8 {
@@ -1346,6 +1347,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 .c6 > svg {
   color: #5A5A5A;
   margin: 0;
+  overflow: visible;
 }
 
 .c8 {

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -262,13 +262,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   width: 100%;
 }
 
-.c8::after {
-  content: '',border-top:0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-left: 0.625rem;
-  width: 100%;
-}
-
 .c8 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -276,6 +269,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
+}
+
+.c8::after {
+  content: '';
+  border-top: 0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-left: 0.625rem;
+  width: 100%;
 }
 
 .c4 {
@@ -1361,13 +1362,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   width: 100%;
 }
 
-.c8::after {
-  content: '',border-top:0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-right: 0.625rem;
-  width: 100%;
-}
-
 .c8 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -1375,6 +1369,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
+}
+
+.c8::after {
+  content: '';
+  border-top: 0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-right: 0.625rem;
+  width: 100%;
 }
 
 .c4 {

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c21 {
+.c20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -19,14 +19,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.75rem;
 }
 
-.c14 {
+.c13 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c14:before {
+.c13:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -38,17 +38,17 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   z-index: 1;
 }
 
-.c14:hover,
-.c14:focus {
+.c13:hover,
+.c13:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c14:visited {
+.c13:visited {
   color: #6E6E73;
 }
 
-.c16 {
+.c15 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -60,7 +60,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c15 {
+.c14 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -69,7 +69,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.c11 {
+.c10 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -83,7 +83,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 100%;
 }
 
-.c12 {
+.c11 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -91,7 +91,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   flex-grow: 1;
 }
 
-.c13 {
+.c12 {
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
@@ -101,7 +101,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c23 {
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
@@ -111,7 +111,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -122,7 +122,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.c17 {
+.c16 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -133,7 +133,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c26 {
+.c25 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: block;
@@ -144,7 +144,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c18 {
+.c17 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -155,7 +155,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c19 {
+.c18 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -166,7 +166,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c23 {
+.c22 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -177,7 +177,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c27 {
+.c26 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -188,7 +188,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c20 > svg {
+.c19 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -196,7 +196,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c28 > svg {
+.c27 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -204,7 +204,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c22 {
+.c21 {
   padding-left: 0.5rem;
 }
 
@@ -262,6 +262,13 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   width: 100%;
 }
 
+.c8::after {
+  content: '',border-top:0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-left: 0.625rem;
+  width: 100%;
+}
+
 .c8 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -269,13 +276,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-}
-
-.c10 {
-  border-top: 0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-left: 0.625rem;
-  width: 100%;
 }
 
 .c4 {
@@ -293,14 +293,28 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c13 {
+  .c12 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c12 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c23 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c23 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -315,6 +329,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c24 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -336,102 +364,74 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c17 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c18 {
+  .c17 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c19 {
+  .c18 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c19 {
+  .c18 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
+  .c22 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c22 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c23 {
+  .c22 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c27 {
+  .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c27 {
+  .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c27 {
+  .c26 {
     background-color: transparent;
   }
 }
@@ -609,24 +609,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
-          <span
-            class="c10"
-            dir="ltr"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -638,13 +634,13 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               >
                 <span
                   aria-hidden="true"
-                  class="c15"
+                  class="c14"
                   dir="ltr"
                 >
                   LIVE 
                 </span>
                 <span
-                  class="c16"
+                  class="c15"
                   lang="en-GB"
                 >
                   Live, 
@@ -652,14 +648,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               </span>
               Could a computer ever create better art than a human?
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -667,20 +663,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c19"
+        class="c18"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -695,12 +691,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c16"
+            class="c15"
           >
              Duration 
             1,00,00 
@@ -758,24 +754,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
-          <span
-            class="c10"
-            dir="ltr"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -784,14 +776,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             >
               Could a computer ever create better art than a human?
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -799,20 +791,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c23"
+        class="c22"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -827,12 +819,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c16"
+            class="c15"
           >
              Duration 
             1,00,00 
@@ -890,24 +882,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
-          <span
-            class="c10"
-            dir="ltr"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -916,14 +904,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             >
               Could a computer ever create better art than a human?
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -931,20 +919,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c23"
+        class="c22"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -959,12 +947,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c16"
+            class="c15"
           >
              Duration 
             1,00,00 
@@ -1022,62 +1010,58 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
-          <span
-            class="c10"
-            dir="ltr"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c24"
+          class="c23"
         >
           <span
             class=""
             role="text"
           >
             <span
-              class="c25"
+              class="c24"
               dir="ltr"
             >
               NEXT 
             </span>
             Could a computer ever create better art than a human?
             <span
-              class="c16"
+              class="c15"
             >
               , 
               14:54
               , 
             </span>
             <span
-              class="c26"
+              class="c25"
             >
               29/01/1990
             </span>
           </span>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c27"
+        class="c26"
       >
         <span
-          class="c28"
+          class="c27"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1092,12 +1076,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c16"
+            class="c15"
           >
              Duration 
             1,00,00 
@@ -1125,7 +1109,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c21 {
+.c20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1134,14 +1118,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.75rem;
 }
 
-.c14 {
+.c13 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c14:before {
+.c13:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1153,17 +1137,17 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   z-index: 1;
 }
 
-.c14:hover,
-.c14:focus {
+.c13:hover,
+.c13:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c14:visited {
+.c13:visited {
   color: #6E6E73;
 }
 
-.c16 {
+.c15 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -1175,7 +1159,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c15 {
+.c14 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1184,7 +1168,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin-left: 0.5rem;
 }
 
-.c11 {
+.c10 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -1198,7 +1182,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 100%;
 }
 
-.c12 {
+.c11 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1206,7 +1190,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   flex-grow: 1;
 }
 
-.c13 {
+.c12 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1216,7 +1200,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c23 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1226,7 +1210,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1237,7 +1221,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin-left: 0.5rem;
 }
 
-.c17 {
+.c16 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -1248,7 +1232,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1.625rem;
 }
 
-.c26 {
+.c25 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: block;
@@ -1259,7 +1243,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1.625rem;
 }
 
-.c18 {
+.c17 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1270,7 +1254,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c19 {
+.c18 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1281,7 +1265,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c23 {
+.c22 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1292,7 +1276,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c27 {
+.c26 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1303,7 +1287,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c20 > svg {
+.c19 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1311,7 +1295,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c28 > svg {
+.c27 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -1319,7 +1303,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c22 {
+.c21 {
   padding-right: 0.5rem;
 }
 
@@ -1377,6 +1361,13 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   width: 100%;
 }
 
+.c8::after {
+  content: '',border-top:0.0625rem solid #AEAEB5;
+  top: 1rem;
+  margin-right: 0.625rem;
+  width: 100%;
+}
+
 .c8 > time {
   color: #5A5A5A;
   font-size: 0.75rem;
@@ -1384,13 +1375,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-}
-
-.c10 {
-  border-top: 0.0625rem solid #AEAEB5;
-  top: 1rem;
-  margin-right: 0.625rem;
-  width: 100%;
 }
 
 .c4 {
@@ -1408,14 +1392,28 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c13 {
+  .c12 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c12 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c23 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c23 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1430,6 +1428,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c24 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1451,102 +1463,74 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c17 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c18 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c19 {
+  .c18 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c19 {
+  .c18 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
+  .c22 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c22 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c23 {
+  .c22 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c27 {
+  .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c27 {
+  .c26 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c27 {
+  .c26 {
     background-color: transparent;
   }
 }
@@ -1724,24 +1708,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
-          <span
-            class="c10"
-            dir="rtl"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -1752,7 +1732,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
                 role="text"
               >
                 <span
-                  class="c15"
+                  class="c14"
                   dir="rtl"
                 >
                   مباشر 
@@ -1760,14 +1740,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               </span>
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -1775,20 +1755,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c19"
+        class="c18"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1803,12 +1783,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c16"
+            class="c15"
           >
              المدة الزمنية 
             1,00,00 
@@ -1866,24 +1846,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
-          <span
-            class="c10"
-            dir="rtl"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -1892,14 +1868,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             >
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -1907,20 +1883,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c23"
+        class="c22"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1935,12 +1911,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c16"
+            class="c15"
           >
              المدة الزمنية 
             1,00,00 
@@ -1998,24 +1974,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
-          <span
-            class="c10"
-            dir="rtl"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c13"
+          class="c12"
         >
           <a
-            class="c14"
+            class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -2024,14 +1996,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             >
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c16"
+                class="c15"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c17"
+                class="c16"
               >
                 29/01/1990
               </span>
@@ -2039,20 +2011,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c23"
+        class="c22"
       >
         <span
-          class="c20"
+          class="c19"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2067,12 +2039,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c16"
+            class="c15"
           >
              المدة الزمنية 
             1,00,00 
@@ -2130,62 +2102,58 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
-          <span
-            class="c10"
-            dir="rtl"
-          />
         </span>
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <h3
-          class="c24"
+          class="c23"
         >
           <span
             class=""
             role="text"
           >
             <span
-              class="c25"
+              class="c24"
               dir="rtl"
             >
               مباشر 
             </span>
             لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class="c16"
+              class="c15"
             >
               , 
               ۱۴:۵۴
               , 
             </span>
             <span
-              class="c26"
+              class="c25"
             >
               29/01/1990
             </span>
           </span>
         </h3>
         <p
-          class="c18"
+          class="c17"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c27"
+        class="c26"
       >
         <span
-          class="c28"
+          class="c27"
         >
           <svg
             aria-hidden="true"
-            class="c21"
+            class="c20"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2200,12 +2168,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c22"
+          class="c21"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c16"
+            class="c15"
           >
              المدة الزمنية 
             1,00,00 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c20 {
+.c21 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -19,14 +19,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.75rem;
 }
 
-.c13 {
+.c14 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13:before {
+.c14:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -38,17 +38,17 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   z-index: 1;
 }
 
-.c13:hover,
-.c13:focus {
+.c14:hover,
+.c14:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c13:visited {
+.c14:visited {
   color: #6E6E73;
 }
 
-.c15 {
+.c16 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -60,7 +60,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c14 {
+.c15 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -69,7 +69,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.c10 {
+.c11 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -83,7 +83,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 100%;
 }
 
-.c11 {
+.c12 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -91,7 +91,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   flex-grow: 1;
 }
 
-.c12 {
+.c13 {
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
@@ -101,7 +101,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
@@ -111,7 +111,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -122,7 +122,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.c16 {
+.c17 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -133,7 +133,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c25 {
+.c26 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: block;
@@ -144,7 +144,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c17 {
+.c18 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -155,7 +155,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c18 {
+.c19 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -167,7 +167,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c22 {
+.c23 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -179,7 +179,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c26 {
+.c27 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -191,7 +191,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c19 > svg {
+.c20 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -199,7 +199,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c27 > svg {
+.c28 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -207,7 +207,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c21 {
+.c22 {
   padding-left: 0.5rem;
 }
 
@@ -273,8 +273,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-style: normal;
 }
 
-.c8::after {
-  content: '';
+.c10 {
   border-top: 0.0625rem solid #AEAEB5;
   top: 1rem;
   margin-left: 0.625rem;
@@ -296,28 +295,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c23 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -332,20 +317,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c24 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c16 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -367,55 +338,83 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c26 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c26 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -594,20 +593,24 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
+          <span
+            class="c10"
+            dir="ltr"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -619,13 +622,13 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               >
                 <span
                   aria-hidden="true"
-                  class="c14"
+                  class="c15"
                   dir="ltr"
                 >
                   LIVE 
                 </span>
                 <span
-                  class="c15"
+                  class="c16"
                   lang="en-GB"
                 >
                   Live, 
@@ -633,14 +636,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
               </span>
               Could a computer ever create better art than a human?
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -648,20 +651,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c18"
+        class="c19"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -676,12 +679,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c15"
+            class="c16"
           >
              Duration 
             1,00,00 
@@ -739,20 +742,24 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
+          <span
+            class="c10"
+            dir="ltr"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -761,14 +768,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             >
               Could a computer ever create better art than a human?
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -776,20 +783,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -804,12 +811,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c15"
+            class="c16"
           >
              Duration 
             1,00,00 
@@ -867,20 +874,24 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
+          <span
+            class="c10"
+            dir="ltr"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
@@ -889,14 +900,14 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             >
               Could a computer ever create better art than a human?
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 14:54
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -904,20 +915,20 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -932,12 +943,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c15"
+            class="c16"
           >
              Duration 
             1,00,00 
@@ -995,58 +1006,62 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           >
             14:54
           </time>
+          <span
+            class="c10"
+            dir="ltr"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c23"
+          class="c24"
         >
           <span
             class=""
             role="text"
           >
             <span
-              class="c24"
+              class="c25"
               dir="ltr"
             >
               NEXT 
             </span>
             Could a computer ever create better art than a human?
             <span
-              class="c15"
+              class="c16"
             >
               , 
               14:54
               , 
             </span>
             <span
-              class="c25"
+              class="c26"
             >
               29/01/1990
             </span>
           </span>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c26"
+        class="c27"
       >
         <span
-          class="c27"
+          class="c28"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1061,12 +1076,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
           <span
-            class="c15"
+            class="c16"
           >
              Duration 
             1,00,00 
@@ -1094,7 +1109,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c20 {
+.c21 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1103,14 +1118,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.75rem;
 }
 
-.c13 {
+.c14 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13:before {
+.c14:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1122,17 +1137,17 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   z-index: 1;
 }
 
-.c13:hover,
-.c13:focus {
+.c14:hover,
+.c14:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c13:visited {
+.c14:visited {
   color: #6E6E73;
 }
 
-.c15 {
+.c16 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -1144,7 +1159,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c14 {
+.c15 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1153,7 +1168,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin-left: 0.5rem;
 }
 
-.c10 {
+.c11 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -1167,7 +1182,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 100%;
 }
 
-.c11 {
+.c12 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1175,7 +1190,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   flex-grow: 1;
 }
 
-.c12 {
+.c13 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1185,7 +1200,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1195,7 +1210,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1206,7 +1221,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin-left: 0.5rem;
 }
 
-.c16 {
+.c17 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: block;
@@ -1217,7 +1232,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1.625rem;
 }
 
-.c25 {
+.c26 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: block;
@@ -1228,7 +1243,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1.625rem;
 }
 
-.c17 {
+.c18 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1239,7 +1254,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c18 {
+.c19 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1251,7 +1266,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c22 {
+.c23 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1263,7 +1278,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c26 {
+.c27 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1275,7 +1290,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   border-top: 1px solid transparent;
 }
 
-.c19 > svg {
+.c20 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1283,7 +1298,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c27 > svg {
+.c28 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -1291,7 +1306,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c21 {
+.c22 {
   padding-right: 0.5rem;
 }
 
@@ -1357,8 +1372,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-style: normal;
 }
 
-.c8::after {
-  content: '';
+.c10 {
   border-top: 0.0625rem solid #AEAEB5;
   top: 1rem;
   margin-right: 0.625rem;
@@ -1380,28 +1394,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c13 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c23 {
+  .c13 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1416,20 +1416,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c24 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c16 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c16 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1451,55 +1437,83 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
+    font-size: 1.25rem;
+    line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c17 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c26 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c26 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -1678,20 +1692,24 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
+          <span
+            class="c10"
+            dir="rtl"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -1702,7 +1720,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
                 role="text"
               >
                 <span
-                  class="c14"
+                  class="c15"
                   dir="rtl"
                 >
                   مباشر 
@@ -1710,14 +1728,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
               </span>
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -1725,20 +1743,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c18"
+        class="c19"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1753,12 +1771,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c15"
+            class="c16"
           >
              المدة الزمنية 
             1,00,00 
@@ -1816,20 +1834,24 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
+          <span
+            class="c10"
+            dir="rtl"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -1838,14 +1860,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             >
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -1853,20 +1875,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1881,12 +1903,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c15"
+            class="c16"
           >
              المدة الزمنية 
             1,00,00 
@@ -1944,20 +1966,24 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
+          <span
+            class="c10"
+            dir="rtl"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c12"
+          class="c13"
         >
           <a
-            class="c13"
+            class="c14"
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
@@ -1966,14 +1992,14 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             >
               لماذا يخجل البعض من اسم قريته في مصر؟
               <span
-                class="c15"
+                class="c16"
               >
                 , 
                 ۱۴:۵۴
                 , 
               </span>
               <span
-                class="c16"
+                class="c17"
               >
                 29/01/1990
               </span>
@@ -1981,20 +2007,20 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2009,12 +2035,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c15"
+            class="c16"
           >
              المدة الزمنية 
             1,00,00 
@@ -2072,58 +2098,62 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           >
             ۱۴:۵۴
           </time>
+          <span
+            class="c10"
+            dir="rtl"
+          />
         </span>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <div
-        class="c11"
+        class="c12"
       >
         <h3
-          class="c23"
+          class="c24"
         >
           <span
             class=""
             role="text"
           >
             <span
-              class="c24"
+              class="c25"
               dir="rtl"
             >
               مباشر 
             </span>
             لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class="c15"
+              class="c16"
             >
               , 
               ۱۴:۵۴
               , 
             </span>
             <span
-              class="c25"
+              class="c26"
             >
               29/01/1990
             </span>
           </span>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c26"
+        class="c27"
       >
         <span
-          class="c27"
+          class="c28"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2138,12 +2168,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
           <span
-            class="c15"
+            class="c16"
           >
              المدة الزمنية 
             1,00,00 


### PR DESCRIPTION
Resolves #3301 

**Overall change:** _Fix clock icon being cut off on smaller breakpoints

_Added overflow styling to fix pixels being cut off._

**Before**
<img width="349" alt="Screenshot 2020-03-31 at 17 52 25" src="https://user-images.githubusercontent.com/12303856/78040737-84d45880-7378-11ea-9fe4-90fea7c923d9.png">

**After**
<img width="363" alt="Screenshot 2020-03-31 at 17 53 06" src="https://user-images.githubusercontent.com/12303856/78040763-8d2c9380-7378-11ea-9fa1-50c6102622b1.png">

**Code changes:**
- _Add `overflow: visible` styling to clock icon via `StyledClock`._
- _Update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
