### PR TITLE
Change default lang prop in bulletin

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#3430](https://github.com/bbc/psammead/pull/3430) Remove `lang` prop from bulletin |
+| 3.1.0 | [PR#3430](https://github.com/bbc/psammead/pull/3430) Change default `lang` prop to `null` |
 | 3.0.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 3.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.3 | [PR#3381](https://github.com/bbc/psammead/pull/3381) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.0 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Remove `lang` prop from bulletin |
 | 3.0.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 3.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.3 | [PR#3381](https://github.com/bbc/psammead/pull/3381) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Remove `lang` prop from bulletin |
+| 3.1.0 | [PR#3430](https://github.com/bbc/psammead/pull/3430) Remove `lang` prop from bulletin |
 | 3.0.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 3.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.3 | [PR#3381](https://github.com/bbc/psammead/pull/3381) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-bulletin/README.md
+++ b/packages/components/psammead-bulletin/README.md
@@ -29,6 +29,7 @@ npm install @bbc/psammead-bulletin --save
 | `isLive` | boolean | no | `false` | `true` |
 | `liveText` | string | no | `'Live'` | `'Localised Live'` |
 | `offScreenText` | string | yes | N/A | `'Watch Live'` |
+| `lang` | string | no | `null` | `'en-GB'` |
 
 ## Usage
 

--- a/packages/components/psammead-bulletin/README.md
+++ b/packages/components/psammead-bulletin/README.md
@@ -29,7 +29,6 @@ npm install @bbc/psammead-bulletin --save
 | `isLive` | boolean | no | `false` | `true` |
 | `liveText` | string | no | `'Live'` | `'Localised Live'` |
 | `offScreenText` | string | yes | N/A | `'Watch Live'` |
-| `lang` | string | no | `'en-GB'` | `'en-GB'` |
 
 ## Usage
 

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -319,7 +319,7 @@ exports[`Bulletin should render audio correctly 1`] = `
 </div>
 `;
 
-exports[`Bulletin should render audio correctly with lang 1`] = `
+exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 .c2 {
   display: block;
   width: 100%;
@@ -1302,6 +1302,325 @@ exports[`Bulletin should render live video correctly 1`] = `
         </svg>
       </span>
       Watch Live
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Bulletin should render video correctly 1`] = `
+.c2 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.c10 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.c6 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c5 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c5:hover,
+.c5:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:visited {
+  color: #6E6E73;
+}
+
+.c1 {
+  vertical-align: top;
+  display: inline-block;
+  width: 100%;
+  padding: 0.5rem 0.5rem 0 0.5rem;
+}
+
+.c3 {
+  display: inline-block;
+  width: 100%;
+}
+
+.c0 {
+  position: relative;
+  background-color: #F2F2F2;
+  display: grid;
+  grid-template-columns: repeat(6,1fr);
+  grid-column-gap: 1rem;
+}
+
+.c4 {
+  color: #222222;
+  margin: 0;
+  padding: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+}
+
+.c7 {
+  color: #3F3F42;
+  margin: 0;
+  padding: 0 0.5rem 1rem;
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+
+.c9 > svg {
+  color: #FFFFFF;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.c8 {
+  background-color: #222222;
+  border: 0.0625rem solid transparent;
+  color: #FFFFFF;
+  padding: 0.75rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    width: 50%;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    padding: 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c1 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    width: 50%;
+    padding-left: 1rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c3 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    padding: 0 0 0.5rem 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    padding: 0.5rem 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <img
+      alt="Iron man"
+      class="c2"
+      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+    />
+  </div>
+  <div
+    class="c3"
+    dir="ltr"
+  >
+    <h3
+      class="c4"
+      dir="ltr"
+    >
+      <a
+        class="c5"
+        href="https://bbc.co.uk"
+      >
+        <span
+          role="text"
+        >
+          <span
+            class="c6"
+          >
+            Watch, 
+          </span>
+          <span>
+            This is the headline
+          </span>
+        </span>
+      </a>
+    </h3>
+    <p
+      class="c7"
+      dir="ltr"
+    >
+      This is the summary text
+    </p>
+    <div
+      aria-hidden="true"
+      class="c8"
+      dir="ltr"
+    >
+      <span
+        class="c9"
+        dir="ltr"
+      >
+        <svg
+          aria-hidden="true"
+          class="c10"
+          focusable="false"
+          height="12px"
+          viewBox="0 0 32 32"
+          width="12px"
+        >
+          <polygon
+            points="3,32 29,16 3,0"
+          />
+        </svg>
+      </span>
+      Watch
     </div>
   </div>
 </div>

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -273,7 +273,6 @@ exports[`Bulletin should render audio correctly 1`] = `
         >
           <span
             class="c6"
-            lang="en-GB"
           >
             Listen, 
           </span>
@@ -320,7 +319,7 @@ exports[`Bulletin should render audio correctly 1`] = `
 </div>
 `;
 
-exports[`Bulletin should render audio correctly in arabic 1`] = `
+exports[`Bulletin should render audio correctly with lang 1`] = `
 .c2 {
   display: block;
   width: 100%;
@@ -593,8 +592,9 @@ exports[`Bulletin should render audio correctly in arabic 1`] = `
         >
           <span
             class="c6"
+            lang="en-GB"
           >
-            استمع, 
+            Listen, 
           </span>
           <span>
             This is the headline
@@ -633,7 +633,7 @@ exports[`Bulletin should render audio correctly in arabic 1`] = `
           />
         </svg>
       </span>
-      استمع
+      Listen
     </div>
   </div>
 </div>
@@ -1302,326 +1302,6 @@ exports[`Bulletin should render live video correctly 1`] = `
         </svg>
       </span>
       Watch Live
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Bulletin should render video correctly 1`] = `
-.c2 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.c10 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.75rem;
-  height: 0.75rem;
-}
-
-.c6 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.c5 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c5:hover,
-.c5:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c5:visited {
-  color: #6E6E73;
-}
-
-.c1 {
-  vertical-align: top;
-  display: inline-block;
-  width: 100%;
-  padding: 0.5rem 0.5rem 0 0.5rem;
-}
-
-.c3 {
-  display: inline-block;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  background-color: #F2F2F2;
-  display: grid;
-  grid-template-columns: repeat(6,1fr);
-  grid-column-gap: 1rem;
-}
-
-.c4 {
-  color: #222222;
-  margin: 0;
-  padding: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-}
-
-.c7 {
-  color: #3F3F42;
-  margin: 0;
-  padding: 0 0.5rem 1rem;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding-right: 0.5rem;
-}
-
-.c9 > svg {
-  color: #FFFFFF;
-  fill: currentColor;
-  width: 1.0625rem;
-  height: 1rem;
-  margin: 0;
-}
-
-.c8 {
-  background-color: #222222;
-  border: 0.0625rem solid transparent;
-  color: #FFFFFF;
-  padding: 0.75rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@media (min-width:37.5rem) {
-  .c1 {
-    width: 50%;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c1 {
-    padding: 0;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c1 {
-    width: initial;
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c3 {
-    width: 50%;
-    padding-left: 1rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c3 {
-    width: initial;
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c4 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c4 {
-    padding: 0 0 0.5rem 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c7 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c7 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c8 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c8 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c8 {
-    display: -webkit-inline-box;
-    display: -webkit-inline-flex;
-    display: -ms-inline-flexbox;
-    display: inline-flex;
-    padding: 0.5rem 1rem;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <img
-      alt="Iron man"
-      class="c2"
-      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-    />
-  </div>
-  <div
-    class="c3"
-    dir="ltr"
-  >
-    <h3
-      class="c4"
-      dir="ltr"
-    >
-      <a
-        class="c5"
-        href="https://bbc.co.uk"
-      >
-        <span
-          role="text"
-        >
-          <span
-            class="c6"
-            lang="en-GB"
-          >
-            Watch, 
-          </span>
-          <span>
-            This is the headline
-          </span>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="c7"
-      dir="ltr"
-    >
-      This is the summary text
-    </p>
-    <div
-      aria-hidden="true"
-      class="c8"
-      dir="ltr"
-    >
-      <span
-        class="c9"
-        dir="ltr"
-      >
-        <svg
-          aria-hidden="true"
-          class="c10"
-          focusable="false"
-          height="12px"
-          viewBox="0 0 32 32"
-          width="12px"
-        >
-          <polygon
-            points="3,32 29,16 3,0"
-          />
-        </svg>
-      </span>
-      Watch
     </div>
   </div>
 </div>

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -428,7 +428,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding-right: 0.5rem;
+  padding-left: 0.5rem;
 }
 
 .c9 > svg {
@@ -485,7 +485,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c3 {
     width: 66.67%;
-    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }
 
@@ -514,7 +514,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   .c4 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
-    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -534,7 +534,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c7 {
-    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -577,11 +577,11 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   </div>
   <div
     class="c3"
-    dir="ltr"
+    dir="rtl"
   >
     <h3
       class="c4"
-      dir="ltr"
+      dir="rtl"
     >
       <a
         class="c5"
@@ -604,18 +604,18 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
     </h3>
     <p
       class="c7"
-      dir="ltr"
+      dir="rtl"
     >
       This is the summary text
     </p>
     <div
       aria-hidden="true"
       class="c8"
-      dir="ltr"
+      dir="rtl"
     >
       <span
         class="c9"
-        dir="ltr"
+        dir="rtl"
       >
         <svg
           aria-hidden="true"

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -320,6 +320,325 @@ exports[`Bulletin should render audio correctly 1`] = `
 </div>
 `;
 
+exports[`Bulletin should render audio correctly in arabic 1`] = `
+.c2 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.c10 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c6 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c5 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c5:hover,
+.c5:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:visited {
+  color: #6E6E73;
+}
+
+.c1 {
+  vertical-align: top;
+  display: inline-block;
+  width: 100%;
+  padding: 0.5rem 0.5rem 0 0.5rem;
+}
+
+.c3 {
+  display: inline-block;
+  width: 100%;
+}
+
+.c0 {
+  position: relative;
+  background-color: #F2F2F2;
+  display: grid;
+  grid-template-columns: repeat(6,1fr);
+  grid-column-gap: 1rem;
+  background-color: #F2F2F2;
+}
+
+.c4 {
+  color: #222222;
+  margin: 0;
+  padding: 0.5rem;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 1rem;
+  line-height: 1.625rem;
+}
+
+.c7 {
+  color: #3F3F42;
+  margin: 0;
+  padding: 0 0.5rem 1rem;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+
+.c9 > svg {
+  color: #FFFFFF;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.c8 {
+  background-color: #222222;
+  border: 0.0625rem solid transparent;
+  color: #FFFFFF;
+  padding: 0.75rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1rem;
+  line-height: 1.625rem;
+  font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c1 {
+    width: 33.33%;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    padding: 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c1 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c3 {
+    width: 66.67%;
+    padding-left: 1rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c3 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c4 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c7 {
+    padding-left: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c8 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <img
+      alt="Iron man"
+      class="c2"
+      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+    />
+  </div>
+  <div
+    class="c3"
+    dir="ltr"
+  >
+    <h3
+      class="c4"
+      dir="ltr"
+    >
+      <a
+        class="c5"
+        href="https://bbc.co.uk"
+      >
+        <span
+          role="text"
+        >
+          <span
+            class="c6"
+          >
+            استمع, 
+          </span>
+          <span>
+            This is the headline
+          </span>
+        </span>
+      </a>
+    </h3>
+    <p
+      class="c7"
+      dir="ltr"
+    >
+      This is the summary text
+    </p>
+    <div
+      aria-hidden="true"
+      class="c8"
+      dir="ltr"
+    >
+      <span
+        class="c9"
+        dir="ltr"
+      >
+        <svg
+          aria-hidden="true"
+          class="c10"
+          focusable="false"
+          height="12px"
+          viewBox="0 0 13 12"
+          width="13px"
+        >
+          <path
+            d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+          />
+          <path
+            d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+          />
+        </svg>
+      </span>
+      استمع
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Bulletin should render live audio correctly 1`] = `
 .c2 {
   display: block;

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -180,12 +180,12 @@ const Bulletin = ({
   isLive,
   liveText,
   offScreenText,
+  lang,
 }) => {
   const isAudio = mediaType === 'audio';
   const bulletinType = isAudio ? 'radio' : 'tv';
   const BulletinWrapper = isAudio ? RadioBulletinWrapper : TVBulletinWrapper;
-  const ctaTextIsEnglish = ctaText === 'Watch' || ctaText === 'Listen';
-  const langProp = ctaTextIsEnglish ? { lang: 'en-GB' } : {};
+  const hiddenTextProps = lang ? { lang } : {};
 
   return (
     <BulletinWrapper>
@@ -214,7 +214,7 @@ const Bulletin = ({
               // eslint-disable-next-line jsx-a11y/aria-role
               <span role="text">
                 {offScreenText && (
-                  <VisuallyHiddenText {...langProp}>
+                  <VisuallyHiddenText {...hiddenTextProps}>
                     {`${offScreenText}, `}
                   </VisuallyHiddenText>
                 )}
@@ -259,6 +259,7 @@ Bulletin.propTypes = {
   isLive: bool,
   liveText: string,
   offScreenText: string.isRequired,
+  lang: string,
 };
 
 Bulletin.defaultProps = {
@@ -266,6 +267,7 @@ Bulletin.defaultProps = {
   image: null,
   isLive: false,
   liveText: 'LIVE',
+  lang: null,
 };
 
 export default Bulletin;

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -180,11 +180,12 @@ const Bulletin = ({
   isLive,
   liveText,
   offScreenText,
-  lang,
 }) => {
   const isAudio = mediaType === 'audio';
   const bulletinType = isAudio ? 'radio' : 'tv';
   const BulletinWrapper = isAudio ? RadioBulletinWrapper : TVBulletinWrapper;
+  const ctaTextIsEnglish = ctaText === 'Watch' || ctaText === 'Listen';
+  const langProp = ctaTextIsEnglish ? { lang: 'en-GB' } : {};
 
   return (
     <BulletinWrapper>
@@ -213,7 +214,7 @@ const Bulletin = ({
               // eslint-disable-next-line jsx-a11y/aria-role
               <span role="text">
                 {offScreenText && (
-                  <VisuallyHiddenText lang={lang}>
+                  <VisuallyHiddenText {...langProp}>
                     {`${offScreenText}, `}
                   </VisuallyHiddenText>
                 )}
@@ -258,7 +259,6 @@ Bulletin.propTypes = {
   isLive: bool,
   liveText: string,
   offScreenText: string.isRequired,
-  lang: string,
 };
 
 Bulletin.defaultProps = {
@@ -266,7 +266,6 @@ Bulletin.defaultProps = {
   image: null,
   isLive: false,
   liveText: 'LIVE',
-  lang: 'en-GB',
 };
 
 export default Bulletin;

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -185,7 +185,6 @@ const Bulletin = ({
   const isAudio = mediaType === 'audio';
   const bulletinType = isAudio ? 'radio' : 'tv';
   const BulletinWrapper = isAudio ? RadioBulletinWrapper : TVBulletinWrapper;
-  const hiddenTextProps = lang ? { lang } : {};
 
   return (
     <BulletinWrapper>
@@ -214,7 +213,7 @@ const Bulletin = ({
               // eslint-disable-next-line jsx-a11y/aria-role
               <span role="text">
                 {offScreenText && (
-                  <VisuallyHiddenText {...hiddenTextProps}>
+                  <VisuallyHiddenText lang={lang}>
                     {`${offScreenText}, `}
                   </VisuallyHiddenText>
                 )}

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { latin } from '@bbc/gel-foundations/scripts';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
 import Image from '@bbc/psammead-image';
 import Bulletin from '.';
 
@@ -43,6 +43,16 @@ describe('Bulletin', () => {
       service="news"
       mediaType="audio"
       ctaText="Listen"
+    />,
+  );
+
+  shouldMatchSnapshot(
+    'should render audio correctly in arabic',
+    <BulletinComponent
+      script={arabic}
+      service="arabic"
+      mediaType="audio"
+      ctaText="استمع"
     />,
   );
 

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -5,7 +5,14 @@ import Image from '@bbc/psammead-image';
 import Bulletin from '.';
 
 /* eslint-disable react/prop-types */
-const BulletinComponent = ({ script, service, isLive, mediaType, ctaText }) => {
+const BulletinComponent = ({
+  script,
+  service,
+  isLive,
+  mediaType,
+  ctaText,
+  lang = null,
+}) => {
   const summaryText = 'This is the summary text';
   const headlineText = 'This is the headline';
   const ctaLink = 'https://bbc.co.uk';
@@ -31,6 +38,7 @@ const BulletinComponent = ({ script, service, isLive, mediaType, ctaText }) => {
       ctaText={playCtaText}
       isLive={isLive}
       offScreenText={offScreenText}
+      lang={lang}
     />
   );
 };
@@ -47,22 +55,13 @@ describe('Bulletin', () => {
   );
 
   shouldMatchSnapshot(
-    'should render audio correctly in arabic',
+    'should render audio correctly with lang prop passed in',
     <BulletinComponent
       script={arabic}
       service="arabic"
       mediaType="audio"
-      ctaText="استمع"
-    />,
-  );
-
-  shouldMatchSnapshot(
-    'should render video correctly',
-    <BulletinComponent
-      script={latin}
-      service="news"
-      mediaType="video"
-      ctaText="Watch"
+      ctaText="Listen"
+      lang="en-GB"
     />,
   );
 

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -66,6 +66,16 @@ describe('Bulletin', () => {
   );
 
   shouldMatchSnapshot(
+    'should render video correctly',
+    <BulletinComponent
+      script={latin}
+      service="news"
+      mediaType="video"
+      ctaText="Watch"
+    />,
+  );
+
+  shouldMatchSnapshot(
     'should render live audio correctly',
     <BulletinComponent
       script={latin}

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -11,6 +11,7 @@ const BulletinComponent = ({
   isLive,
   mediaType,
   ctaText,
+  dir = 'ltr',
   lang = null,
 }) => {
   const summaryText = 'This is the summary text';
@@ -38,6 +39,7 @@ const BulletinComponent = ({
       ctaText={playCtaText}
       isLive={isLive}
       offScreenText={offScreenText}
+      dir={dir}
       lang={lang}
     />
   );
@@ -61,6 +63,7 @@ describe('Bulletin', () => {
       service="arabic"
       mediaType="audio"
       ctaText="Listen"
+      dir="rtl"
       lang="en-GB"
     />,
   );


### PR DESCRIPTION
Partially resolves #3428 

**Overall change:** _Change default `lang` prop to `null` in psammead-bulletin and apply `lang` attribute to the hidden text if `lang` is defined_

**Code changes:**

- _Change default `lang` prop to null_
- _Apply `lang` attribute if it's defined._
- _Add test for `Arabic` service and update snapshots._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
