### PR TITLE
Fix FireFox High Contrast Mode for Radio Schedule

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.28 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Fix Duration border on FireFox High Contrast Mode |
+| 0.1.0-alpha.28 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |
 | 0.1.0-alpha.27 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.28 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Fix Duration border on FireFox High Contrast Mode |
 | 0.1.0-alpha.27 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |
 | 0.1.0-alpha.25 | [PR#3302](https://github.com/bbc/psammead/pull/3302) Fix radio schedules duration formatting |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.27",
+  "version": "0.1.0-alpha.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.27",
+  "version": "0.1.0-alpha.28",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -197,6 +197,8 @@ exports[`ProgramCard should render correctly for live 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c8 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -331,7 +333,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -483,6 +485,8 @@ exports[`ProgramCard should render correctly for next 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c7 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -630,7 +634,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -757,6 +761,8 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c7 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -903,7 +909,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1030,6 +1036,8 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c7 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1185,7 +1193,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1287,6 +1295,8 @@ exports[`ProgramCard should render correctly without summary 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c7 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -122,6 +122,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #B80000;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -394,6 +395,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #FFFFFF;
+  outline: 0.0625rem solid transparent;
   color: #11708C;
 }
 
@@ -682,6 +684,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #222222;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -955,6 +958,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #222222;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -1226,6 +1230,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #B80000;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -198,7 +198,6 @@ exports[`ProgramCard should render correctly for live 1`] = `
   .c8 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -486,7 +485,6 @@ exports[`ProgramCard should render correctly for next 1`] = `
   .c7 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -762,7 +760,6 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   .c7 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1037,7 +1034,6 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   .c7 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1296,7 +1292,6 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   .c7 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -331,7 +331,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -630,7 +630,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -903,7 +903,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1185,7 +1185,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -35,7 +35,7 @@ const CardWrapper = styled.div`
   background-color: ${C_WHITE};
   display: flex;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 `;
 
@@ -90,6 +90,8 @@ const ButtonWrapper = styled.div`
   color: ${({ durationColor }) => durationColor};
   @media screen and (-ms-high-contrast: active) {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 `;
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -35,7 +35,7 @@ const CardWrapper = styled.div`
   background-color: ${C_WHITE};
   display: flex;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 `;
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -86,6 +86,7 @@ const ButtonWrapper = styled.div`
   ${({ script }) => script && getMinion(script)};
   padding: ${GEL_SPACING};
   background-color: ${({ backgroundColor }) => backgroundColor};
+  outline: 0.0625rem solid transparent;
   color: ${({ durationColor }) => durationColor};
   @media screen and (-ms-high-contrast: active) {
     background-color: transparent;

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -91,7 +91,6 @@ const ButtonWrapper = styled.div`
   @media screen and (-ms-high-contrast: active) {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 `;
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -397,7 +397,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   .c18 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -419,7 +418,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   .c22 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -441,7 +439,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   .c26 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1501,7 +1498,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c18 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1523,7 +1519,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c22 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1545,7 +1540,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .c26 {
     background-color: transparent;
     outline: none;
-    border-top: 0.0625rem solid transparent;
   }
 }
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -79,7 +79,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1177,7 +1177,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -163,6 +163,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #B80000;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -174,6 +175,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #222222;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -185,6 +187,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #FFFFFF;
+  outline: 0.0625rem solid transparent;
   color: #11708C;
 }
 
@@ -1262,6 +1265,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #B80000;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -1273,6 +1277,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #222222;
+  outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
 
@@ -1284,6 +1289,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   line-height: 1rem;
   padding: 0.5rem;
   background-color: #FFFFFF;
+  outline: 0.0625rem solid transparent;
   color: #11708C;
 }
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -79,7 +79,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -396,6 +396,8 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c18 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -416,6 +418,8 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c22 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -436,6 +440,8 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c26 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1177,7 +1183,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  outline: 0.0625rem solid transparent;
+  border: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1494,6 +1500,8 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c18 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1514,6 +1522,8 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c22 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 
@@ -1534,6 +1544,8 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 @media screen and (-ms-high-contrast:active) {
   .c26 {
     background-color: transparent;
+    outline: none;
+    border-top: 0.0625rem solid transparent;
   }
 }
 


### PR DESCRIPTION
Resolves #3323

**Overall change:** 
Made duration border display in FireFox High Contrast Mode. 
The reason why `outline` is used instead of `border-top` is because during Radio Schedule accessibility swarm UX mentioned that there should be no extra border around the duration button (even if it's invisible) because it adds height.

Before:
<img width="263" alt="Screenshot 2020-04-01 at 11 06 46" src="https://user-images.githubusercontent.com/17802955/78130104-949f7b80-7410-11ea-9f1f-fe9d7872fc65.png">

After:
<img width="263" alt="Screenshot 2020-04-01 at 11 06 34" src="https://user-images.githubusercontent.com/17802955/78130115-99fcc600-7410-11ea-8220-ecd1dafb270c.png">


**Code changes:**

- Added `outline` to duration button.
- Updated snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
