### PR TITLE
Invalid HTML bug in section label

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.3 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Remove a `div` nested within the `h2` element |
+| 5.0.3 | [PR#3316](https://github.com/bbc/psammead/pull/3316) Replace a `div` with a `span` tag to fix invalid HTML syntax |
 | 5.0.2 | [PR#3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
 | 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.3 | [PR#3316](https://github.com/bbc/psammead/pull/3316) Replace a `div` with a `span` tag to fix invalid HTML syntax |
+| 5.0.3 | [PR#3328](https://github.com/bbc/psammead/pull/3328) Replace a `div` with a `span` tag to fix invalid HTML syntax |
 | 5.0.2 | [PR#3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
 | 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.3 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Remove a `div` nested within the `h2` element |
 | 5.0.2 | [PR#3262](https://github.com/bbc/psammead/pull/3262) Add `backgroundColor` prop |
 | 5.0.1 | [PR#3195](https://github.com/bbc/psammead/pull/3195) Define `z-index` on section-label wrapper |
 | 5.0.0 | [PR#3133](https://github.com/bbc/psammead/pull/3133) Change background colour from white to ghost |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -122,7 +122,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   <h2
     class="c1"
   >
-    <div
+    <span
       class="c2"
     >
       <span
@@ -136,7 +136,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
           This is the text in a SectionLabel
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -336,7 +336,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
       class="c3"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c4"
       >
         <span
@@ -358,7 +358,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -559,7 +559,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
       class="c3"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c4"
       >
         <span
@@ -581,7 +581,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -782,7 +782,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
       class="c3"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c4"
       >
         <span
@@ -804,7 +804,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -1005,7 +1005,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
       class="c3"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c4"
       >
         <span
@@ -1027,7 +1027,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -1170,7 +1170,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
   <h2
     class="c2"
   >
-    <div
+    <span
       class="c3"
     >
       <span
@@ -1184,7 +1184,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
           This is text in a SectionLabel.
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -1326,7 +1326,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   <h2
     class="c2"
   >
-    <div
+    <span
       class="c3"
     >
       <span
@@ -1340,7 +1340,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
           بعض محتوى النص
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -1482,7 +1482,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   <h2
     class="c2"
   >
-    <div
+    <span
       class="c3"
     >
       <span
@@ -1496,7 +1496,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
           This is text in a SectionLabel rendering in ltr mode.
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -1638,7 +1638,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   <h2
     class="c2"
   >
-    <div
+    <span
       class="c3"
     >
       <span
@@ -1652,7 +1652,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
           This is text in a SectionLabel, and there is a bar over to the right
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -1829,7 +1829,7 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
       class="c2"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c3"
       >
         <span
@@ -1851,7 +1851,7 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -2029,7 +2029,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
       class="c2"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c3"
       >
         <span
@@ -2051,7 +2051,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -2229,7 +2229,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
       class="c2"
       href="/igbo/other-index"
     >
-      <div
+      <span
         class="c3"
       >
         <span
@@ -2251,7 +2251,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
             See All
           </span>
         </span>
-      </div>
+      </span>
     </a>
   </h2>
 </div>
@@ -2371,7 +2371,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
   <h2
     class="c1"
   >
-    <div
+    <span
       class="c2"
     >
       <span
@@ -2385,7 +2385,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
           This is text in a SectionLabel.
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -2504,7 +2504,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <h2
     class="c1"
   >
-    <div
+    <span
       class="c2"
     >
       <span
@@ -2518,7 +2518,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
           بعض محتوى النص
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;
@@ -2637,7 +2637,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <h2
     class="c1"
   >
-    <div
+    <span
       class="c2"
     >
       <span
@@ -2651,7 +2651,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
           This is text in a SectionLabel rendering in ltr mode.
         </span>
       </span>
-    </div>
+    </span>
   </h2>
 </div>
 `;

--- a/packages/components/psammead-section-label/src/titles.jsx
+++ b/packages/components/psammead-section-label/src/titles.jsx
@@ -23,7 +23,7 @@ const paddingReverseDir = ({ dir }) =>
 // This makes it work right. I don't fully understand how, but am
 // eternally grateful to the Flexbugs project.
 // https://github.com/philipwalton/flexbugs#flexbug-3
-const FlexColumn = styled.div`
+const FlexColumn = styled.span`
   display: flex;
   flex-direction: column;
 `;


### PR DESCRIPTION
Resolves #3316

**Overall change:** 
Replaced a `div` with a `span` within section label to fix invalid HTML syntax (`div` nested within an `h2` element).
New DOM structure:
<img width="798" alt="Screenshot 2020-04-02 at 18 07 30" src="https://user-images.githubusercontent.com/17802955/78278065-65baff80-750d-11ea-9fb7-b02a6bc48276.png">

**Code changes:**
- Replaced a `div` with a `span` in section label.
- Updated snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
