### PR TITLE
Radio Schedules - Update Program Card Heading markup and CSS

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.29 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Program Card Heading markup and CSS to fix issue with AT |
+| 0.1.0-alpha.29 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.28 | [PR#3321](https://github.com/bbc/psammead/pull/3321) Fix radio schedules duration markup |
 | 0.1.0-alpha.27 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.29 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.28 | [PR#3321](https://github.com/bbc/psammead/pull/3321) Fix radio schedules duration markup |
 | 0.1.0-alpha.27 | [PR#3309](https://github.com/bbc/psammead/pull/3309) Fix Program Card styling |
 | 0.1.0-alpha.26 | [PR#3312](https://github.com/bbc/psammead/pull/3312) Fix `ProgramCard` border on Windows High Contrast Mode |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.28",
+  "version": "0.1.0-alpha.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.28",
+  "version": "0.1.0-alpha.29",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -72,7 +72,11 @@ exports[`ProgramCard should render correctly for live 1`] = `
   color: #6E6E73;
 }
 
-.c3:hover .c6,
+.c3:hover .c6 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c3:focus .c6 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -334,7 +338,11 @@ exports[`ProgramCard should render correctly for next 1`] = `
   line-height: 1.25rem;
 }
 
-.c12:hover .c5,
+.c12:hover .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c12:focus .c5 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -634,7 +642,11 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   color: #6E6E73;
 }
 
-.c3:hover .c5,
+.c3:hover .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c3:focus .c5 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -908,7 +920,11 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   color: #6E6E73;
 }
 
-.c3:hover .c5,
+.c3:hover .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c3:focus .c5 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1191,7 +1207,11 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   color: #6E6E73;
 }
 
-.c3:hover .c6,
+.c3:hover .c6 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c3:focus .c6 {
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -1,13 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProgramCard should render correctly for live 1`] = `
-.c10 {
+.c11 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
   fill: currentColor;
   width: 0.8125rem;
   height: 0.75rem;
+}
+
+.c5 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c4 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #B80000;
+  display: inline-block;
+  margin-right: 0.5rem;
+}
+
+.c7 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
 }
 
 .c3 {
@@ -39,25 +72,10 @@ exports[`ProgramCard should render correctly for live 1`] = `
   color: #6E6E73;
 }
 
-.c5 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c4 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #B80000;
-  display: inline-block;
-  margin-right: 0.5rem;
+.c3:hover .c6,
+.c3:focus .c6 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0 {
@@ -92,15 +110,277 @@ exports[`ProgramCard should render correctly for live 1`] = `
   margin: 0;
 }
 
