### PR TITLE
Update Swahili relative timestamps

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.1.8 | [PR#3412](https://github.com/bbc/psammead/pull/3390) Update Swahili relative timestamps |
 | 4.1.7 | [PR#3390](https://github.com/bbc/psammead/pull/3390) Bump prettier major version and disable rule for brackets around a single prop |
 | 4.1.6 | [PR#3357](https://github.com/bbc/psammead/pull/3357) Update Pashto date format for LL & LLL |
 | 4.1.5 | [PR#3351](https://github.com/bbc/psammead/pull/3351) Update Arabic translation for hours |

--- a/packages/utilities/psammead-locales/moment/sw.js
+++ b/packages/utilities/psammead-locales/moment/sw.js
@@ -9,12 +9,12 @@ moment.updateLocale('sw', {
     past: '%s',
     s: function (number, withoutSuffix, key, isFuture) {
       return withoutSuffix === false && isFuture === false
-        ? 'hivi punde zilizopita'
+        ? 'sekunde chache zilizopita'
         : 'hivi punde';
     },
     ss: function (number, withoutSuffix, key, isFuture) {
       return withoutSuffix === false && isFuture === false
-        ? 'hivi punde zilizopita'
+        ? 'sekunde chache zilizopita'
         : 'hivi punde';
     },
     m: function (number, withoutSuffix, key, isFuture) {

--- a/packages/utilities/psammead-locales/moment/sw.js
+++ b/packages/utilities/psammead-locales/moment/sw.js
@@ -5,4 +5,37 @@ moment.updateLocale('sw', {
   months: 'Januari_Februari_Machi_Aprili_Mei_Juni_Julai_Agosti_Septemba_Oktoba_Novemba_Disemba'.split(
     '_'
   ),
+  relativeTime: {
+    past: '%s',
+    s: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'hivi punde zilizopita'
+        : 'hivi punde';
+    },
+    ss: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'hivi punde zilizopita'
+        : 'hivi punde';
+    },
+    m: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'Dakika 1 iliyopita'
+        : 'Dakika 1';
+    },
+    mm: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'Dakika ' + number + ' zilizopita'
+        : 'Dakika ' + number;
+    },
+    h: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'Saa 1 iliyopita'
+        : 'Saa 1';
+    },
+    hh: function (number, withoutSuffix, key, isFuture) {
+      return withoutSuffix === false && isFuture === false
+        ? 'Saa ' + number + ' zilizopita'
+        : 'Saa ' + number;
+    },
+  },
 });

--- a/packages/utilities/psammead-locales/moment/sw.test.js
+++ b/packages/utilities/psammead-locales/moment/sw.test.js
@@ -141,11 +141,11 @@ test('from', function () {
 
 test('suffix', function () {
   assert.equal(moment(30000).from(0), 'hivi punde baadaye',  'prefix');
-  assert.equal(moment(0).from(30000), 'hivi punde zilizopita', 'suffix');
+  assert.equal(moment(0).from(30000), 'sekunde chache zilizopita', 'suffix');
 });
 
 test('now from now', function () {
-  assert.equal(moment().fromNow(), 'hivi punde zilizopita',  'now from now should display as in the past');
+  assert.equal(moment().fromNow(), 'sekunde chache zilizopita',  'now from now should display as in the past');
 });
 
 test('fromNow', function () {

--- a/packages/utilities/psammead-locales/moment/sw.test.js
+++ b/packages/utilities/psammead-locales/moment/sw.test.js
@@ -110,15 +110,15 @@ test('format week', function () {
 test('from', function () {
   var start = moment([2007, 1, 28]);
   assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'hivi punde',   '44 seconds = a few seconds');
-  assert.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  'dakika moja',  '45 seconds = a minute');
-  assert.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  'dakika moja',  '89 seconds = a minute');
-  assert.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  'dakika 2',     '90 seconds = 2 minutes');
-  assert.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  'dakika 44',    '44 minutes = 44 minutes');
-  assert.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  'saa limoja',   '45 minutes = an hour');
-  assert.equal(start.from(moment([2007, 1, 28]).add({m: 89}), true),  'saa limoja',   '89 minutes = an hour');
-  assert.equal(start.from(moment([2007, 1, 28]).add({m: 90}), true),  'masaa 2',      '90 minutes = 2 hours');
-  assert.equal(start.from(moment([2007, 1, 28]).add({h: 5}), true),   'masaa 5',      '5 hours = 5 hours');
-  assert.equal(start.from(moment([2007, 1, 28]).add({h: 21}), true),  'masaa 21',     '21 hours = 21 hours');
+  assert.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  'Dakika 1',  '45 seconds = a minute');
+  assert.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  'Dakika 1',  '89 seconds = a minute');
+  assert.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  'Dakika 2',     '90 seconds = 2 minutes');
+  assert.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  'Dakika 44',    '44 minutes = 44 minutes');
+  assert.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  'Saa 1',   '45 minutes = an hour');
+  assert.equal(start.from(moment([2007, 1, 28]).add({m: 89}), true),  'Saa 1',   '89 minutes = an hour');
+  assert.equal(start.from(moment([2007, 1, 28]).add({m: 90}), true),  'Saa 2',      '90 minutes = 2 hours');
+  assert.equal(start.from(moment([2007, 1, 28]).add({h: 5}), true),   'Saa 5',      '5 hours = 5 hours');
+  assert.equal(start.from(moment([2007, 1, 28]).add({h: 21}), true),  'Saa 21',     '21 hours = 21 hours');
   assert.equal(start.from(moment([2007, 1, 28]).add({h: 22}), true),  'siku moja',    '22 hours = a day');
   assert.equal(start.from(moment([2007, 1, 28]).add({h: 35}), true),  'siku moja',    '35 hours = a day');
   assert.equal(start.from(moment([2007, 1, 28]).add({h: 36}), true),  'masiku 2',     '36 hours = 2 days');
