### PR TITLE
Talos - Bump @bbc/psammead-styles, @bbc/gel-foundations, @bbc/psammead-assets...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.135 | [PR#3407](https://github.com/bbc/psammead/pull/3407) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.134 | [PR#3405](https://github.com/bbc/psammead/pull/3405) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.133 | [PR#3402](https://github.com/bbc/psammead/pull/3402) Dependency updates |
 | 2.0.132 | [PR#3401](https://github.com/bbc/psammead/pull/3401) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.134",
+  "version": "2.0.135",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1662,9 +1662,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.7.15",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.7.15.tgz",
-      "integrity": "sha512-OeBQchgr5YACd4bSWaQAxCzXaI3oSTMC7bvOqGlDYN0ZSfFUFv2mVzLSZlqJ0v0lRppxzuePbHmoEpGFxdW7Ug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.0.tgz",
+      "integrity": "sha512-7D4c5IIX936XgzgLtD5QRM+aLP9uNqA9Qxv6pyXl3vkEzWy3fOsf0Cr474h3vfo92IYDjYD1JaCXfatnegBZbw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.134",
+  "version": "2.0.135",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -87,7 +87,7 @@
     "@bbc/psammead-styles": "^4.3.1",
     "@bbc/psammead-test-helpers": "^3.1.5",
     "@bbc/psammead-timestamp": "^2.2.27",
-    "@bbc/psammead-timestamp-container": "^2.7.15",
+    "@bbc/psammead-timestamp-container": "^3.0.0",
     "@bbc/psammead-useful-links": "^1.0.17",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@loadable/babel-plugin": "^5.12.0",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^2.7.15  →  ^3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#3403](https://github.com/bbc/psammead/pull/3403) Update formatDuration to use locale, rename unixTimestampToMoment to localisedMoment since it now uses locale, update formatDuration, localisedMoment, formatUnixTimestamp to use destructured props. |
</details>

