### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.138 | [PR#3425](https://github.com/bbc/psammead/pull/3425) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.137 | [PR#3414](https://github.com/bbc/psammead/pull/3414) Talos - Bump Dependencies - @bbc/psammead-calendars, @bbc/psammead-timestamp-container |
 | 2.0.136 | [PR#3413](https://github.com/bbc/psammead/pull/3413) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.135 | [PR#3407](https://github.com/bbc/psammead/pull/3407) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.137",
+  "version": "2.0.138",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1533,29 +1533,16 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-2.0.0.tgz",
-      "integrity": "sha512-b82CXCiqC8EOh2mzTpLuxkQDO/yOXKVP6QYX92aYZ/fuz8RjEjjCLi+mc9nXn0ra3fm1u7zyw0E+Yo7Ysa9Mqg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-2.0.1.tgz",
+      "integrity": "sha512-IS4DCsViwPDVH5i+Wts7TDyQFx7UGlNem0FpYA4b5Xb4uv7uzkIzlebUdYZ4KS31sY5xFsv/nhNsKudh5gn3Fg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.14.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.3.1",
-        "@bbc/psammead-timestamp-container": "^3.0.0"
-      },
-      "dependencies": {
-        "@bbc/psammead-timestamp-container": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.0.tgz",
-          "integrity": "sha512-7D4c5IIX936XgzgLtD5QRM+aLP9uNqA9Qxv6pyXl3vkEzWy3fOsf0Cr474h3vfo92IYDjYD1JaCXfatnegBZbw==",
-          "dev": true,
-          "requires": {
-            "@bbc/gel-foundations": "^4.0.1",
-            "@bbc/psammead-timestamp": "^2.2.27",
-            "moment-timezone": "^0.5.26"
-          }
-        }
+        "@bbc/psammead-timestamp-container": "^3.0.1"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.137",
+  "version": "2.0.138",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -76,7 +76,7 @@
     "@bbc/psammead-navigation": "^6.0.9",
     "@bbc/psammead-paragraph": "^2.2.27",
     "@bbc/psammead-play-button": "^1.1.15",
-    "@bbc/psammead-radio-schedule": "2.0.0",
+    "@bbc/psammead-radio-schedule": "2.0.1",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.14",
     "@bbc/psammead-section-label": "^5.0.4",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  2.0.0  →  2.0.1

| Version | Description |
|---------|-------------|
| 2.0.1 | [PR#3414](https://github.com/bbc/psammead/pull/3414) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

