### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.119 | [PR#3355](https://github.com/bbc/psammead/pull/3355) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.118 | [PR#3354](https://github.com/bbc/psammead/pull/3354) Talos - Bump Dependencies - @bbc/psammead-calendars, @bbc/psammead-timestamp-container |
 | 2.0.117 | [PR#3353](https://github.com/bbc/psammead/pull/3353) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.116 | [PR#3339](https://github.com/bbc/psammead/pull/3339) Dependency updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.118",
+  "version": "2.0.119",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1457,10 +1457,17 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-ZRY4KQCuxIvNpSoMRMWXWcAQoSCN2TLErx5mb1B2EeUJXivCyHtyPH6PQIGZ4X/bpo86TD5mlBE9fN1wXkt0Ig==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-1.0.1.tgz",
+      "integrity": "sha512-rYClOlPP+6H1kdyJNfkGkYx0t+xaI4mdHgk8QXqmQ4v81ea3Q+mTRPjUzwGA3KnM5V0DXxcg5uQ5fJ4RWrrxvw==",
+      "dev": true,
+      "requires": {
+        "@bbc/gel-foundations": "^4.0.1",
+        "@bbc/psammead-assets": "^2.13.0",
+        "@bbc/psammead-live-label": "^1.0.0",
+        "@bbc/psammead-styles": "^4.3.0",
+        "@bbc/psammead-timestamp-container": "^2.7.11"
+      }
     },
     "@bbc/psammead-rich-text-transforms": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.118",
+  "version": "2.0.119",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -76,7 +76,7 @@
     "@bbc/psammead-navigation": "^6.0.6",
     "@bbc/psammead-paragraph": "^2.2.26",
     "@bbc/psammead-play-button": "^1.1.13",
-    "@bbc/psammead-radio-schedule": "0.1.0-alpha.2",
+    "@bbc/psammead-radio-schedule": "1.0.1",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.13",
     "@bbc/psammead-section-label": "^5.0.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  0.1.0-alpha.2  →  1.0.1

| Version | Description |
|---------|-------------|
| 1.0.1 | [PR#3354](https://github.com/bbc/psammead/pull/3354) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
| 1.0.0 | [PR#3350](https://github.com/BBC/psammead/pull/3350) Remove alpha tag |
| 0.1.0-alpha.33 | [PR#3348](https://github.com/bbc/psammead/pull/3348) Add wrapping span with role `text` around the headline |
| 0.1.0-alpha.32 | [PR#3345](https://github.com/bbc/psammead/pull/3345) Remove border from Program Card |
| 0.1.0-alpha.31 | [PR#3326](https://github.com/bbc/psammead/pull/3326) Update Program Card Heading markup and CSS to fix issue with AT |
| 0.1.0-alpha.30 | [PR#3324](https://github.com/bbc/psammead/pull/3324) Fix Duration border on FireFox High Contrast Mode |
</details>