+.c8 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.c9 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.5rem;
+  background-color: #B80000;
+  color: #FFFFFF;
+}
+
+.c10 > svg {
+  color: #FFFFFF;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 0.75rem;
+  margin: 0;
+}
+
+.c12 {
+  padding-left: 0.5rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c9 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c9 {
+    background-color: transparent;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <h3
+      class="c2"
+    >
+      <a
+        class="c3"
+        href="/news/articles/cn7k01xp8kxo"
+      >
+        <span
+          role="text"
+        >
+          <span
+            aria-hidden="true"
+            class="c4"
+            dir="ltr"
+          >
+            LIVE 
+          </span>
+          <span
+            class="c5"
+            lang="en-GB"
+          >
+            Live, 
+          </span>
+        </span>
+        Could a computer ever create better art than a human?
+        <span
+          class="c5"
+        >
+          , 
+          14:54
+          , 
+        </span>
+        <span
+          class="c6 c7"
+        >
+          29/01/1990
+        </span>
+      </a>
+    </h3>
+    <p
+      class="c8"
+    >
+      The critic, author, poet and TV host was known for his witty commentary on international television.
+    </p>
+  </div>
+  <div
+    class="c9"
+  >
+    <span
+      class="c10"
+    >
+      <svg
+        aria-hidden="true"
+        class="c11"
+        focusable="false"
+        height="12px"
+        viewBox="0 0 13 12"
+        width="13px"
+      >
+        <path
+          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+        />
+        <path
+          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+        />
+      </svg>
+    </span>
+    <time
+      class="c12"
+      datetime="PT30M"
+      dir="ltr"
+    >
+      <span
+        class="c5"
+      >
+         Duration 30,00 
+      </span>
+      <span
+        aria-hidden="true"
+        class=""
+      >
+        30:00
+      </span>
+    </time>
+  </div>
+</div>
+`;
+
+exports[`ProgramCard should render correctly for next 1`] = `
+.c10 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c4 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 .c6 {
-  color: #3F3F42;
+  color: #6E6E73;
   padding: 0.5rem 0;
-  display: block;
+  display: inline-block;
+  width: 100%;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
+}
+
+.c12:hover .c5,
+.c12:focus .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-top: 0.5rem;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 0.0625rem solid transparent;
+  height: 100%;
+}
+
+.c1 {
+  padding: 0 0.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c2 {
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  color: #6E6E73;
+  margin: 0;
+}
+
+.c3 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  color: #11708C;
+  display: inline-block;
+  margin-right: 0.5rem;
 }
 
 .c7 {
@@ -121,7 +401,296 @@ exports[`ProgramCard should render correctly for live 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #FFFFFF;
+  color: #11708C;
+}
+
+.c9 > svg {
+  color: #11708C;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 0.75rem;
+  margin: 0;
+}
+
+.c11 {
+  padding-left: 0.5rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c3 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c8 {
+    background-color: transparent;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <h3
+      class="c2"
+    >
+      <span
+        class="c3"
+        dir="ltr"
+      >
+        NEXT 
+      </span>
+      Could a computer ever create better art than a human?
+      <span
+        class="c4"
+      >
+        , 
+        14:54
+        , 
+      </span>
+      <span
+        class="c5 c6"
+      >
+        29/01/1990
+      </span>
+    </h3>
+    <p
+      class="c7"
+    >
+      The critic, author, poet and TV host was known for his witty commentary on international television.
+    </p>
+  </div>
+  <div
+    class="c8"
+  >
+    <span
+      class="c9"
+    >
+      <svg
+        aria-hidden="true"
+        class="c10"
+        focusable="false"
+        height="12px"
+        viewBox="0 0 13 12"
+        width="13px"
+      >
+        <path
+          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+        />
+        <path
+          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+        />
+      </svg>
+    </span>
+    <time
+      class="c11"
+      datetime="PT30M"
+      dir="ltr"
+    >
+      <span
+        class="c4"
+      >
+         Duration 30,00 
+      </span>
+      <span
+        aria-hidden="true"
+        class=""
+      >
+        30:00
+      </span>
+    </time>
+  </div>
+</div>
+`;
+
+exports[`ProgramCard should render correctly for onDemand 1`] = `
+.c10 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c4 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c6 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c3 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c3:hover,
+.c3:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c3:visited {
+  color: #6E6E73;
+}
+
+.c3:hover .c5,
+.c3:focus .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-top: 0.5rem;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 0.0625rem solid transparent;
+  height: 100%;
+}
+
+.c1 {
+  padding: 0 0.5rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c2 {
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  color: #222222;
+  margin: 0;
+}
+
+.c7 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.c8 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.5rem;
+  background-color: #222222;
   color: #FFFFFF;
 }
 
@@ -138,28 +707,28 @@ exports[`ProgramCard should render correctly for live 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
+  .c6 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c6 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -212,40 +781,18 @@ exports[`ProgramCard should render correctly for live 1`] = `
         class="c3"
         href="/news/articles/cn7k01xp8kxo"
       >
+        Could a computer ever create better art than a human?
         <span
-          class=""
-          role="text"
+          class="c4"
         >
-          <span
-            role="text"
-          >
-            <span
-              aria-hidden="true"
-              class="c4"
-              dir="ltr"
-            >
-              LIVE 
-            </span>
-            <span
-              class="c5"
-              lang="en-GB"
-            >
-              Live, 
-            </span>
-          </span>
-          Could a computer ever create better art than a human?
-          <span
-            class="c5"
-          >
-            , 
-            14:54
-            , 
-          </span>
-          <span
-            class="c6"
-          >
-            29/01/1990
-          </span>
+          , 
+          14:54
+          , 
+        </span>
+        <span
+          class="c5 c6"
+        >
+          29/01/1990
         </span>
       </a>
     </h3>
@@ -283,554 +830,13 @@ exports[`ProgramCard should render correctly for live 1`] = `
       dir="ltr"
     >
       <span
-        class="c5"
+        class="c4"
       >
          Duration 30,00 
       </span>
       <span
         aria-hidden="true"
-        class="Duration0 "
-      >
-        30:00
-      </span>
-    </time>
-  </div>
-</div>
-`;
-
-exports[`ProgramCard should render correctly for next 1`] = `
-.c9 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c4 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c0 {
-  padding-top: 0.5rem;
-  background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  border: 0.0625rem solid transparent;
-  height: 100%;
-}
-
-.c1 {
-  padding: 0 0.5rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c2 {
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  color: #6E6E73;
-  margin: 0;
-}
-
-.c3 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  color: #11708C;
-  display: inline-block;
-  margin-right: 0.5rem;
-}
-
-.c5 {
-  color: #6E6E73;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-.c6 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  padding-bottom: 1rem;
-  margin: 0;
-}
-
-.c7 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  padding: 0.5rem;
-  background-color: #FFFFFF;
-  color: #11708C;
-}
-
-.c8 > svg {
-  color: #11708C;
-  fill: currentColor;
-  width: 1.0625rem;
-  height: 0.75rem;
-  margin: 0;
-}
-
-.c10 {
-  padding-left: 0.5rem;
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c3 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c5 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c6 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
-    font-size: 0.75rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c7 {
-    font-size: 0.75rem;
-    line-height: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c7 {
-    background-color: transparent;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <h3
-      class="c2"
-    >
-      <span
         class=""
-        role="text"
-      >
-        <span
-          class="c3"
-          dir="ltr"
-        >
-          NEXT 
-        </span>
-        Could a computer ever create better art than a human?
-        <span
-          class="c4"
-        >
-          , 
-          14:54
-          , 
-        </span>
-        <span
-          class="c5"
-        >
-          29/01/1990
-        </span>
-      </span>
-    </h3>
-    <p
-      class="c6"
-    >
-      The critic, author, poet and TV host was known for his witty commentary on international television.
-    </p>
-  </div>
-  <div
-    class="c7"
-  >
-    <span
-      class="c8"
-    >
-      <svg
-        aria-hidden="true"
-        class="c9"
-        focusable="false"
-        height="12px"
-        viewBox="0 0 13 12"
-        width="13px"
-      >
-        <path
-          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-        />
-        <path
-          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-        />
-      </svg>
-    </span>
-    <time
-      class="c10"
-      datetime="PT30M"
-      dir="ltr"
-    >
-      <span
-        class="c4"
-      >
-         Duration 30,00 
-      </span>
-      <span
-        aria-hidden="true"
-        class="Duration0 "
-      >
-        30:00
-      </span>
-    </time>
-  </div>
-</div>
-`;
-
-exports[`ProgramCard should render correctly for onDemand 1`] = `
-.c9 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c3 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c3:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c3:hover,
-.c3:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c3:visited {
-  color: #6E6E73;
-}
-
-.c4 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c0 {
-  padding-top: 0.5rem;
-  background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  border: 0.0625rem solid transparent;
-  height: 100%;
-}
-
-.c1 {
-  padding: 0 0.5rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c2 {
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  color: #222222;
-  margin: 0;
-}
-
-.c5 {
-  color: #3F3F42;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-.c6 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  padding-bottom: 1rem;
-  margin: 0;
-}
-
-.c7 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  padding: 0.5rem;
-  background-color: #222222;
-  color: #FFFFFF;
-}
-
-.c8 > svg {
-  color: #FFFFFF;
-  fill: currentColor;
-  width: 1.0625rem;
-  height: 0.75rem;
-  margin: 0;
-}
-
-.c10 {
-  padding-left: 0.5rem;
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c5 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c6 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
-    font-size: 0.75rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c7 {
-    font-size: 0.75rem;
-    line-height: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c7 {
-    background-color: transparent;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <h3
-      class="c2"
-    >
-      <a
-        class="c3"
-        href="/news/articles/cn7k01xp8kxo"
-      >
-        <span
-          class=""
-          role="text"
-        >
-          Could a computer ever create better art than a human?
-          <span
-            class="c4"
-          >
-            , 
-            14:54
-            , 
-          </span>
-          <span
-            class="c5"
-          >
-            29/01/1990
-          </span>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="c6"
-    >
-      The critic, author, poet and TV host was known for his witty commentary on international television.
-    </p>
-  </div>
-  <div
-    class="c7"
-  >
-    <span
-      class="c8"
-    >
-      <svg
-        aria-hidden="true"
-        class="c9"
-        focusable="false"
-        height="12px"
-        viewBox="0 0 13 12"
-        width="13px"
-      >
-        <path
-          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-        />
-        <path
-          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-        />
-      </svg>
-    </span>
-    <time
-      class="c10"
-      datetime="PT30M"
-      dir="ltr"
-    >
-      <span
-        class="c4"
-      >
-         Duration 30,00 
-      </span>
-      <span
-        aria-hidden="true"
-        class="Duration0 "
       >
         30:00
       </span>
@@ -840,13 +846,37 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
 `;
 
 exports[`ProgramCard should render correctly in RTL 1`] = `
-.c9 {
+.c10 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
   fill: currentColor;
   width: 0.8125rem;
   height: 0.75rem;
+}
+
+.c4 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c6 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
 }
 
 .c3 {
@@ -878,16 +908,10 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   color: #6E6E73;
 }
 
-.c4 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
+.c3:hover .c5,
+.c3:focus .c5 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0 {
@@ -922,18 +946,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   margin: 0;
 }
 
-.c5 {
-  color: #3F3F42;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 1rem;
-  line-height: 1.625rem;
-}
-
-.c6 {
+.c7 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -944,7 +957,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   margin: 0;
 }
 
-.c7 {
+.c8 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -955,7 +968,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   color: #FFFFFF;
 }
 
-.c8 > svg {
+.c9 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -963,11 +976,25 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   margin: 0;
 }
 
-.c10 {
+.c11 {
   padding-right: 0.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
+  .c6 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
   .c2 {
     font-size: 1.25rem;
     line-height: 1.625rem;
@@ -978,53 +1005,39 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   .c2 {
     font-size: 1.25rem;
     line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c5 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c6 {
-    font-size: 1.125rem;
-    line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c7 {
+  .c8 {
     background-color: transparent;
   }
 }
@@ -1042,41 +1055,36 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
         class="c3"
         href="/arabic/articles/c1er5mjnznzo"
       >
+        لماذا يخجل البعض من اسم قريته في مصر؟
         <span
-          class=""
-          role="text"
+          class="c4"
         >
-          لماذا يخجل البعض من اسم قريته في مصر؟
-          <span
-            class="c4"
-          >
-            , 
-            ١٤:٥٤
-            , 
-          </span>
-          <span
-            class="c5"
-          >
-            29/01/1990
-          </span>
+          , 
+          ١٤:٥٤
+          , 
+        </span>
+        <span
+          class="c5 c6"
+        >
+          29/01/1990
         </span>
       </a>
     </h3>
     <p
-      class="c6"
+      class="c7"
     >
       هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
     </p>
   </div>
   <div
-    class="c7"
+    class="c8"
   >
     <span
-      class="c8"
+      class="c9"
     >
       <svg
         aria-hidden="true"
-        class="c9"
+        class="c10"
         focusable="false"
         height="12px"
         viewBox="0 0 13 12"
@@ -1091,7 +1099,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
       </svg>
     </span>
     <time
-      class="c10"
+      class="c11"
       datetime="PT30M"
       dir="rtl"
     >
@@ -1102,7 +1110,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
       </span>
       <span
         aria-hidden="true"
-        class="Duration0 "
+        class=""
       >
         30:00
       </span>
@@ -1112,42 +1120,13 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
 `;
 
 exports[`ProgramCard should render correctly without summary 1`] = `
-.c9 {
+.c10 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
   fill: currentColor;
   width: 0.8125rem;
   height: 0.75rem;
-}
-
-.c3 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c3:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c3:hover,
-.c3:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c3:visited {
-  color: #6E6E73;
 }
 
 .c5 {
@@ -1171,6 +1150,53 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   margin-right: 0.5rem;
 }
 
+.c7 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c3 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c3:hover,
+.c3:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c3:visited {
+  color: #6E6E73;
+}
+
+.c3:hover .c6,
+.c3:focus .c6 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c0 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
@@ -1203,18 +1229,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   margin: 0;
 }
 
-.c6 {
-  color: #3F3F42;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-.c7 {
+.c8 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1225,7 +1240,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   color: #FFFFFF;
 }
 
-.c8 > svg {
+.c9 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1233,54 +1248,54 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   margin: 0;
 }
 
-.c10 {
+.c11 {
   padding-left: 0.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c2 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c6 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c7 {
+  .c8 {
     background-color: transparent;
   }
 }
@@ -1299,52 +1314,47 @@ exports[`ProgramCard should render correctly without summary 1`] = `
         href="/news/articles/cn7k01xp8kxo"
       >
         <span
-          class=""
           role="text"
         >
           <span
-            role="text"
+            aria-hidden="true"
+            class="c4"
+            dir="ltr"
           >
-            <span
-              aria-hidden="true"
-              class="c4"
-              dir="ltr"
-            >
-              LIVE 
-            </span>
-            <span
-              class="c5"
-              lang="en-GB"
-            >
-              Live, 
-            </span>
+            LIVE 
           </span>
-          Could a computer ever create better art than a human?
           <span
             class="c5"
+            lang="en-GB"
           >
-            , 
-            14:54
-            , 
+            Live, 
           </span>
-          <span
-            class="c6"
-          >
-            29/01/1990
-          </span>
+        </span>
+        Could a computer ever create better art than a human?
+        <span
+          class="c5"
+        >
+          , 
+          14:54
+          , 
+        </span>
+        <span
+          class="c6 c7"
+        >
+          29/01/1990
         </span>
       </a>
     </h3>
   </div>
   <div
-    class="c7"
+    class="c8"
   >
     <span
-      class="c8"
+      class="c9"
     >
       <svg
         aria-hidden="true"
-        class="c9"
+        class="c10"
         focusable="false"
         height="12px"
         viewBox="0 0 13 12"
@@ -1359,7 +1369,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
       </svg>
     </span>
     <time
-      class="c10"
+      class="c11"
       datetime="PT30M"
       dir="ltr"
     >
@@ -1370,7 +1380,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
       </span>
       <span
         aria-hidden="true"
-        class="Duration0 "
+        class=""
       >
         30:00
       </span>

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -40,7 +40,11 @@ const TitleWrapper = styled.span`
 `;
 
 const StyledLink = styled(Link)`
-  &:hover ${TitleWrapper}, &:focus ${TitleWrapper} {
+  &:hover ${TitleWrapper} {
+    text-decoration: underline;
+  }
+
+  &:focus ${TitleWrapper} {
     text-decoration: underline;
   }
 `;

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -30,6 +30,21 @@ import {
   formatDuration,
 } from '@bbc/psammead-timestamp-container/utilities';
 
+const TitleWrapper = styled.span`
+  color: ${({ titleColor }) => titleColor};
+  padding: ${GEL_SPACING} 0;
+  display: inline-block;
+  width: 100%;
+  ${({ service }) => service && getSansRegular(service)};
+  ${({ script }) => script && getPica(script)};
+`;
+
+const StyledLink = styled(Link)`
+  &:hover ${TitleWrapper}, &:focus ${TitleWrapper} {
+    text-decoration: underline;
+  }
+`;
+
 const CardWrapper = styled.div`
   padding-top: ${GEL_SPACING};
   background-color: ${C_WHITE};
@@ -44,14 +59,12 @@ const TextWrapper = styled.div`
   flex-grow: 1;
 `;
 
-const HeadingWrapper = styled.h3`
+const StyledH3 = styled.h3`
   ${({ service }) => service && getSerifMedium(service)};
   ${({ script }) => script && getPica(script)};
   color: ${({ headerTextColor }) => headerTextColor};
   margin: 0; /* Reset */
 `;
-
-const HeadingContentWrapper = styled.span.attrs({ role: 'text' })``;
 
 const NextLabel = styled.span`
   ${({ service }) => service && getSansBold(service)};
@@ -63,14 +76,6 @@ const NextLabel = styled.span`
     dir === 'rtl'
       ? `margin-left: ${GEL_SPACING};`
       : `margin-right: ${GEL_SPACING};`}
-`;
-
-const TitleWrapper = styled.span`
-  color: ${({ titleColor }) => titleColor};
-  padding: ${GEL_SPACING} 0;
-  display: block;
-  ${({ service }) => service && getSansRegular(service)};
-  ${({ script }) => script && getPica(script)};
 `;
 
 const SummaryWrapper = styled.p`
@@ -160,7 +165,7 @@ const renderHeaderContent = ({
   );
 
   const content = (
-    <HeadingContentWrapper>
+    <>
       {isLive && (
         <LiveLabel
           service={service}
@@ -184,10 +189,14 @@ const renderHeaderContent = ({
       >
         {episodeTitle}
       </TitleWrapper>
-    </HeadingContentWrapper>
+    </>
   );
 
-  return state === 'next' ? content : <Link href={link}>{content}</Link>;
+  return state === 'next' ? (
+    content
+  ) : (
+    <StyledLink href={link}>{content}</StyledLink>
+  );
 };
 
 const getDurationFormat = (duration, separator = ':') => {
@@ -217,7 +226,7 @@ const ProgramCard = ({
 }) => (
   <CardWrapper>
     <TextWrapper>
-      <HeadingWrapper
+      <StyledH3
         service={service}
         script={script}
         {...programStateConfig[state]}
@@ -236,7 +245,7 @@ const ProgramCard = ({
           locale,
           dir,
         })}
-      </HeadingWrapper>
+      </StyledH3>
       {summary && (
         <SummaryWrapper service={service} script={script}>
           {summary}

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -10,13 +10,58 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c20 {
+.c21 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
   fill: currentColor;
   width: 0.8125rem;
   height: 0.75rem;
+}
+
+.c15 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c14 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #B80000;
+  display: inline-block;
+  margin-right: 0.5rem;
+}
+
+.c17 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c26 {
+  color: #6E6E73;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
 }
 
 .c13 {
@@ -48,25 +93,10 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c15 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c14 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #B80000;
-  display: inline-block;
-  margin-right: 0.5rem;
+.c13:hover .c16,
+.c13:focus .c16 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c10 {
@@ -101,7 +131,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
@@ -111,7 +141,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -122,29 +152,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.c16 {
-  color: #3F3F42;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-.c25 {
-  color: #6E6E73;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-.c17 {
+.c18 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -155,7 +163,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c18 {
+.c19 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -166,7 +174,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c22 {
+.c23 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -177,7 +185,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c26 {
+.c27 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -188,7 +196,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c19 > svg {
+.c20 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -196,7 +204,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c27 > svg {
+.c28 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -204,7 +212,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c21 {
+.c22 {
   padding-left: 0.5rem;
 }
 
@@ -293,145 +301,145 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c12 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c23 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c24 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c16 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c16 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c25 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c26 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c26 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c12 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c12 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c24 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c25 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c25 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c18 {
+  .c19 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c22 {
+  .c23 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     background-color: transparent;
   }
 }
@@ -626,57 +634,52 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
-              class=""
               role="text"
             >
               <span
-                role="text"
+                aria-hidden="true"
+                class="c14"
+                dir="ltr"
               >
-                <span
-                  aria-hidden="true"
-                  class="c14"
-                  dir="ltr"
-                >
-                  LIVE 
-                </span>
-                <span
-                  class="c15"
-                  lang="en-GB"
-                >
-                  Live, 
-                </span>
+                LIVE 
               </span>
-              Could a computer ever create better art than a human?
               <span
                 class="c15"
+                lang="en-GB"
               >
-                , 
-                14:54
-                , 
+                Live, 
               </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+            </span>
+            Could a computer ever create better art than a human?
+            <span
+              class="c15"
+            >
+              , 
+              14:54
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c18"
+        class="c19"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -691,7 +694,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
@@ -702,7 +705,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -769,41 +772,36 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
+            Could a computer ever create better art than a human?
             <span
-              class=""
-              role="text"
+              class="c15"
             >
-              Could a computer ever create better art than a human?
-              <span
-                class="c15"
-              >
-                , 
-                14:54
-                , 
-              </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+              , 
+              14:54
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -818,7 +816,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
@@ -829,7 +827,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -896,41 +894,36 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
+            Could a computer ever create better art than a human?
             <span
-              class=""
-              role="text"
+              class="c15"
             >
-              Could a computer ever create better art than a human?
-              <span
-                class="c15"
-              >
-                , 
-                14:54
-                , 
-              </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+              , 
+              14:54
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -945,7 +938,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
@@ -956,7 +949,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -1017,48 +1010,43 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
         class="c11"
       >
         <h3
-          class="c23"
+          class="c24"
         >
           <span
-            class=""
-            role="text"
+            class="c25"
+            dir="ltr"
           >
-            <span
-              class="c24"
-              dir="ltr"
-            >
-              NEXT 
-            </span>
-            Could a computer ever create better art than a human?
-            <span
-              class="c15"
-            >
-              , 
-              14:54
-              , 
-            </span>
-            <span
-              class="c25"
-            >
-              29/01/1990
-            </span>
+            NEXT 
+          </span>
+          Could a computer ever create better art than a human?
+          <span
+            class="c15"
+          >
+            , 
+            14:54
+            , 
+          </span>
+          <span
+            class="c16 c26"
+          >
+            29/01/1990
           </span>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           The critic, author, poet and TV host was known for his witty commentary on international television.
         </p>
       </div>
       <div
-        class="c26"
+        class="c27"
       >
         <span
-          class="c27"
+          class="c28"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1073,7 +1061,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="ltr"
         >
@@ -1084,7 +1072,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -1105,13 +1093,58 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   height: 0.725rem;
 }
 
-.c20 {
+.c21 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
   fill: currentColor;
   width: 0.8125rem;
   height: 0.75rem;
+}
+
+.c15 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c14 {
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #B80000;
+  display: inline-block;
+  margin-left: 0.5rem;
+}
+
+.c17 {
+  color: #3F3F42;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
+}
+
+.c26 {
+  color: #6E6E73;
+  padding: 0.5rem 0;
+  display: inline-block;
+  width: 100%;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
 }
 
 .c13 {
@@ -1143,25 +1176,10 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c15 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c14 {
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #B80000;
-  display: inline-block;
-  margin-left: 0.5rem;
+.c13:hover .c16,
+.c13:focus .c16 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c10 {
@@ -1196,7 +1214,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1206,7 +1224,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1217,29 +1235,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin-left: 0.5rem;
 }
 
-.c16 {
-  color: #3F3F42;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 1rem;
-  line-height: 1.625rem;
-}
-
-.c25 {
-  color: #6E6E73;
-  padding: 0.5rem 0;
-  display: block;
-  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 1rem;
-  line-height: 1.625rem;
-}
-
-.c17 {
+.c18 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1250,7 +1246,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c18 {
+.c19 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1261,7 +1257,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c22 {
+.c23 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1272,7 +1268,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #FFFFFF;
 }
 
-.c26 {
+.c27 {
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1283,7 +1279,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #11708C;
 }
 
-.c19 > svg {
+.c20 > svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1291,7 +1287,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c27 > svg {
+.c28 > svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -1299,7 +1295,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
-.c21 {
+.c22 {
   padding-right: 0.5rem;
 }
 
@@ -1388,28 +1384,42 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c17 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
+  .c17 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c23 {
+  .c26 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c26 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c12 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c12 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
@@ -1430,20 +1440,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c16 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c16 {
-    font-size: 1.25rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c25 {
     font-size: 1.25rem;
     line-height: 1.625rem;
@@ -1458,75 +1454,75 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c18 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c18 {
+  .c19 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c18 {
+  .c19 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c22 {
+  .c23 {
     background-color: transparent;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     background-color: transparent;
   }
 }
@@ -1721,50 +1717,45 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
-              class=""
               role="text"
             >
               <span
-                role="text"
+                class="c14"
+                dir="rtl"
               >
-                <span
-                  class="c14"
-                  dir="rtl"
-                >
-                  مباشر 
-                </span>
+                مباشر 
               </span>
-              لماذا يخجل البعض من اسم قريته في مصر؟
-              <span
-                class="c15"
-              >
-                , 
-                ۱۴:۵۴
-                , 
-              </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+            </span>
+            لماذا يخجل البعض من اسم قريته في مصر؟
+            <span
+              class="c15"
+            >
+              , 
+              ۱۴:۵۴
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c18"
+        class="c19"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1779,7 +1770,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
@@ -1790,7 +1781,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -1857,41 +1848,36 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
+            لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class=""
-              role="text"
+              class="c15"
             >
-              لماذا يخجل البعض من اسم قريته في مصر؟
-              <span
-                class="c15"
-              >
-                , 
-                ۱۴:۵۴
-                , 
-              </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+              , 
+              ۱۴:۵۴
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1906,7 +1892,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
@@ -1917,7 +1903,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -1984,41 +1970,36 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
+            لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class=""
-              role="text"
+              class="c15"
             >
-              لماذا يخجل البعض من اسم قريته في مصر؟
-              <span
-                class="c15"
-              >
-                , 
-                ۱۴:۵۴
-                , 
-              </span>
-              <span
-                class="c16"
-              >
-                29/01/1990
-              </span>
+              , 
+              ۱۴:۵۴
+              , 
+            </span>
+            <span
+              class="c16 c17"
+            >
+              29/01/1990
             </span>
           </a>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c22"
+        class="c23"
       >
         <span
-          class="c19"
+          class="c20"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2033,7 +2014,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
@@ -2044,7 +2025,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>
@@ -2105,48 +2086,43 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
         class="c11"
       >
         <h3
-          class="c23"
+          class="c24"
         >
           <span
-            class=""
-            role="text"
+            class="c25"
+            dir="rtl"
           >
-            <span
-              class="c24"
-              dir="rtl"
-            >
-              مباشر 
-            </span>
-            لماذا يخجل البعض من اسم قريته في مصر؟
-            <span
-              class="c15"
-            >
-              , 
-              ۱۴:۵۴
-              , 
-            </span>
-            <span
-              class="c25"
-            >
-              29/01/1990
-            </span>
+            مباشر 
+          </span>
+          لماذا يخجل البعض من اسم قريته في مصر؟
+          <span
+            class="c15"
+          >
+            , 
+            ۱۴:۵۴
+            , 
+          </span>
+          <span
+            class="c16 c26"
+          >
+            29/01/1990
           </span>
         </h3>
         <p
-          class="c17"
+          class="c18"
         >
           هناك وقائع عدة تتسم بالسخرية والجدل والتنمر، ضد أهل القرية الذين أصابهم الغضب والسخط مما دفعهم إلى تقديم طلب لتغيير اسم قريتهم.
         </p>
       </div>
       <div
-        class="c26"
+        class="c27"
       >
         <span
-          class="c27"
+          class="c28"
         >
           <svg
             aria-hidden="true"
-            class="c20"
+            class="c21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -2161,7 +2137,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </svg>
         </span>
         <time
-          class="c21"
+          class="c22"
           datetime="PT1H"
           dir="rtl"
         >
@@ -2172,7 +2148,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           </span>
           <span
             aria-hidden="true"
-            class="Duration0 "
+            class=""
           >
             1:00:00
           </span>

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -93,7 +93,11 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c13:hover .c16,
+.c13:hover .c16 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c13:focus .c16 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1176,7 +1180,11 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   color: #6E6E73;
 }
 
-.c13:hover .c16,
+.c13:hover .c16 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c13:focus .c16 {
   -webkit-text-decoration: underline;
   text-decoration: underline;


### PR DESCRIPTION
Resolves #3305

**Overall change:** 
Update Program Card Heading markup and CSS to fix a11y bugs explained in the [issue](https://github.com/bbc/psammead/issues/3305).

**Code changes:**
- Remove `HeadingContentWrapper` as @greenc05 pointed in https://github.com/bbc/psammead/pull/3297#discussion_r401024955
- Replace `display:inline` with `display:inline-block` in the `TitleWrapper` span to fix the a11y bug. These changes require:
  - Apply a `width: 100%` so it stays under the headline
  - Apply the `text-decoration: underline;` when hovering or focus over the Link, otherwise it just underlines the first part of the h3

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
