### PR TITLE
Story Promo - Add overflow-wrap property to Link

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 6.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add `overflow-wrap` property to `Link` |
+| 6.0.2 | [PR#3410](https://github.com/bbc/psammead/pull/3410) Add `overflow-wrap` property to `Link` |
 | 6.0.1 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.0 | [PR#3264](https://github.com/bbc/psammead/pull/3264) Use `LiveLabel` component |
 | 5.1.0 | [PR#3206](https://github.com/bbc/psammead/pull/3206) Add prop to toggle if live label is hidden, as styled components strips aria tag |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Add `overflow-wrap` property to `Link` |
 | 6.0.1 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.0 | [PR#3264](https://github.com/bbc/psammead/pull/3264) Use `LiveLabel` component |
 | 5.1.0 | [PR#3206](https://github.com/bbc/psammead/pull/3206) Add prop to toggle if live label is hidden, as styled components strips aria tag |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -49,6 +49,7 @@ exports[`StoryPromo - Leading Story should render correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c3:before {
@@ -309,6 +310,7 @@ exports[`StoryPromo - Leading Story should render with Media Indicator correctly
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c3:before {
@@ -576,6 +578,7 @@ exports[`StoryPromo - Top Story should render correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -818,6 +821,7 @@ exports[`StoryPromo - Top Story should render with Media Indicator correctly 1`]
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c10:before {
@@ -1113,6 +1117,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -1511,6 +1516,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -1858,6 +1864,7 @@ exports[`StoryPromo should render Live promo correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -2099,6 +2106,7 @@ exports[`StoryPromo should render a RTL Live promo correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -2319,6 +2327,7 @@ exports[`StoryPromo should render correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c5:before {
@@ -2559,6 +2568,7 @@ exports[`StoryPromo with Media Indicator should render a RTL promo with media in
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c10:before {
@@ -2862,6 +2872,7 @@ exports[`StoryPromo with Media Indicator should render correctly 1`] = `
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .c10:before {

--- a/packages/components/psammead-story-promo/src/index.jsx
+++ b/packages/components/psammead-story-promo/src/index.jsx
@@ -198,6 +198,7 @@ export const Link = styled.a`
   position: static;
   color: ${C_EBON};
   text-decoration: none;
+  overflow-wrap: break-word;
 
   &:before {
     bottom: 0;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
After confirming that the story promo headlines are not overflowing on the live site using Opera Mini Extreme Mode, we can now apply the changes from [this](https://github.com/bbc/simorgh/pull/6248) PR directly in Psammead. 

**Code changes:**
- Add `overflow-wrap: break-word;` to `Link`
- Update snapshots

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
