### PR TITLE
Remove white border from Program Card

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.32 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Remove border from Program Card |
 | 0.1.0-alpha.31 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.30 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |
 | 0.1.0-alpha.29 | [PR#3318](https://github.com/bbc/psammead/pull/3318) Fix `StartTime` clock icon styling in Safari |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.32 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Remove border from Program Card |
+| 0.1.0-alpha.32 | [PR#3345](https://github.com/bbc/psammead/pull/3345) Remove border from Program Card |
 | 0.1.0-alpha.31 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.30 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |
 | 0.1.0-alpha.29 | [PR#3318](https://github.com/bbc/psammead/pull/3318) Fix `StartTime` clock icon styling in Safari |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.31",
+  "version": "0.1.0-alpha.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.31",
+  "version": "0.1.0-alpha.32",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -92,7 +92,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -360,7 +360,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -666,7 +666,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -946,7 +946,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1235,7 +1235,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -54,7 +54,7 @@ const CardWrapper = styled.div`
   background-color: ${C_WHITE};
   display: flex;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 `;
 

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -113,7 +113,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 
@@ -1207,7 +1207,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border: 0.0625rem solid transparent;
+  outline: 0.0625rem solid transparent;
   height: 100%;
 }
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Duration button was not completely adjacent to Card Wrapper because of the 1px border. Border is now replaced with outline, so the duration button sticks to the program card while FireFox high contrast mode still maintains the borders visible.

Before:

<img width="265" alt="Screenshot 2020-04-07 at 14 23 47" src="https://user-images.githubusercontent.com/17802955/78675940-aafc7a00-78dd-11ea-988d-122f622f7c31.png">

After:

<img width="299" alt="Screenshot 2020-04-07 at 14 24 54" src="https://user-images.githubusercontent.com/17802955/78675961-b0f25b00-78dd-11ea-9494-326a78dcb025.png">

High Contrast mode in FireFox:

<img width="364" alt="Screenshot 2020-04-07 at 14 39 47" src="https://user-images.githubusercontent.com/17802955/78675981-b94a9600-78dd-11ea-8127-23657b12eadf.png">


**Code changes:**

- Replaced `border` with `outline` in `CardWrapper`.
- Updated snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
