### PR TITLE
Fix radio schedule duration

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.26 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration markup |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |
 | 0.1.0-alpha.24 | [PR#3291](https://github.com/bbc/psammead/pull/3291) Use withServicesKnob `selectedService` prop |
 | 0.1.0-alpha.23 | [PR#3297](https://github.com/bbc/psammead/pull/3297) Use LiveLabel, and pass in translations for next and live |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -280,7 +280,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
       <span
         class="c5"
       >
-         Duration 
+         Duration 30,00 
       </span>
       <span
         aria-hidden="true"
@@ -544,7 +544,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
       <span
         class="c4"
       >
-         Duration 
+         Duration 30,00 
       </span>
       <span
         aria-hidden="true"
@@ -811,7 +811,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
       <span
         class="c4"
       >
-         Duration 
+         Duration 30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1078,7 +1078,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
       <span
         class="c4"
       >
-         المدة الزمنية 
+         المدة الزمنية 30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1341,7 +1341,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
       <span
         class="c5"
       >
-         Duration 
+         Duration 30,00 
       </span>
       <span
         aria-hidden="true"

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -281,7 +281,6 @@ exports[`ProgramCard should render correctly for live 1`] = `
         class="c5"
       >
          Duration 
-        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -546,7 +545,6 @@ exports[`ProgramCard should render correctly for next 1`] = `
         class="c4"
       >
          Duration 
-        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -814,7 +812,6 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
         class="c4"
       >
          Duration 
-        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1082,7 +1079,6 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
         class="c4"
       >
          المدة الزمنية 
-        30,00 
       </span>
       <span
         aria-hidden="true"
@@ -1346,7 +1342,6 @@ exports[`ProgramCard should render correctly without summary 1`] = `
         class="c5"
       >
          Duration 
-        30,00 
       </span>
       <span
         aria-hidden="true"

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -249,9 +249,13 @@ const ProgramCard = ({
       <IconWrapper {...programStateConfig[state]}>
         {mediaIcons.audio}
       </IconWrapper>
-
       <DurationWrapper dir={dir} dateTime={duration}>
-        <VisuallyHiddenText>{` ${durationLabel} `}</VisuallyHiddenText>
+        <VisuallyHiddenText>
+          {` ${durationLabel} ${formatDuration(
+            duration,
+            getDurationFormat(duration, ','),
+          )} `}
+        </VisuallyHiddenText>
         <DurationTextWrapper>
           {formatDuration(duration, getDurationFormat(duration))}
         </DurationTextWrapper>

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -249,11 +249,9 @@ const ProgramCard = ({
       <IconWrapper {...programStateConfig[state]}>
         {mediaIcons.audio}
       </IconWrapper>
+
       <DurationWrapper dir={dir} dateTime={duration}>
-        <VisuallyHiddenText>
-          {` ${durationLabel} `}
-          {`${formatDuration(duration, getDurationFormat(duration, ','))} `}
-        </VisuallyHiddenText>
+        <VisuallyHiddenText>{` ${durationLabel} `}</VisuallyHiddenText>
         <DurationTextWrapper>
           {formatDuration(duration, getDurationFormat(duration))}
         </DurationTextWrapper>

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -683,7 +683,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             Duration 
+             Duration 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -810,7 +810,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             Duration 
+             Duration 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -937,7 +937,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             Duration 
+             Duration 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1065,7 +1065,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             Duration 
+             Duration 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1756,7 +1756,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             المدة الزمنية 
+             المدة الزمنية 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1883,7 +1883,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             المدة الزمنية 
+             المدة الزمنية 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -2010,7 +2010,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             المدة الزمنية 
+             المدة الزمنية 1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -2138,7 +2138,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           <span
             class="c15"
           >
-             المدة الزمنية 
+             المدة الزمنية 1,00,00 
           </span>
           <span
             aria-hidden="true"

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -684,7 +684,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c15"
           >
              Duration 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -812,7 +811,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c15"
           >
              Duration 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -940,7 +938,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c15"
           >
              Duration 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1069,7 +1066,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c15"
           >
              Duration 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1761,7 +1757,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c15"
           >
              المدة الزمنية 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -1889,7 +1884,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c15"
           >
              المدة الزمنية 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -2017,7 +2011,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c15"
           >
              المدة الزمنية 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"
@@ -2146,7 +2139,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c15"
           >
              المدة الزمنية 
-            1,00,00 
           </span>
           <span
             aria-hidden="true"


### PR DESCRIPTION
Resolves #3303

**Overall change:** _Fixed duration being read out twice on iphone voice over._

**Code changes:**

- _Updated the visually hidden text to be in a single string, as previously it was causing the user to have to swipe right twice on iphone voice over in order to hear the duration text._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
