### PR TITLE
psammead-storybook-helper - add timezone to withServicesKnob helper

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 8.3.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Adding timezone to withServicesKnob helper |
 | 8.2.7 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |
 | 8.2.6 | [PR#3279](https://github.com/bbc/psammead/pull/3279) Add `selectedService` to withServicesKnob `storyProps` |
 | 8.2.5 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 8.3.0 | [PR#x](https://github.com/bbc/psammead/pull/x) Adding timezone to withServicesKnob helper |
+| 8.3.0 | [PR#3376](https://github.com/bbc/psammead/pull/3376) Adding timezone to withServicesKnob helper |
 | 8.2.7 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |
 | 8.2.6 | [PR#3279](https://github.com/bbc/psammead/pull/3279) Add `selectedService` to withServicesKnob `storyProps` |
 | 8.2.5 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.2.7",
+  "version": "8.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.2.7",
+  "version": "8.3.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/text-variants.js
+++ b/packages/utilities/psammead-storybook-helpers/src/text-variants.js
@@ -5,6 +5,7 @@ const TEXT_VARIANTS = {
       "MM Abiy Ahimed paartii isaanii ADWUI jedhamuun waggoota 28'f biyya bulchaa ture walitti baqsuun paartii Badhaadhinaa [PP] jedhamu hundeessaa jiru.",
     script: 'latin',
     locale: 'om',
+    timezone: 'Africa/Addis_Ababa',
     articlePath: '/afaanoromoo/articles/c4g19kgl85ko',
   },
   afrique: {
@@ -13,6 +14,7 @@ const TEXT_VARIANTS = {
       'Comment Ruja Ignatova a-t-elle gagné 4 milliards de dollars en vendant sa fausse monnaie numérique au monde - et où est-elle allée ?',
     script: 'latinDiacritics',
     locale: 'fr',
+    timezone: 'GMT',
     articlePath: '/afrique/articles/cz216x22106o',
   },
   amharic: {
@@ -21,6 +23,7 @@ const TEXT_VARIANTS = {
       'እንግሊዝ በምዕራብ አውሮጳ ከሩስያ ጋር የምትላተም ከሆነ የብሪታኒያ እግረኛ ወታደሮች ከጦር መሣሪያ ውጭ ይሆናሉ ይላል አንድ ቡድን።',
     script: 'ethiopic',
     locale: 'am',
+    timezone: 'Africa/Addis_Ababa',
     articlePath: '/amharic/articles/c3rykrrvy19o',
   },
   arabic: {
@@ -30,6 +33,7 @@ const TEXT_VARIANTS = {
     script: 'arabic',
     dir: 'rtl',
     locale: 'ar',
+    timezone: 'GMT',
     articlePath: '/arabic/articles/c1er5mjnznzo',
   },
   azeri: {
@@ -38,6 +42,7 @@ const TEXT_VARIANTS = {
       'Son aylarda müxtəlif səbəblərə görə Britaniya mətbuatında İngiltərədə yaşayan və ya burada biznesi olan azərbaycanlı məmurların ailə üzvlərinin adları qeyd olunub.',
     script: 'latinDiacritics',
     locale: 'az',
+    timezone: 'Asia/Baku',
     articlePath: '/azeri/articles/c5k08pqnzexo',
   },
   bengali: {
@@ -46,6 +51,7 @@ const TEXT_VARIANTS = {
       'বিমানবন্দরে যাওয়ার আগে সাইফ দেখেন, তার ভিসার মেয়াদ দুদিন আগেই শেষ হয়ে গেছে। তখন জরিমানা দিয়ে তাকে আবার এক্সিট পারমিট নিতে হয়।',
     script: 'bengali',
     locale: 'bn',
+    timezone: 'Asia/Dhaka',
     articlePath: '/bengali/articles/c6p3yp5zzmeo',
   },
   burmese: {
@@ -54,6 +60,7 @@ const TEXT_VARIANTS = {
       'တပ်မတော်နဲ့ ကရင်နယ်ခြားစောင့်တပ် BGF ပူးပေါင်းတပ်ဖွဲ့က MNLA ရဲ့ မြို့နယ်ခွဲရုံး ဖြစ်တဲ့ ဟင်္သာတိုင် ဂိတ်စခန်းနဲ့ ဂျပန်ရေတွင်းတို့ကို ထိန်းချုပ်ထားတယ်လို့ ဆိုပါတယ်။',
     script: 'burmese',
     locale: 'my',
+    timezone: 'GMT',
     articlePath: '/burmese/articles/c3w1kwwmm5yo',
   },
   gahuza: {
@@ -62,6 +69,7 @@ const TEXT_VARIANTS = {
       "Phenny Awiti ni umunyakenya agendana umugera wa SIDA, akaba yamenye ko awugendana mu mwaka wa 2008, ico gihe yiga mu mwaka w'icenda.",
     script: 'latin',
     locale: 'rw',
+    timezone: 'GMT',
     articlePath: '/gahuza/articles/cey23zx8wx8o',
   },
   gujarati: {
@@ -70,6 +78,7 @@ const TEXT_VARIANTS = {
       'ભારતીય અભિનેત્રી ઐશ્વર્યા રાય સાથે અમિરીકી ફિલ્મ નિર્માતા હાર્વી વાઇનસ્ટીન, જેના પર અનેક અભિનેત્રીઓના યૌન શોષણના આરોપો મુકાઈ રહ્યા છે',
     script: 'hindi',
     locale: 'gu',
+    timezone: 'Asia/Kolkata',
     articlePath: '/gujarati/articles/cr5el5kw591o',
   },
   hausa: {
@@ -78,6 +87,7 @@ const TEXT_VARIANTS = {
       'Zhara ta ce za ta yi amfani da kudaden ne wajen tafiyar da gidauniyarta mai tallafa wa marayu a fadin Najeriya.',
     script: 'latin',
     locale: 'ha',
+    timezone: 'GMT',
     articlePath: '/hausa/articles/c2nr6xqmnewo',
   },
   hindi: {
@@ -86,6 +96,7 @@ const TEXT_VARIANTS = {
       'मई तक ये कहानियां या तो अनकही हो गई थीं या इनके बारे में दबी हुई आवाज़ में बात की जा रही थी. लेकिन अब मामला जोर पकड़ रहा है.',
     script: 'hindi',
     locale: 'hi',
+    timezone: 'Asia/Kolkata',
     articlePath: '/hindi/articles/c0469479x9xo',
   },
   igbo: {
@@ -94,6 +105,7 @@ const TEXT_VARIANTS = {
       'Ọtụtụ mgbe ka ndị mmadụ na-emerụ ahụ maọbụ nwụọ ebe ha na-enyere mmadụ ibe ha aka mana lee ka ị ga-esi gbanarị ọdachị a.',
     script: 'latinDiacritics',
     locale: 'ig',
+    timezone: 'Africa/Lagos',
     articlePath: '/igbo/articles/cr1lw620ygjo',
   },
   indonesia: {
@@ -103,6 +115,7 @@ const TEXT_VARIANTS = {
       'Seorang perempuan yang menyebut dirinya ratu kripto dan meraup US$4 miliar atau Rp56 triliun dengan menjual mata uang digital palsu dan kemudian menghilang.',
     script: 'latin',
     locale: 'id',
+    timezone: 'Asia/Jakarta',
     articlePath: '/indonesia/articles/c0q2zq8pzvzo',
   },
   japanese: {
@@ -111,6 +124,7 @@ const TEXT_VARIANTS = {
       'バラク・オバマ前米大統領など各国の著名人が訪れることで有名な東京のすし店が、レストランガイド「ミシュラン」の最新版から除外された。一般客からの予約を受け付けなくなったため。',
     script: 'chinese',
     locale: 'ja',
+    timezone: 'Asia/Tokyo',
     articlePath: '/japanese/articles/c693w95w0mko',
   },
   korean: {
@@ -119,6 +133,7 @@ const TEXT_VARIANTS = {
       '유출된 문서를 통해 중국이 철통보안의 감옥에서 어떻게 수십만 명의 무슬림들을 조직적으로 세뇌하고 있는지가 상세하게 드러났다.',
     script: 'korean',
     locale: 'ko',
+    timezone: 'Asia/Seoul',
     articlePath: '/korean/articles/cpv9kv2yzk6o',
   },
   kyrgyz: {
@@ -127,6 +142,7 @@ const TEXT_VARIANTS = {
       'Кыргыз Республикасынын Жогорку Кеңешинин депутаты Каныбек Иманалиевдин Чыңгыз Айтматовдун 90 жылдыгына арналган илимий-практикалык конференцияда сүйлөгөн сөзү.',
     script: 'cyrillic',
     locale: 'ky',
+    timezone: 'GMT',
     articlePath: '/kyrgyz/articles/c3xd4xg3rm9o',
   },
   marathi: {
@@ -135,6 +151,7 @@ const TEXT_VARIANTS = {
       "तो फोटो मुंबईकर आजही विसरू शकलेले नाहीत. पण त्या फोटोनं मिळालेल्या प्रसिद्धीपासून डि'सुझा यांनी दूर राहणंच पसंत केलं. पण त्या फोटोनं मिळालेल्या प्रसिद्धीपासून डि'सुझा यांनी दूर राहणंच पसंत केलं.",
     script: 'hindi',
     locale: 'mr',
+    timezone: 'Asia/Kolkata',
     articlePath: '/marathi/articles/cp47g4myxz7o',
   },
   mundo: {
@@ -143,6 +160,7 @@ const TEXT_VARIANTS = {
       'Colombia entra a su sexto día de protestas sin que se resuelvan dos preguntas clave: cuál es el problema y cuáles las soluciones. Uno de expertos en el país más famosos del mundo, el economista británico James Robinson, habló con BBC Mundo sobre esta complejidad histórica.',
     script: 'latinDiacritics',
     locale: 'es',
+    timezone: 'GMT',
     articlePath: '/mundo/articles/ce42wzqr2mko',
   },
   nepali: {
@@ -151,6 +169,7 @@ const TEXT_VARIANTS = {
       'काठमाण्डूमा बुधवार भएको नेपाल र भारतका अधिकारीहरूको एउटा बैठकमा भारत नेपाललाई आफ्ना तीनवटा जलमार्गहरू प्रयोग गर्न दिन सहमत भएको उक्त बैठकमा सहभागी नेपाली अधिकारीले बताएका छन्।',
     script: 'nepali',
     locale: 'ne',
+    timezone: 'Asia/Kathmandu',
     articlePath: '/nepali/articles/cl90j9m3mn6o',
   },
   news: {
@@ -159,6 +178,7 @@ const TEXT_VARIANTS = {
       'The critic, author, poet and TV host was known for his witty commentary on international television.',
     script: 'latin',
     locale: 'en',
+    timezone: 'Europe/London',
     articlePath: '/news/articles/cn7k01xp8kxo',
   },
   pashto: {
@@ -169,6 +189,7 @@ const TEXT_VARIANTS = {
     script: 'arabicPashto',
     dir: 'rtl',
     locale: 'ps',
+    timezone: 'GMT',
     articlePath: '/pashto/articles/cyjmdl92z3ro',
   },
   persian: {
@@ -179,6 +200,7 @@ const TEXT_VARIANTS = {
     script: 'arabic',
     dir: 'rtl',
     locale: 'fa',
+    timezone: 'GMT',
     articlePath: '/persian/articles/cej3lzd5e0go',
   },
   pidgin: {
@@ -187,6 +209,7 @@ const TEXT_VARIANTS = {
       'Before di agreement workers union bin dey demand 29 per cent increase for workers wey dey collect salary wey pass N30,000.',
     script: 'latin',
     locale: 'pcm',
+    timezone: 'Africa/Lagos',
     articlePath: '/pidgin/articles/cwl08rd38l6o',
   },
   portuguese: {
@@ -195,6 +218,7 @@ const TEXT_VARIANTS = {
       'Medidas anunciadas no encontro entre Bolsonaro e Trump celebram aproximação com o governo americano - mas elas agora precisam passar pelo teste da concretização',
     script: 'latinDiacritics',
     locale: 'pt-br',
+    timezone: 'America/Sao_Paulo',
     articlePath: '/portuguese/articles/cd61pm8gzmpo',
   },
   punjabi: {
@@ -203,6 +227,7 @@ const TEXT_VARIANTS = {
       'ਪਾਕਿਸਤਾਨੀ ਮਹਿਲਾ ਰਾਹਿਲਾ ਨੇ ਭਾਰਤੀ ਵਕੀਲ ਜ਼ਰੀਏ ਅਦਾਲਤ ਵਿੱਚ ਦਿੱਤੀ ਅਰਜ਼ੀ ਵਿੱਚ ਕਿਹਾ ਕਿ ਮਾਮਲੇ ਨਾਲ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ ਜੁੜੇ ਪਾਕਿਸਤਾਨੀ ਗਵਾਹਾਂ ਨੂੰ ਬੁਲਾਇਆ ਜਾਵੇ',
     script: 'hindi',
     locale: 'pa-in',
+    timezone: 'Asia/Kolkata',
     articlePath: '/punjabi/articles/c0l79lr39qyo',
   },
   russian: {
@@ -211,6 +236,7 @@ const TEXT_VARIANTS = {
       'Фотография умирающего пожилого человека, который решил в последний раз выпить пива в окружении своих родных, неожиданно нашла отклик у очень многих людей по всему миру. Почему?',
     script: 'cyrillic',
     locale: 'ru',
+    timezone: 'GMT',
     articlePath: '/russian/articles/ck7pz7re3zgo',
   },
   serbianCyr: {
@@ -221,6 +247,7 @@ const TEXT_VARIANTS = {
       'Захтеви за оставкама чланова владе Србије, из различитих разлога, одјекивали су у медијима више пута него што је оставки заиста било.',
     script: 'cyrillic',
     locale: 'sr-cyrl',
+    timezone: 'GMT',
     articlePath: '/serbian/articles/c805k05kr73o/cyr',
   },
   serbianLat: {
@@ -231,6 +258,7 @@ const TEXT_VARIANTS = {
       'Zahtevi za ostavkama članova vlade Srbije, iz različitih razloga, odjekivali su u medijima više puta nego što je ostavki zaista bilo.',
     script: 'latin',
     locale: 'sr',
+    timezone: 'GMT',
     articlePath: '/serbian/articles/c805k05kr73o/lat',
   },
   sinhala: {
@@ -239,6 +267,7 @@ const TEXT_VARIANTS = {
       'ජනාධිපතිවරණයට පෙර එම ගිවිසුමට අනිවාර්යයෙන්ම අත්සන් තබන බවට නව ප්‍රජාතන්ත්‍රවාදී පෙරමුණ අවධාරණය කළ අතර, ශ්‍රී ලංකා පොදුජන පෙරමුණ චෝදනා කළේ, එය "ඇමෙරිකානු මර උගුලක්" වන අතර ඒ හරහා ඇමෙරිකාවට ශ්‍රී ලංකාවේ ඉඩම් "කුණු කොල්ලයට" විකිණෙන බවටය.',
     script: 'sinhalese',
     locale: 'si',
+    timezone: 'GMT',
     articlePath: '/sinhala/articles/c45w255zlexo',
   },
   somali: {
@@ -248,6 +277,7 @@ const TEXT_VARIANTS = {
       '"Sidey ugu suurtagashay Ruja Ignatova inay sameyso lacag dhan $4bilyan oo doolar iyadoo caalamka oo dhan ka iibineysa barnaamij been abuur ah oo ay ku sheegeysay in lacagta ay ku labajibbaareyso - xaggeyse aadday?"',
     script: 'latin',
     locale: 'so',
+    timezone: 'Africa/Mogadishu',
     articlePath: '/somali/articles/cgn6emk3jm8o',
   },
   swahili: {
@@ -256,6 +286,7 @@ const TEXT_VARIANTS = {
       'Rais aliyechaguliwa na wengi atahitaji washirika wangi bungeni kuhakikisha kwamba kuna upitishwaji wa haraka wa miswada mbali na kuidhinisha maswala muhimu ya biashara za serikali iwapo mapendekezo ya BBI yatakubalika.',
     script: 'latin',
     locale: 'sw',
+    timezone: 'Africa/Nairobi',
     articlePath: '/swahili/articles/czjqge2jwn2o',
   },
   tamil: {
@@ -265,6 +296,7 @@ const TEXT_VARIANTS = {
       'மகாராஷ்டிராவில் சிவசேனை கட்சித் தலைமையில் அமையவுள்ள புதிய மாநில அரசாங்கத்தில் தேசியவாத காங்கிரஸ் கட்சிக்கு ஒரு துணை முதல்வர் பதவி வழங்கப்படும்; காங்கிரஸை சேர்ந்தவர் சபாநாயகராக தேர்வு செய்யப்படுவார்.',
     script: 'tamil',
     locale: 'ta',
+    timezone: 'GMT',
     articlePath: '/tamil/articles/cwl08ll3me8o',
   },
   telugu: {
@@ -274,6 +306,7 @@ const TEXT_VARIANTS = {
       'చైనా ప్రభుత్వం ఈ కాన్సంట్రేషన్ క్యాంపులను విద్య, శిక్షణ కేంద్రాలుగా చెబుతోంది. చైనా ప్రభుత్వం వీగర్ ముస్లింల విషయంలో వ్యవహరిస్తున్న తీరుపై ఫిరోజా ఆది, సోమవారాల్లో మూడు వీడియోలు పోస్ట్ చేశారు.',
     script: 'hindi',
     locale: 'te',
+    timezone: 'Asia/Kolkata',
     articlePath: '/telugu/articles/cq0y4008d4vo',
   },
   thai: {
@@ -282,6 +315,7 @@ const TEXT_VARIANTS = {
       'คุณนึกภาพคนที่เรียนจบมหาวิทยาลัยด้วยวัยเพียง 9 ขวบออกไหม โลรองต์ ไซมอนส์ จากเบลเยี่ยมคือคนคนนั้น เดือน ธ.ค. นี้ เขาจะได้รับปริญญาตรีสาขาวิศวกรรมไฟฟ้า จากมหาวิทยาลัยเทคโนโลยีไอนด์โฮเวน (Eindhoven University of Technology) ครูและคนหลายคนเรียกเขาว่าอัจฉริยะ เขามีแผนการหลายอย่างในอนาคต รวมถึงการเรียนระดับปริญญาเอก',
     script: 'thai',
     locale: 'th',
+    timezone: 'Asia/Bangkok',
     articlePath: '/thai/articles/c3qxeqm7ldjo',
   },
   tigrinya: {
@@ -290,6 +324,7 @@ const TEXT_VARIANTS = {
       'ኣብ ኤርትራ ዞባ ሰሜናዊ ቀይሕ ባሕሪ ከባቢ ጋሕቴላይ ዝተራእየ ወረር ኣንበጣ ምድረበዳ ምሉእ ብምሉእ ኣብ ትሕቲ ቁጽጽር ከም ዝኣተወ ሚኒስትሪ ሕርሻ ኣፍሊጡ።',
     script: 'ethiopic',
     locale: 'ti',
+    timezone: 'Africa/Addis_Ababa',
     articlePath: '/tigrinya/articles/c12g32eldk6o',
   },
   turkce: {
@@ -298,6 +333,7 @@ const TEXT_VARIANTS = {
       "HIV pozitif olan bağışçılar için dünyanın ilk sperm bankası, hastalıkla ilgili önyargılarla mücadele amacıyla Yeni Zelanda'da açıldı. Bulaşılık düzeyleri tespit edilemeyecek seviyede düşük olan üç HIV pozitif erkek, şimdiden sperm bankasına bağışta bulundu.",
     script: 'latin',
     locale: 'tr',
+    timezone: 'Asia/Istanbul',
     articlePath: '/turkce/articles/c8q1ze59n25o',
   },
   ukchinaSimp: {
@@ -308,6 +344,7 @@ const TEXT_VARIANTS = {
       '但在当今世界，尽管许多人已不再把步行作为一种主要的出行方式，但巴黎仍然是属于孤僻、哲学式观察者的理想城市。毕竟，法国人习惯于花时间以文学和哲学的方式观察和思考周围的环境',
     script: 'chinese',
     locale: 'zh-cn',
+    timezone: 'GMT',
     articlePath: '/ukchina/articles/c0e8weny66ko/simp',
   },
   ukchinaTrad: {
@@ -318,6 +355,7 @@ const TEXT_VARIANTS = {
       '但在當今世界，儘管許多人已不再把步行作為一種主要的出行方式，但巴黎仍然是屬於孤僻、哲學式觀察者的理想城市。畢竟，法國人習慣於花時間以文學和哲學的方式觀察和思考周圍的環境',
     script: 'chinese',
     locale: 'zh-tw',
+    timezone: 'GMT',
     articlePath: '/ukchina/articles/c0e8weny66ko/trad',
   },
   ukrainian: {
@@ -327,6 +365,7 @@ const TEXT_VARIANTS = {
       "Альфред Честнат, Ендр Стюарт і Ренсом Воткінс потрапили за ґрати ще у 1984 році. З'ясувалося, вони ні в чому не винні, ні в чому не винні",
     script: 'cyrillic',
     locale: 'uk',
+    timezone: 'GMT',
     articlePath: '/ukrainian/articles/c0glz45kqz6o',
   },
   urdu: {
@@ -336,6 +375,7 @@ const TEXT_VARIANTS = {
     script: 'arabic',
     dir: 'rtl',
     locale: 'ur',
+    timezone: 'Asia/Karachi',
     articlePath: '/urdu/articles/cwgq7rzv172o',
   },
   uzbek: {
@@ -345,6 +385,7 @@ const TEXT_VARIANTS = {
       'Ўзбекистон: 12 йиллик муҳожиратдан кейин Ватанга қайтган фаол вафот этди - Толиб Ёқубов мустақил Ўзбекистондаги илк ва энг таниқли инсон ҳуқуқлари ҳимоячиларидан бири эди. У Каримов даврида Ўзбекистонни тарк этишга мажбур бўлган, муҳожиратда экан, фуқароликдан маҳрум этилганди.',
     script: 'cyrillic',
     locale: 'uz',
+    timezone: 'GMT',
     articlePath: '/uzbek/articles/cxj3rjxm6r0o',
   },
   vietnamese: {
@@ -353,6 +394,7 @@ const TEXT_VARIANTS = {
       'Lợi nhuận tại các công ty công nghiệp Trung Quốc tiếp tục trượt giảm trong tháng 10, thể hiện sự suy giảm mạnh nhất từ 2011.',
     script: 'latinDiacritics',
     locale: 'vi',
+    timezone: 'Asia/Ho_Chi_Minh',
     articlePath: '/vietnamese/articles/c3y59g5zm19o',
   },
   yoruba: {
@@ -361,6 +403,7 @@ const TEXT_VARIANTS = {
       'Ni ipinlẹ Zamfara, ailesan owo tabua tawọn Gomina n gba ni owo ifẹyinti, mu ki awọn aṣofin wọgile ofin to ya owo yii sọtọ fun wọn.',
     script: 'latin',
     locale: 'yo',
+    timezone: 'Africa/Lagos',
     articlePath: '/yoruba/articles/clw06m0nj8qo',
   },
   zhongwenSimp: {
@@ -371,6 +414,7 @@ const TEXT_VARIANTS = {
       '香港区议会选举以民主派大胜结束。中国官方在大陆的媒体只发出简讯，告知公众选举结束，并未交代哪方获胜及失败。不过，连续两日，官方将矛头对准美国。',
     script: 'chinese',
     locale: 'zh-hans',
+    timezone: 'GMT',
     articlePath: '/zhongwen/articles/c3xd4x9prgyo/simp',
   },
   zhongwenTrad: {
@@ -381,6 +425,7 @@ const TEXT_VARIANTS = {
       '香港區議會選舉以民主派大勝結束。中國官方在大陸的媒體只發出簡訊，告知公眾選舉結束，並未交代哪方獲勝及失敗。不過，連續兩日，官方將矛頭對凖美國。',
     script: 'chinese',
     locale: 'zh-hant',
+    timezone: 'GMT',
     articlePath: '/zhongwen/articles/c3xd4x9prgyo/trad',
   },
 };

--- a/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.jsx
@@ -34,6 +34,7 @@ export default ({
     script,
     locale,
     dir = 'ltr',
+    timezone = 'GMT',
   } = TEXT_VARIANTS[selectedService];
 
   const storyProps = {
@@ -46,6 +47,7 @@ export default ({
     service,
     variant: variant || 'default',
     selectedService,
+    timezone,
   };
 
   return (

--- a/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
@@ -69,6 +69,7 @@ it('should pass the correct props to the story function', () => {
     dir: 'ltr',
     locale: 'en',
     variant: 'default',
+    timezone: 'Europe/London',
     selectedService: 'news',
   };
 
@@ -91,6 +92,7 @@ it('should pass the correct chosen service props to the story function', () => {
     dir: 'rtl',
     locale: 'ar',
     variant: 'default',
+    timezone: 'GMT',
     selectedService: 'arabic',
   };
 
@@ -113,6 +115,7 @@ it('should pass the correct chosen service props to the story function', () => {
     dir: 'ltr',
     locale: 'zh-cn',
     variant: 'simp',
+    timezone: 'GMT',
     selectedService: 'ukchinaSimp',
   };
 


### PR DESCRIPTION
Part of #3358

This is needed to enable correct timezones in Storybook for the Radio Schedules component (PR #3377).

**Overall change:** Makes timezones available to Storybook knobs. 
Note that the timezones added were obtained from the Simorgh Service Config files: e.g. for [Afaan Oromoo](https://github.com/bbc/simorgh/blob/2a35672a541f34980acc294ba6454b3a40b793ee/src/app/lib/config/services/afaanoromoo.js#L246)

**Code changes:**

- Added timezone
- Updated tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
