### PR TITLE
Radio Schedules - Fix VoiceOver bug with the NEXT card headline

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.33 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add wrapping span with role `text` around the headline |
+| 0.1.0-alpha.33 | [PR#3348](https://github.com/bbc/psammead/pull/3348) Add wrapping span with role `text` around the headline |
 | 0.1.0-alpha.32 | [PR#3345](https://github.com/bbc/psammead/pull/3345) Remove border from Program Card |
 | 0.1.0-alpha.31 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.30 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.33 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add wrapping span with role `text` around the headline |
 | 0.1.0-alpha.32 | [PR#3345](https://github.com/bbc/psammead/pull/3345) Remove border from Program Card |
 | 0.1.0-alpha.31 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
 | 0.1.0-alpha.30 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.32",
+  "version": "0.1.0-alpha.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "0.1.0-alpha.32",
+  "version": "0.1.0-alpha.33",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -226,34 +226,39 @@ exports[`ProgramCard should render correctly for live 1`] = `
         href="/news/articles/cn7k01xp8kxo"
       >
         <span
+          class=""
           role="text"
         >
           <span
-            aria-hidden="true"
-            class="c4"
-            dir="ltr"
+            role="text"
           >
-            LIVE 
+            <span
+              aria-hidden="true"
+              class="c4"
+              dir="ltr"
+            >
+              LIVE 
+            </span>
+            <span
+              class="c5"
+              lang="en-GB"
+            >
+              Live, 
+            </span>
           </span>
+          Could a computer ever create better art than a human?
           <span
             class="c5"
-            lang="en-GB"
           >
-            Live, 
+            , 
+            14:54
+            , 
           </span>
-        </span>
-        Could a computer ever create better art than a human?
-        <span
-          class="c5"
-        >
-          , 
-          14:54
-          , 
-        </span>
-        <span
-          class="c6 c7"
-        >
-          29/01/1990
+          <span
+            class="c6 c7"
+          >
+            29/01/1990
+          </span>
         </span>
       </a>
     </h3>
@@ -515,23 +520,28 @@ exports[`ProgramCard should render correctly for next 1`] = `
       class="c2"
     >
       <span
-        class="c3"
-        dir="ltr"
+        class=""
+        role="text"
       >
-        NEXT 
-      </span>
-      Could a computer ever create better art than a human?
-      <span
-        class="c4"
-      >
-        , 
-        14:54
-        , 
-      </span>
-      <span
-        class="c5 c6"
-      >
-        29/01/1990
+        <span
+          class="c3"
+          dir="ltr"
+        >
+          NEXT 
+        </span>
+        Could a computer ever create better art than a human?
+        <span
+          class="c4"
+        >
+          , 
+          14:54
+          , 
+        </span>
+        <span
+          class="c5 c6"
+        >
+          29/01/1990
+        </span>
       </span>
     </h3>
     <p
@@ -799,18 +809,23 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
         class="c3"
         href="/news/articles/cn7k01xp8kxo"
       >
-        Could a computer ever create better art than a human?
         <span
-          class="c4"
+          class=""
+          role="text"
         >
-          , 
-          14:54
-          , 
-        </span>
-        <span
-          class="c5 c6"
-        >
-          29/01/1990
+          Could a computer ever create better art than a human?
+          <span
+            class="c4"
+          >
+            , 
+            14:54
+            , 
+          </span>
+          <span
+            class="c5 c6"
+          >
+            29/01/1990
+          </span>
         </span>
       </a>
     </h3>
@@ -1079,18 +1094,23 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
         class="c3"
         href="/arabic/articles/c1er5mjnznzo"
       >
-        لماذا يخجل البعض من اسم قريته في مصر؟
         <span
-          class="c4"
+          class=""
+          role="text"
         >
-          , 
-          ١٤:٥٤
-          , 
-        </span>
-        <span
-          class="c5 c6"
-        >
-          29/01/1990
+          لماذا يخجل البعض من اسم قريته في مصر؟
+          <span
+            class="c4"
+          >
+            , 
+            ١٤:٥٤
+            , 
+          </span>
+          <span
+            class="c5 c6"
+          >
+            29/01/1990
+          </span>
         </span>
       </a>
     </h3>
@@ -1344,34 +1364,39 @@ exports[`ProgramCard should render correctly without summary 1`] = `
         href="/news/articles/cn7k01xp8kxo"
       >
         <span
+          class=""
           role="text"
         >
           <span
-            aria-hidden="true"
-            class="c4"
-            dir="ltr"
+            role="text"
           >
-            LIVE 
+            <span
+              aria-hidden="true"
+              class="c4"
+              dir="ltr"
+            >
+              LIVE 
+            </span>
+            <span
+              class="c5"
+              lang="en-GB"
+            >
+              Live, 
+            </span>
           </span>
+          Could a computer ever create better art than a human?
           <span
             class="c5"
-            lang="en-GB"
           >
-            Live, 
+            , 
+            14:54
+            , 
           </span>
-        </span>
-        Could a computer ever create better art than a human?
-        <span
-          class="c5"
-        >
-          , 
-          14:54
-          , 
-        </span>
-        <span
-          class="c6 c7"
-        >
-          29/01/1990
+          <span
+            class="c6 c7"
+          >
+            29/01/1990
+          </span>
         </span>
       </a>
     </h3>

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -143,6 +143,8 @@ const programStateConfig = {
   },
 };
 
+const HeadingContentWrapper = styled.span.attrs({ role: 'text' })``;
+
 const renderHeaderContent = ({
   state,
   link,
@@ -171,7 +173,7 @@ const renderHeaderContent = ({
   );
 
   const content = (
-    <>
+    <HeadingContentWrapper>
       {isLive && (
         <LiveLabel
           service={service}
@@ -195,7 +197,7 @@ const renderHeaderContent = ({
       >
         {episodeTitle}
       </TitleWrapper>
-    </>
+    </HeadingContentWrapper>
   );
 
   return state === 'next' ? (

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -645,34 +645,39 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             href="/news/articles/cn7k01xp8kxo"
           >
             <span
+              class=""
               role="text"
             >
               <span
-                aria-hidden="true"
-                class="c14"
-                dir="ltr"
+                role="text"
               >
-                LIVE 
+                <span
+                  aria-hidden="true"
+                  class="c14"
+                  dir="ltr"
+                >
+                  LIVE 
+                </span>
+                <span
+                  class="c15"
+                  lang="en-GB"
+                >
+                  Live, 
+                </span>
               </span>
+              Could a computer ever create better art than a human?
               <span
                 class="c15"
-                lang="en-GB"
               >
-                Live, 
+                , 
+                14:54
+                , 
               </span>
-            </span>
-            Could a computer ever create better art than a human?
-            <span
-              class="c15"
-            >
-              , 
-              14:54
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -783,18 +788,23 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
-            Could a computer ever create better art than a human?
             <span
-              class="c15"
+              class=""
+              role="text"
             >
-              , 
-              14:54
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              Could a computer ever create better art than a human?
+              <span
+                class="c15"
+              >
+                , 
+                14:54
+                , 
+              </span>
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -905,18 +915,23 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
             class="c13"
             href="/news/articles/cn7k01xp8kxo"
           >
-            Could a computer ever create better art than a human?
             <span
-              class="c15"
+              class=""
+              role="text"
             >
-              , 
-              14:54
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              Could a computer ever create better art than a human?
+              <span
+                class="c15"
+              >
+                , 
+                14:54
+                , 
+              </span>
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -1024,23 +1039,28 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
           class="c24"
         >
           <span
-            class="c25"
-            dir="ltr"
+            class=""
+            role="text"
           >
-            NEXT 
-          </span>
-          Could a computer ever create better art than a human?
-          <span
-            class="c15"
-          >
-            , 
-            14:54
-            , 
-          </span>
-          <span
-            class="c16 c26"
-          >
-            29/01/1990
+            <span
+              class="c25"
+              dir="ltr"
+            >
+              NEXT 
+            </span>
+            Could a computer ever create better art than a human?
+            <span
+              class="c15"
+            >
+              , 
+              14:54
+              , 
+            </span>
+            <span
+              class="c16 c26"
+            >
+              29/01/1990
+            </span>
           </span>
         </h3>
         <p
@@ -1739,27 +1759,32 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             href="/arabic/articles/c1er5mjnznzo"
           >
             <span
+              class=""
               role="text"
             >
               <span
-                class="c14"
-                dir="rtl"
+                role="text"
               >
-                مباشر 
+                <span
+                  class="c14"
+                  dir="rtl"
+                >
+                  مباشر 
+                </span>
               </span>
-            </span>
-            لماذا يخجل البعض من اسم قريته في مصر؟
-            <span
-              class="c15"
-            >
-              , 
-              ۱۴:۵۴
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              لماذا يخجل البعض من اسم قريته في مصر؟
+              <span
+                class="c15"
+              >
+                , 
+                ۱۴:۵۴
+                , 
+              </span>
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -1870,18 +1895,23 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
-            لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class="c15"
+              class=""
+              role="text"
             >
-              , 
-              ۱۴:۵۴
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              لماذا يخجل البعض من اسم قريته في مصر؟
+              <span
+                class="c15"
+              >
+                , 
+                ۱۴:۵۴
+                , 
+              </span>
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -1992,18 +2022,23 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
             class="c13"
             href="/arabic/articles/c1er5mjnznzo"
           >
-            لماذا يخجل البعض من اسم قريته في مصر؟
             <span
-              class="c15"
+              class=""
+              role="text"
             >
-              , 
-              ۱۴:۵۴
-              , 
-            </span>
-            <span
-              class="c16 c17"
-            >
-              29/01/1990
+              لماذا يخجل البعض من اسم قريته في مصر؟
+              <span
+                class="c15"
+              >
+                , 
+                ۱۴:۵۴
+                , 
+              </span>
+              <span
+                class="c16 c17"
+              >
+                29/01/1990
+              </span>
             </span>
           </a>
         </h3>
@@ -2111,23 +2146,28 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
           class="c24"
         >
           <span
-            class="c25"
-            dir="rtl"
+            class=""
+            role="text"
           >
-            مباشر 
-          </span>
-          لماذا يخجل البعض من اسم قريته في مصر؟
-          <span
-            class="c15"
-          >
-            , 
-            ۱۴:۵۴
-            , 
-          </span>
-          <span
-            class="c16 c26"
-          >
-            29/01/1990
+            <span
+              class="c25"
+              dir="rtl"
+            >
+              مباشر 
+            </span>
+            لماذا يخجل البعض من اسم قريته في مصر؟
+            <span
+              class="c15"
+            >
+              , 
+              ۱۴:۵۴
+              , 
+            </span>
+            <span
+              class="c16 c26"
+            >
+              29/01/1990
+            </span>
           </span>
         </h3>
         <p


### PR DESCRIPTION
Resolves #3347

**Overall change:** 
In [this](https://github.com/bbc/psammead/pull/3326) PR we removed the span that was wrapping the Promo Card Headline in order to simplify the markup. Unfortunately, this is necessary to avoid VoiceOver splitting the content within it.

**Code changes:**
- Add `HeadingContentWrapper` back with the role='text'

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