@@ -141,14 +141,18 @@ test('from', function () {
 
 test('suffix', function () {
   assert.equal(moment(30000).from(0), 'hivi punde baadaye',  'prefix');
-  assert.equal(moment(0).from(30000), 'tokea hivi punde', 'suffix');
+  assert.equal(moment(0).from(30000), 'hivi punde zilizopita', 'suffix');
 });
 
 test('now from now', function () {
-  assert.equal(moment().fromNow(), 'tokea hivi punde',  'now from now should display as in the past');
+  assert.equal(moment().fromNow(), 'hivi punde zilizopita',  'now from now should display as in the past');
 });
 
 test('fromNow', function () {
+  assert.equal(moment().subtract({m: 1}).fromNow(), 'Dakika 1 iliyopita', '1 minute ago');
+  assert.equal(moment().subtract({m: 5}).fromNow(), 'Dakika 5 zilizopita', '5 minutes ago');
+  assert.equal(moment().subtract({h: 1}).fromNow(), 'Saa 1 iliyopita', '1 hour ago');
+  assert.equal(moment().subtract({h: 5}).fromNow(), 'Saa 5 zilizopita', '5 hours ago');
   assert.equal(moment().add({s: 30}).fromNow(), 'hivi punde baadaye', 'in a few seconds');
   assert.equal(moment().add({d: 5}).fromNow(), 'masiku 5 baadaye', 'in 5 days');
 });

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #3411 

**Overall change:**
Updates the Swahili relative timestamps to match editorial expectations

**Code changes:**

- Updates Swahili relative timestamps
- Updates tests

<img width="524" alt="Screen Shot 2020-04-24 at 11 44 52" src="https://user-images.githubusercontent.com/8124899/80204913-a0eab300-8621-11ea-83dc-c571b260ac64.png">
<img width="518" alt="Screen Shot 2020-04-24 at 11 44 57" src="https://user-images.githubusercontent.com/8124899/80204916-a34d0d00-8621-11ea-803a-153f487e6a91.png">
<img width="523" alt="Screen Shot 2020-04-24 at 11 45 05" src="https://user-images.githubusercontent.com/8124899/80204936-afd16580-8621-11ea-8d87-ea32ed3f4791.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
