### PR TITLE
Psammead Social Embed alpha adjustments

### DIFF
--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description   |
 |---------------|---------------|
+| 0.1.0-alpha.4 | [PR#3319](https://github.com/bbc/psammead/pull/3319) Remove dependency on @bbc/psammead-oembed. |
 | 0.1.0-alpha.3 | [PR#3311](https://github.com/bbc/psammead/pull/3311) Transpile with @loadable/babel-plugin. |
 | 0.1.0-alpha.2 | [PR#3298](https://github.com/bbc/psammead/pull/3298) Add webpackChunkName to dynamic import. |
 | 0.1.0-alpha.1 | [PR#3217](https://github.com/bbc/psammead/pull/3217) Initial creation of package. |

--- a/packages/components/psammead-social-embed/README.md
+++ b/packages/components/psammead-social-embed/README.md
@@ -145,6 +145,10 @@ This component will not provide a rich social media embed for providers outside 
 
 This component provides a [Skip Link](https://webaim.org/techniques/skipnav/), which allows users to identify and skip over social media content in your pages. `skipLink.endTextId` should be set to a value that uniquely identifies `skipLink.endTextVisuallyHidden`. This is especially important when there are more than one social media embeds from the same provider on a page.
 
+`fallback.linkTextSuffixVisuallyHidden` is used to add a suffix to `fallback.text`. This will not be visible on the UI, but will be captured by assistive technology.
+
+`caption.textPrefixVisuallyHidden` is used to add a prefix to `caption.text`. This will not be visible on the UI, but will be captured by assistive technology.
+
 ## Miscellaneous
 
 Some components within `SocialEmbed` render the same result given the same props and are memoized using [React.memo](https://reactjs.org/docs/react-api.html#reactmemo) to prevent unnecessary renders.

--- a/packages/components/psammead-social-embed/README.md
+++ b/packages/components/psammead-social-embed/README.md
@@ -8,8 +8,6 @@ This component is currently tagged as alpha and is not suitable for production u
 
 The `SocialEmbed` component renders a rich social media embed for a number of supported providers or a fallback containing a link to the source content.
 
-Note: This component declares `@loadable/component` as a peer dependency. It is used to dynamically import `@bbc/psammead-oembed` if and when it's needed.
-
 ### Supported providers
 
 | Name      | Value       |
@@ -35,7 +33,7 @@ npm install @bbc/psammead-social-embed --save
 | `oEmbed`   | Object | Yes      | n/a     | See [@bbc/psammead-oembed](https://github.com/bbc/psammead/tree/latest/packages/components/psammead-oembed#oembed). |
 | `fallback` | Object | Yes      | n/a     | See [fallback](#fallback).                                                                                          |
 | `skipLink` | Object | Yes      | n/a     | See [skipLink](#skipLink).                                                                                          |
-| `caption`  | Object | Yes      | n/a     | See [caption](#caption).                                                                                            |
+| `caption`  | Object | No       | `null`  | See [caption](#caption).                                                                                            |
 
 ### AMP
 
@@ -46,35 +44,36 @@ npm install @bbc/psammead-social-embed --save
 | `id`       | String | Yes      | n/a     | `'1237210910835392512'`                          |
 | `fallback` | Object | Yes      | n/a     | See [fallback](#fallback).                       |
 | `skipLink` | Object | Yes      | n/a     | See [skipLink](#skipLink).                       |
-| `caption`  | Object | Yes      | n/a     | See [caption](#caption).                         |
+| `caption`  | Object | No       | `null`  | See [caption](#caption).                         |
 
 ### `fallback`
 
-| Argument      | Type   | Required | Default | Example                                                       |
-| ------------- | ------ | -------- | ------- | ------------------------------------------------------------- |
-| `text`        | String | Yes      | n/a     | `"Sorry but we're having trouble displaying this content"`    |
-| `linkText`    | String | Yes      | n/a     | `'View content on %provider_name%'`                           |
-| `linkHref`    | String | Yes      | n/a     | `'https://twitter.com/MileyCyrus/status/1237210910835392512'` |
-| `warningText` | String | No       | `null`  | `Warning: BBC is not responsible for third party content`     |
+| Argument                       | Type   | Required | Default | Example                                                       |
+| ------------------------------ | ------ | -------- | ------- | ------------------------------------------------------------- |
+| `text`                         | String | Yes      | n/a     | `"Sorry but we're having trouble displaying this content"`    |
+| `linkText`                     | String | Yes      | n/a     | `'View content on %provider_name%'`                           |
+| `linkTextSuffixVisuallyHidden` | String | No       | `null`  | `', external'`                                                |
+| `linkHref`                     | String | Yes      | n/a     | `'https://twitter.com/MileyCyrus/status/1237210910835392512'` |
+| `warningText`                  | String | No       | `null`  | `Warning: BBC is not responsible for third party content`     |
 
 Note: For your convenience, instances of `%provider%` and `%provider_name%` in the above strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `twitter` and `Twitter` respectively.
 
 ### `skipLink`
 
-| Argument    | Type   | Required | Default | Example                            |
-| ----------- | ------ | -------- | ------- | ---------------------------------- |
-| `text`      | String | Yes      | n/a     | `'Skip %provider_name% content'`   |
-| `endTextId` | String | Yes      | n/a     | `'skip-%provider%-content'`        |
-| `endText`   | String | Yes      | n/a     | `'End of %provider_name% content'` |
+| Argument                | Type   | Required | Default | Example                            |
+| ----------------------- | ------ | -------- | ------- | ---------------------------------- |
+| `text`                  | String | Yes      | n/a     | `'Skip %provider_name% content'`   |
+| `endTextId`             | String | Yes      | n/a     | `'skip-%provider%-content'`        |
+| `endTextVisuallyHidden` | String | Yes      | n/a     | `'End of %provider_name% content'` |
+
+Note: For your convenience, instances of `%provider%` and `%provider_name%` in the above strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `instagram` and `Instagram` respectively.
 
 ### `caption`
 
-| Argument             | Type   | Required | Default | Example                                              |
-| -------------------- | ------ | -------- | ------- | ---------------------------------------------------- |
-| `visuallyHiddenText` | String | Yes      | n/a     | `'Video caption,'`                                   |
-| `text`               | String | Yes      | n/a     | `'Warning: Third party content may contain adverts'` |
-
-Note: `visuallyHiddenText` will come before `text` and have a trailing space added.
+| Argument                   | Type   | Required | Default | Example                                              |
+| -------------------------- | ------ | -------- | ------- | ---------------------------------------------------- |
+| `textPrefixVisuallyHidden` | String | No       | `null`  | `'Video caption,'`                                   |
+| `text`                     | String | Yes      | n/a     | `'Warning: Third party content may contain adverts'` |
 
 See [accessibility notes](#accessibility-notes) for more information.
 
@@ -98,11 +97,12 @@ import { CanonicalSocialEmbed } from '@bbc/psammead-social-embed';
   skipLink={{
     text: 'Skip %provider_name% content',
     endTextId: 'skip-%provider%-content',
-    endText: 'End of %provider_name% content',
+    endTextVisuallyHidden: 'End of %provider_name% content',
   }}
   fallback={{
     text: "Sorry but we're having trouble displaying this content",
     linkText: 'View content on %provider_name%',
+    linkTextSuffixVisuallyHidden: ', external',
     linkHref: 'https://www.instagram.com/p/B8FPf4ZphHi/',
     warningText: 'Warning: BBC is not responsible for third party content',
   }}
@@ -125,11 +125,12 @@ import { AmpSocialEmbed } from '@bbc/psammead-social-embed';
   skipLink={{
     text: 'Skip %provider_name% content',
     endTextId: 'skip-%provider%-content',
-    endText: 'End of %provider_name% content',
+    endTextVisuallyHidden: 'End of %provider_name% content',
   }}
   fallback={{
     text: "Sorry but we're having trouble displaying this content",
     linkText: 'View content on %provider_name%',
+    linkTextSuffixVisuallyHidden: ', external',
     linkHref: 'https://www.instagram.com/p/B8FPf4ZphHi/',
     warningText: 'Warning: BBC is not responsible for third party content',
   }}
@@ -146,11 +147,7 @@ This component will not provide a rich social media embed for providers outside 
 
 ### Accessibility notes
 
-This component provides a [Skip Link](https://webaim.org/techniques/skipnav/), which allows users to identify and skip over social media content in your pages. `skipLink.endTextId` should be set to a value that uniquely identifies `skipLink.endText`. This is especially important when there is more than one social media embed from the same provider on the page.
-
-## Roadmap
-
-OEmbed is a dynamic import found within CanonicalSocialEmbed. While it is being loaded, `<p>Loading&hellip;</p>` is rendered. This could be updated to inherit the width and height of the oEmbed content and thus prevent reflows when it is replaced.
+This component provides a [Skip Link](https://webaim.org/techniques/skipnav/), which allows users to identify and skip over social media content in your pages. `skipLink.endTextId` should be set to a value that uniquely identifies `skipLink.endTextVisuallyHidden`. This is especially important when there are more than one social media embeds from the same provider on a page.
 
 ## Miscellaneous
 

--- a/packages/components/psammead-social-embed/README.md
+++ b/packages/components/psammead-social-embed/README.md
@@ -56,8 +56,6 @@ npm install @bbc/psammead-social-embed --save
 | `linkHref`                     | String | Yes      | n/a     | `'https://twitter.com/MileyCyrus/status/1237210910835392512'` |
 | `warningText`                  | String | No       | `null`  | `Warning: BBC is not responsible for third party content`     |
 
-Note: For your convenience, instances of `%provider%` and `%provider_name%` in the above strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `twitter` and `Twitter` respectively.
-
 ### `skipLink`
 
 | Argument                | Type   | Required | Default | Example                            |
@@ -65,8 +63,6 @@ Note: For your convenience, instances of `%provider%` and `%provider_name%` in t
 | `text`                  | String | Yes      | n/a     | `'Skip %provider_name% content'`   |
 | `endTextId`             | String | Yes      | n/a     | `'skip-%provider%-content'`        |
 | `endTextVisuallyHidden` | String | Yes      | n/a     | `'End of %provider_name% content'` |
-
-Note: For your convenience, instances of `%provider%` and `%provider_name%` in the above strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `instagram` and `Instagram` respectively.
 
 ### `caption`
 
@@ -77,7 +73,7 @@ Note: For your convenience, instances of `%provider%` and `%provider_name%` in t
 
 See [accessibility notes](#accessibility-notes) for more information.
 
-Note: For your convenience, instances of `%provider%` and `%provider_name%` in the above strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `instagram` and `Instagram` respectively.
+Note: For your convenience, instances of `%provider%` and `%provider_name%` in `fallback`, `skipLink` and `caption` strings will be replaced with the current provider and, where the provider is known, the name of the provider. E.G. `youtube` and `YouTube` respectively.
 
 ## Usage
 

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -9,23 +9,10 @@
       "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.0.1.tgz",
       "integrity": "sha512-0h3p8aG9sGbsEu0y8UOQ/d6VoLoFY0KdsOqwSTkIH0+IyDq9LzMLjP4ceDk+gK1qtAMb+SuqitFjllX/9KavCg=="
     },
-    "@bbc/psammead-oembed": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-oembed/-/psammead-oembed-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-uMrRLvJjtlRL9/LyM/WcZJKFEUfLGNND4xNfxw2HBICX9LELscCZJRQpmNm9xwLtjqKeApCrmYEaBdF00uGTrA==",
-      "requires": {
-        "dompurify": "^2.0.8"
-      }
-    },
     "@bbc/psammead-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.3.0.tgz",
       "integrity": "sha512-bgYd7pGMK7cbWsY2pq2nxbHWdPSW5ZIzEefDJ3xMi9FknwDQDO6m9OJ67TaovWNaPJvduVB9no7V+2eAuity7w=="
-    },
-    "dompurify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.8.tgz",
-      "integrity": "sha512-vIOSyOXkMx81ghEalh4MLBtDHMx1bhKlaqHDMqM2yeitJ996SLOk5mGdDpI9ifJAgokred8Rmu219fX4OltqXw=="
     }
   }
 }

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "publishConfig": {
     "tag": "alpha"
   },

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -23,12 +23,10 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-social-embed/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^4.0.1",
-    "@bbc/psammead-oembed": "0.1.0-alpha.2",
     "@bbc/psammead-styles": "^4.3.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",
-    "styled-components": "^4.4.1",
-    "@loadable/component": "^5.12.0"
+    "styled-components": "^4.4.1"
   }
 }

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -10,6 +10,8 @@ const LANDSCAPE_RATIO = '56.25%';
  */
 const OEmbed = styled.div`
   ${({ styles }) => styles}
+  display: flex;
+  justify-content: center;
 `;
 
 /**

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -1,22 +1,14 @@
 import React, { memo } from 'react';
 import Helmet from 'react-helmet';
 import { shape, string } from 'prop-types';
-import loadable from '@loadable/component';
 import styled, { css } from 'styled-components';
-
-const OEmbed = loadable(
-  () => import(/* webpackChunkName: 'oembed' */ '@bbc/psammead-oembed'),
-  {
-    fallback: <p>Loading&hellip;</p>,
-  },
-);
 
 const LANDSCAPE_RATIO = '56.25%';
 
 /**
  * Apply provider-specific styles.
  */
-const StyledOEmbed = styled(OEmbed)`
+const OEmbed = styled.div`
   ${({ styles }) => styles}
 `;
 
@@ -56,7 +48,10 @@ const CanonicalEmbed = ({ provider, oEmbed }) => (
         <script async src={providers[provider].script} />
       </Helmet>
     )}
-    <StyledOEmbed styles={providers[provider].styles} oEmbed={oEmbed} />
+    <OEmbed
+      styles={providers[provider].styles}
+      dangerouslySetInnerHTML={{ __html: oEmbed.html }}
+    />
   </>
 );
 

--- a/packages/components/psammead-social-embed/src/CaptionWrapper/index.jsx
+++ b/packages/components/psammead-social-embed/src/CaptionWrapper/index.jsx
@@ -34,13 +34,8 @@ const CaptionWrapper = ({
   <Figure>
     {children}
     <FigCaption service={service}>
-      {textPrefixVisuallyHidden ? (
-        <>
-          <span>{textPrefixVisuallyHidden}</span> {text}
-        </>
-      ) : (
-        text
-      )}
+      {textPrefixVisuallyHidden && <span>{textPrefixVisuallyHidden}</span>}
+      {text}
     </FigCaption>
   </Figure>
 );

--- a/packages/components/psammead-social-embed/src/CaptionWrapper/index.jsx
+++ b/packages/components/psammead-social-embed/src/CaptionWrapper/index.jsx
@@ -25,13 +25,18 @@ const FigCaption = styled.figcaption`
   }
 `;
 
-const CaptionWrapper = ({ children, service, visuallyHiddenText, text }) => (
+const CaptionWrapper = ({
+  children,
+  service,
+  textPrefixVisuallyHidden,
+  text,
+}) => (
   <Figure>
     {children}
     <FigCaption service={service}>
-      {visuallyHiddenText ? (
+      {textPrefixVisuallyHidden ? (
         <>
-          <span>{visuallyHiddenText}</span> {text}
+          <span>{textPrefixVisuallyHidden}</span> {text}
         </>
       ) : (
         text
@@ -41,13 +46,13 @@ const CaptionWrapper = ({ children, service, visuallyHiddenText, text }) => (
 );
 
 CaptionWrapper.defaultProps = {
-  visuallyHiddenText: null,
+  textPrefixVisuallyHidden: null,
 };
 
 CaptionWrapper.propTypes = {
   children: node.isRequired,
   service: string.isRequired,
-  visuallyHiddenText: string,
+  textPrefixVisuallyHidden: string,
   text: string.isRequired,
 };
 

--- a/packages/components/psammead-social-embed/src/Notice/index.jsx
+++ b/packages/components/psammead-social-embed/src/Notice/index.jsx
@@ -61,13 +61,9 @@ const Notice = ({
     <Wrapper service={service}>
       <p>{detokenise(text, dictionary)}</p>
       <a href={linkHref}>
-        {linkTextSuffixVisuallyHidden ? (
-          <>
-            {detokenise(linkText, dictionary)}{' '}
-            <span>{detokenise(linkTextSuffixVisuallyHidden, dictionary)}</span>
-          </>
-        ) : (
-          detokenise(linkText, dictionary)
+        {detokenise(linkText, dictionary)}
+        {linkTextSuffixVisuallyHidden && (
+          <span>{detokenise(linkTextSuffixVisuallyHidden, dictionary)}</span>
         )}
       </a>
       {warningText && <small>{warningText}</small>}

--- a/packages/components/psammead-social-embed/src/Notice/index.jsx
+++ b/packages/components/psammead-social-embed/src/Notice/index.jsx
@@ -6,7 +6,11 @@ import { getSansRegular, getSansBold } from '@bbc/psammead-styles/font-styles';
 import { GEL_SPACING_DBL, GEL_SPACING } from '@bbc/gel-foundations/spacings';
 import { GEL_BODY_COPY, GEL_MINION } from '@bbc/gel-foundations/typography';
 
-import { detokenise, dictionaryFactory } from '../utilities';
+import {
+  detokenise,
+  dictionaryFactory,
+  visuallyHiddenStyle,
+} from '../utilities';
 
 const BORDER_WEIGHT = '0.0625rem';
 
@@ -31,6 +35,10 @@ const Wrapper = styled.div`
   a {
     ${({ service }) => getSansBold(service)}
     text-decoration: none;
+
+    > span {
+      ${visuallyHiddenStyle}
+    }
   }
 
   small {
@@ -44,6 +52,7 @@ const Notice = ({
   service,
   text,
   linkText,
+  linkTextSuffixVisuallyHidden,
   linkHref,
   warningText,
 }) => {
@@ -51,13 +60,23 @@ const Notice = ({
   return (
     <Wrapper service={service}>
       <p>{detokenise(text, dictionary)}</p>
-      <a href={linkHref}>{detokenise(linkText, dictionary)}</a>
+      <a href={linkHref}>
+        {linkTextSuffixVisuallyHidden ? (
+          <>
+            {detokenise(linkText, dictionary)}{' '}
+            <span>{detokenise(linkTextSuffixVisuallyHidden, dictionary)}</span>
+          </>
+        ) : (
+          detokenise(linkText, dictionary)
+        )}
+      </a>
       {warningText && <small>{warningText}</small>}
     </Wrapper>
   );
 };
 
 Notice.defaultProps = {
+  linkTextSuffixVisuallyHidden: null,
   warningText: null,
 };
 
@@ -66,6 +85,7 @@ Notice.propTypes = {
   service: string.isRequired,
   text: string.isRequired,
   linkText: string.isRequired,
+  linkTextSuffixVisuallyHidden: string,
   linkHref: string.isRequired,
   warningText: string,
 };

--- a/packages/components/psammead-social-embed/src/SkipLinkWrapper/index.jsx
+++ b/packages/components/psammead-social-embed/src/SkipLinkWrapper/index.jsx
@@ -48,7 +48,7 @@ const SkipLinkWrapper = ({
   endTextId,
   text,
   children,
-  endText,
+  endTextVisuallyHidden,
 }) => {
   const dictionary = dictionaryFactory({ provider });
   return (
@@ -61,7 +61,7 @@ const SkipLinkWrapper = ({
       </SkipLink>
       {children}
       <EndText tabIndex="-1" id={detokenise(endTextId, dictionary)}>
-        {detokenise(endText, dictionary)}
+        {detokenise(endTextVisuallyHidden, dictionary)}
       </EndText>
     </Wrapper>
   );
@@ -73,7 +73,7 @@ SkipLinkWrapper.propTypes = {
   endTextId: string.isRequired,
   children: node.isRequired,
   text: string.isRequired,
-  endText: string.isRequired,
+  endTextVisuallyHidden: string.isRequired,
 };
 
 export default SkipLinkWrapper;

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -485,7 +485,6 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
     href="embed-url"
   >
     View content on unknown
-     
     <span>
       , external
     </span>
@@ -562,7 +561,6 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
     href="embed-url"
   >
     View content on Twitter
-     
     <span>
       , external
     </span>
@@ -1094,9 +1092,8 @@ exports[`CanonicalSocialEmbed should render correctly for YouTube 1`] = `
       class="c4"
     >
       <span>
-        Video caption,
+        Video caption, 
       </span>
-       
       Warning: Third party content may contain adverts
     </figcaption>
   </figure>

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -608,7 +608,7 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
   white-space: nowrap;
 }
 
-.c2 {
+.c3 {
   position: absolute !important;
   height: 1px;
   width: 1px;
@@ -618,6 +618,17 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
   -webkit-clip: rect(1px,1px,1px,1px);
   clip: rect(1px,1px,1px,1px);
   white-space: nowrap;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -651,7 +662,7 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
           Skip Instagram content
         </a>
         <div
-          class=""
+          class="c2"
         >
           <blockquote
             class="instagram-media"
@@ -823,7 +834,7 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
           </blockquote>
         </div>
         <p
-          class="c2"
+          class="c3"
           id="skip-instagram-content"
           tabindex="-1"
         >
@@ -880,7 +891,7 @@ exports[`CanonicalSocialEmbed should render correctly for Twitter 1`] = `
   white-space: nowrap;
 }
 
-.c2 {
+.c3 {
   position: absolute !important;
   height: 1px;
   width: 1px;
@@ -890,6 +901,17 @@ exports[`CanonicalSocialEmbed should render correctly for Twitter 1`] = `
   -webkit-clip: rect(1px,1px,1px,1px);
   clip: rect(1px,1px,1px,1px);
   white-space: nowrap;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -915,7 +937,7 @@ exports[`CanonicalSocialEmbed should render correctly for Twitter 1`] = `
           Skip Twitter content
         </a>
         <div
-          class=""
+          class="c2"
         >
           <blockquote
             class="twitter-tweet"
@@ -937,7 +959,7 @@ exports[`CanonicalSocialEmbed should render correctly for Twitter 1`] = `
 
         </div>
         <p
-          class="c2"
+          class="c3"
           id="skip-twitter-content"
           tabindex="-1"
         >
@@ -1029,6 +1051,14 @@ exports[`CanonicalSocialEmbed should render correctly for YouTube 1`] = `
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c3 > iframe {

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -616,7 +616,7 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
             data-instgrm-captioned=""
             data-instgrm-permalink="https://www.instagram.com/p/B8FPf4ZphHi/?utm_source=ig_embed&utm_campaign=loading"
             data-instgrm-version="12"
-            style="background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"
+            style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"
           >
             <div
               style="padding:16px;"
@@ -624,11 +624,12 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
                
               <a
                 href="https://www.instagram.com/p/B8FPf4ZphHi/?utm_source=ig_embed&utm_campaign=loading"
-                style="background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;"
+                style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;"
+                target="_blank"
               >
                  
                 <div
-                  style="display: flex; flex-direction: row; align-items: center;"
+                  style=" display: flex; flex-direction: row; align-items: center;"
                 >
                    
                   <div
@@ -640,11 +641,11 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
                   >
                      
                     <div
-                      style="background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"
+                      style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"
                     />
                      
                     <div
-                      style="background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"
+                      style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"
                     />
                   </div>
                 </div>
@@ -687,7 +688,7 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
                 >
                    
                   <div
-                    style="color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"
+                    style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"
                   >
                      View this post on Instagram
                   </div>
@@ -718,11 +719,11 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
                   >
                      
                     <div
-                      style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"
+                      style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"
                     />
                      
                     <div
-                      style="width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"
+                      style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"
                     />
                   </div>
                   <div
@@ -730,46 +731,48 @@ exports[`CanonicalSocialEmbed should render correctly for Instagram 1`] = `
                   >
                      
                     <div
-                      style="width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"
+                      style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"
                     />
                      
                     <div
-                      style="background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"
+                      style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"
                     />
                      
                     <div
-                      style="width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"
+                      style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"
                     />
                   </div>
                 </div>
               </a>
                
               <p
-                style="margin:8px 0 0 0; padding:0 4px;"
+                style=" margin:8px 0 0 0; padding:0 4px;"
               >
                  
                 <a
                   href="https://www.instagram.com/p/B8FPf4ZphHi/?utm_source=ig_embed&utm_campaign=loading"
-                  style="color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;"
+                  style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;"
+                  target="_blank"
                 >
                   1917 was the big winner at the Bafta Film Awards, winning seven prizes in total, including best film, best British film, best director and best cinematography. Joker star Joaquin Phoenix was named best actor, while Renee Zellweger was recognised for her portrayal of Judy Garland. Tap the link in our bio to read more about all of the winners at the 2020 Bafta Film Awards. #Baftas #film #awards #BBCNews
                 </a>
               </p>
                
               <p
-                style="color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"
+                style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"
               >
                 A post shared by 
                 <a
                   href="https://www.instagram.com/bbcnews/?utm_source=ig_embed&utm_campaign=loading"
-                  style="color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;"
+                  style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;"
+                  target="_blank"
                 >
                    BBC News
                 </a>
                  (@bbcnews) on 
                 <time
                   datetime="2020-02-02T22:51:31+00:00"
-                  style="font-family:Arial,sans-serif; font-size:14px; line-height:17px;"
+                  style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;"
                 >
                   Feb 2, 2020 at 2:51pm PST
                 </time>
@@ -1035,6 +1038,9 @@ exports[`CanonicalSocialEmbed should render correctly for YouTube 1`] = `
       class="c3"
     >
       <iframe
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen=""
+        frameborder="0"
         height="270"
         src="https://www.youtube.com/embed/chiWVxreqhU?feature=oembed"
         width="480"

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -31,6 +31,18 @@ exports[`AmpSocialEmbed should render a notice when the provider is unsupported 
   text-decoration: none;
 }
 
+.c0 a > span {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px 1px 1px 1px);
+  clip: rect(1px 1px 1px 1px);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0 small {
   margin-top: 0.5rem;
   font-size: 0.75rem;
@@ -438,6 +450,18 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
   text-decoration: none;
 }
 
+.c0 a > span {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px 1px 1px 1px);
+  clip: rect(1px 1px 1px 1px);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0 small {
   margin-top: 0.5rem;
   font-size: 0.75rem;
@@ -461,6 +485,10 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
     href="embed-url"
   >
     View content on unknown
+     
+    <span>
+      , external
+    </span>
   </a>
   <small>
     Warning: BBC is not responsible for third party content
@@ -499,6 +527,18 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
   text-decoration: none;
 }
 
+.c0 a > span {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px 1px 1px 1px);
+  clip: rect(1px 1px 1px 1px);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0 small {
   margin-top: 0.5rem;
   font-size: 0.75rem;
@@ -522,6 +562,10 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
     href="embed-url"
   >
     View content on Twitter
+     
+    <span>
+      , external
+    </span>
   </a>
   <small>
     Warning: BBC is not responsible for third party content

--- a/packages/components/psammead-social-embed/src/index.jsx
+++ b/packages/components/psammead-social-embed/src/index.jsx
@@ -82,15 +82,16 @@ const sharedPropTypes = {
   skipLink: shape({
     text: string.isRequired,
     endTextId: string.isRequired,
-    endText: string.isRequired,
+    endTextVisuallyHidden: string.isRequired,
   }).isRequired,
   caption: shape({
-    visuallyHiddenText: string,
+    textPrefixVisuallyHidden: string,
     text: string.isRequired,
   }),
   fallback: shape({
     text: string.isRequired,
     linkText: string.isRequired,
+    linkTextSuffixVisuallyHidden: string,
     linkHref: string.isRequired,
     warningText: string,
   }).isRequired,

--- a/packages/components/psammead-social-embed/src/index.stories.jsx
+++ b/packages/components/psammead-social-embed/src/index.stories.jsx
@@ -17,7 +17,7 @@ storiesOf('Components|SocialEmbed/Canonical', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              textPrefixVisuallyHidden: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption, ',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;
@@ -83,7 +83,7 @@ storiesOf('Components|SocialEmbed/Canonical', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              textPrefixVisuallyHidden: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption, ',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;
@@ -138,7 +138,7 @@ storiesOf('Components|SocialEmbed/AMP', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              textPrefixVisuallyHidden: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption, ',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;

--- a/packages/components/psammead-social-embed/src/index.stories.jsx
+++ b/packages/components/psammead-social-embed/src/index.stories.jsx
@@ -17,7 +17,7 @@ storiesOf('Components|SocialEmbed/Canonical', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              visuallyHiddenText: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption,',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;
@@ -29,11 +29,12 @@ storiesOf('Components|SocialEmbed/Canonical', module)
           skipLink={{
             text: 'Skip %provider_name% content',
             endTextId: 'skip-%provider%-content',
-            endText: 'End of %provider_name% content',
+            endTextVisuallyHidden: 'End of %provider_name% content',
           }}
           fallback={{
             text: "Sorry but we're having trouble displaying this content",
             linkText: 'View content on %provider_name%',
+            linkTextSuffixVisuallyHidden: ', external',
             linkHref: 'https://www.bbc.co.uk',
             warningText:
               'Warning: BBC is not responsible for third party content',
@@ -57,11 +58,12 @@ storiesOf('Components|SocialEmbed/Canonical', module)
           skipLink={{
             text: 'Skip %provider_name% content',
             endTextId: 'skip-%provider%-content',
-            endText: 'End of %provider_name% content',
+            endTextVisuallyHidden: 'End of %provider_name% content',
           }}
           fallback={{
             text: "Sorry but we're having trouble displaying this content",
             linkText: 'View content on %provider_name%',
+            linkTextSuffixVisuallyHidden: ', external',
             linkHref: 'https://www.bbc.co.uk',
             warningText:
               'Warning: BBC is not responsible for third party content',
@@ -81,7 +83,7 @@ storiesOf('Components|SocialEmbed/Canonical', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              visuallyHiddenText: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption,',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;
@@ -92,11 +94,12 @@ storiesOf('Components|SocialEmbed/Canonical', module)
           skipLink={{
             text: 'Skip %provider_name% content',
             endTextId: 'skip-%provider%-content',
-            endText: 'End of %provider_name% content',
+            endTextVisuallyHidden: 'End of %provider_name% content',
           }}
           fallback={{
             text: "Sorry but we're having trouble displaying this content",
             linkText: 'View content on %provider_name%',
+            linkTextSuffixVisuallyHidden: ', external',
             linkHref: 'https://www.bbc.co.uk',
             warningText:
               'Warning: BBC is not responsible for third party content',
@@ -135,7 +138,7 @@ storiesOf('Components|SocialEmbed/AMP', module)
       const caption =
         fixture.source === 'youtube'
           ? {
-              visuallyHiddenText: 'Video caption,',
+              textPrefixVisuallyHidden: 'Video caption,',
               text: 'Warning: Third party content may contain adverts',
             }
           : null;
@@ -147,11 +150,12 @@ storiesOf('Components|SocialEmbed/AMP', module)
           skipLink={{
             text: 'Skip %provider_name% content',
             endTextId: 'skip-%provider%-content',
-            endText: 'End of %provider_name% content',
+            endTextVisuallyHidden: 'End of %provider_name% content',
           }}
           fallback={{
             text: "Sorry but we're having trouble displaying this content",
             linkText: 'View content on %provider_name%',
+            linkTextSuffixVisuallyHidden: ', external',
             linkHref: 'https://www.bbc.co.uk',
             warningText:
               'Warning: BBC is not responsible for third party content',
@@ -175,11 +179,12 @@ storiesOf('Components|SocialEmbed/AMP', module)
           skipLink={{
             text: 'Skip %provider_name% content',
             endTextId: 'skip-%provider%-content',
-            endText: 'End of %provider_name% content',
+            endTextVisuallyHidden: 'End of %provider_name% content',
           }}
           fallback={{
             text: "Sorry but we're having trouble displaying this content",
             linkText: 'View content on %provider_name%',
+            linkTextSuffixVisuallyHidden: ', external',
             linkHref: 'https://www.bbc.co.uk',
             warningText:
               'Warning: BBC is not responsible for third party content',

--- a/packages/components/psammead-social-embed/src/index.test.jsx
+++ b/packages/components/psammead-social-embed/src/index.test.jsx
@@ -9,7 +9,7 @@ describe('CanonicalSocialEmbed', () => {
     const caption =
       provider === 'youtube'
         ? {
-            textPrefixVisuallyHidden: 'Video caption,',
+            textPrefixVisuallyHidden: 'Video caption, ',
             text: 'Warning: Third party content may contain adverts',
           }
         : null;

--- a/packages/components/psammead-social-embed/src/index.test.jsx
+++ b/packages/components/psammead-social-embed/src/index.test.jsx
@@ -9,7 +9,7 @@ describe('CanonicalSocialEmbed', () => {
     const caption =
       provider === 'youtube'
         ? {
-            visuallyHiddenText: 'Video caption,',
+            textPrefixVisuallyHidden: 'Video caption,',
             text: 'Warning: Third party content may contain adverts',
           }
         : null;
@@ -22,11 +22,12 @@ describe('CanonicalSocialEmbed', () => {
         skipLink={{
           text: 'Skip %provider_name% content',
           endTextId: 'skip-%provider%-content',
-          endText: 'End of %provider_name% content',
+          endTextVisuallyHidden: 'End of %provider_name% content',
         }}
         fallback={{
           text: "Sorry but we're having trouble displaying this content",
           linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
           linkHref: 'embed-url',
           warningText:
             'Warning: BBC is not responsible for third party content',
@@ -45,11 +46,12 @@ describe('CanonicalSocialEmbed', () => {
       skipLink={{
         text: 'Skip %provider_name% content',
         endTextId: 'skip-%provider%-content',
-        endText: 'End of %provider_name% content',
+        endTextVisuallyHidden: 'End of %provider_name% content',
       }}
       fallback={{
         text: "Sorry but we're having trouble displaying this content",
         linkText: 'View content on %provider_name%',
+        linkTextSuffixVisuallyHidden: ', external',
         linkHref: 'embed-url',
         warningText: 'Warning: BBC is not responsible for third party content',
       }}
@@ -64,11 +66,12 @@ describe('CanonicalSocialEmbed', () => {
       skipLink={{
         text: 'Skip %provider_name% content',
         endTextId: 'skip-%provider%-content',
-        endText: 'End of %provider_name% content',
+        endTextVisuallyHidden: 'End of %provider_name% content',
       }}
       fallback={{
         text: "Sorry but we're having trouble displaying this content",
         linkText: 'View content on %provider_name%',
+        linkTextSuffixVisuallyHidden: ', external',
         linkHref: 'embed-url',
         warningText: 'Warning: BBC is not responsible for third party content',
       }}
@@ -95,7 +98,7 @@ describe('AmpSocialEmbed', () => {
         skipLink={{
           text: 'Skip %provider_name% content',
           endTextId: 'skip-%provider%-content',
-          endText: 'End of %provider_name% content',
+          endTextVisuallyHidden: 'End of %provider_name% content',
         }}
         fallback={{
           text: "Sorry but we're having trouble displaying this content",
@@ -118,7 +121,7 @@ describe('AmpSocialEmbed', () => {
       skipLink={{
         text: 'Skip %provider_name% content',
         endTextId: 'skip-%provider%-content',
-        endText: 'End of %provider_name% content',
+        endTextVisuallyHidden: 'End of %provider_name% content',
       }}
       fallback={{
         text: "Sorry but we're having trouble displaying this content",


### PR DESCRIPTION
No issue.

### Overall changes:

- We are lifting the dependency on `psammead-oembed`, because we cannot meet the requirements to render it on the server. This is because DOMPurify, the HTML sanitisation library it uses, requires access to the DOM. Adding JSDOM as an application dependency was not a route we wanted to go down, when we'd like to perform these operations externally (i.e. at the caching layer) in the future.
- We are adding `linkTextSuffixVisuallyHidden` to implement a missing a11y requirement and renaming existing `endText` and `visuallyHiddenText` for consistency.
- Center Canonical oEmbeds.

### Code changes:
- Readme corrections and updates following the below changes.
- Add changelog entry.
- Bump alpha version.
- Update styles.
- Update snapshots.

#### Lifting dependencies
- Uninstall `@bbc/psammead-oembed` and remove `@loadable/component` peer dependency.

#### API improvements
- Add `linkTextSuffixVisuallyHidden` property to Notice. https://github.com/bbc/psammead/pull/3217#discussion_r396341632
- Rename `endText` to `endTextVisuallyHidden` for consistency.
- Rename `visuallyHiddenText` to `textPrefixVisuallyHidden` for consistency.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~~[ ] This PR requires manual testing~~
