### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.132 | [PR#3401](https://github.com/bbc/psammead/pull/3401) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.131 | [PR#3400](https://github.com/bbc/psammead/pull/3400) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 2.0.130 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-calendars, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-grid, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |
 | 2.0.129 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-grid, @bbc/psammead-locales, @bbc/psammead-radio-schedule, @bbc/psammead-styles, @bbc/psammead-timestamp-container |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.131",
+  "version": "2.0.132",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1533,16 +1533,16 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-1.0.7.tgz",
-      "integrity": "sha512-CJJZyB1FyLevD695kkuwlOIj/vXwEFmea0qO6sHWdK4VBjuH5VoFAr96utgQYPqOMaauc/2heD9s3cEXHmKdfg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-1.0.8.tgz",
+      "integrity": "sha512-QhYfaLG6oXjVTMB6IRi3JRLmsCHw6wt246JEEjd6zClzC1YudaA0D/9n9Q2nkSc6cWvgIFFyGvC8t50f87x7kg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.14.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.3.1",
-        "@bbc/psammead-timestamp-container": "^2.7.14"
+        "@bbc/psammead-timestamp-container": "^2.7.15"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.131",
+  "version": "2.0.132",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -76,7 +76,7 @@
     "@bbc/psammead-navigation": "^6.0.9",
     "@bbc/psammead-paragraph": "^2.2.27",
     "@bbc/psammead-play-button": "^1.1.15",
-    "@bbc/psammead-radio-schedule": "1.0.7",
+    "@bbc/psammead-radio-schedule": "1.0.8",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.14",
     "@bbc/psammead-section-label": "^5.0.4",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  1.0.7  →  1.0.8

| Version | Description |
|---------|-------------|
| 1.0.8 | [PR#3400](https://github.com/bbc/psammead/pull/3400) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

