### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.122 | [PR#3380](https://github.com/bbc/psammead/pull/3380) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.121 | [PR#3379](https://github.com/bbc/psammead/pull/3379) Talos - Bump Dependencies - @bbc/psammead-storybook-helpers |
 | 2.0.120 | [PR#3359](https://github.com/bbc/psammead/pull/3359) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin |
 | 2.0.119 | [PR#3356](https://github.com/bbc/psammead/pull/3356) Talos - Bump Dependencies - @bbc/psammead-radio-schedule, @bbc/psammead-story-promo |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.121",
+  "version": "2.0.122",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1457,9 +1457,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-1.0.1.tgz",
-      "integrity": "sha512-rYClOlPP+6H1kdyJNfkGkYx0t+xaI4mdHgk8QXqmQ4v81ea3Q+mTRPjUzwGA3KnM5V0DXxcg5uQ5fJ4RWrrxvw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-1.0.2.tgz",
+      "integrity": "sha512-68dNf8PcKaYkXrxfUAydmfsW7XsxECJYHq4goLgKQO8LW+1hABiZh8n5fTDznJA9USlKxzU4yPFQbi0vcP6egA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.121",
+  "version": "2.0.122",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -76,7 +76,7 @@
     "@bbc/psammead-navigation": "^6.0.6",
     "@bbc/psammead-paragraph": "^2.2.26",
     "@bbc/psammead-play-button": "^1.1.13",
-    "@bbc/psammead-radio-schedule": "1.0.1",
+    "@bbc/psammead-radio-schedule": "1.0.2",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.13",
     "@bbc/psammead-section-label": "^5.0.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  1.0.1  →  1.0.2

| Version | Description |
|---------|-------------|
| 1.0.2 | [PR#3379](https://github.com/bbc/psammead/pull/3379) Talos - Bump Dependencies - @bbc/psammead-storybook-helpers adding timezone |
</details>

