### PR TITLE
Do not display bulletin summary when it's not available

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.6 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Do not render paragraph when summary is not available |
 | 3.0.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 3.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.3 | [PR#3381](https://github.com/bbc/psammead/pull/3381) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.6 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Do not render paragraph when summary is not available |
+| 3.0.6 | [PR#3431](https://github.com/bbc/psammead/pull/3431) Do not render paragraph when summary is not available |
 | 3.0.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-story-promo |
 | 3.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.3 | [PR#3381](https://github.com/bbc/psammead/pull/3381) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-bulletin/README.md
+++ b/packages/components/psammead-bulletin/README.md
@@ -24,7 +24,7 @@ npm install @bbc/psammead-bulletin --save
 | `type` | string | yes | N/A | `One of ['audio', 'video']` |
 | `ctaText` | string | yes | N/A | `Watch` |
 | `ctaLink` | string | yes | N/A | `'http://link.to.resource'` |
-| `summary` | string | yes | N/A | `'Bulletin summary'` |
+| `summary` | string | no | `null` | `'Bulletin summary'` |
 | `headlineText` | string | yes | N/A  | `'Bulletin headline'` |
 | `isLive` | boolean | no | `false` | `true` |
 | `liveText` | string | no | `'Live'` | `'Localised Live'` |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -1542,7 +1542,6 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
         >
           <span
             class="c6"
-            lang="en-GB"
           >
             Listen, 
           </span>

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -988,6 +988,266 @@ exports[`Bulletin should render live video correctly 1`] = `
 </div>
 `;
 
+exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
+.c2 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.c6 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c5 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c5:hover,
+.c5:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:visited {
+  color: #6E6E73;
+}
+
+.c1 {
+  vertical-align: top;
+  display: inline-block;
+  width: 100%;
+  padding: 0.5rem 0.5rem 0 0.5rem;
+}
+
+.c3 {
+  display: inline-block;
+  width: 100%;
+}
+
+.c0 {
+  position: relative;
+  background-color: #F2F2F2;
+  display: grid;
+  grid-template-columns: repeat(6,1fr);
+  grid-column-gap: 1rem;
+}
+
+.c4 {
+  color: #222222;
+  margin: 0;
+  padding: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+
+.c8 > svg {
+  color: #FFFFFF;
+  fill: currentColor;
+  width: 1.0625rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.c7 {
+  background-color: #222222;
+  border: 0.0625rem solid transparent;
+  color: #FFFFFF;
+  padding: 0.75rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    width: 50%;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    padding: 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c1 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    width: 50%;
+    padding-left: 1rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c3 {
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    padding: 0 0 0.5rem 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    padding: 0.5rem 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <img
+      alt="Iron man"
+      class="c2"
+      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+    />
+  </div>
+  <div
+    class="c3"
+    dir="ltr"
+  >
+    <h3
+      class="c4"
+      dir="ltr"
+    >
+      <a
+        class="c5"
+        href="https://bbc.co.uk"
+      >
+        <span
+          role="text"
+        >
+          <span
+            class="c6"
+            lang="en-GB"
+          >
+            Listen, 
+          </span>
+          <span>
+            This is the headline
+          </span>
+        </span>
+      </a>
+    </h3>
+    <div
+      aria-hidden="true"
+      class="c7"
+      dir="ltr"
+    >
+      <span
+        class="c8"
+        dir="ltr"
+      />
+      Listen
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Bulletin should render video correctly 1`] = `
 .c2 {
   display: block;

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -1314,6 +1314,15 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   visibility: visible;
 }
 
+.c9 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
 .c6 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -1373,6 +1382,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   display: grid;
   grid-template-columns: repeat(6,1fr);
   grid-column-gap: 1rem;
+  background-color: #F2F2F2;
 }
 
 .c4 {
@@ -1382,8 +1392,8 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
 }
 
 .c8 {
@@ -1430,9 +1440,9 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   font-style: normal;
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c1 {
-    width: 50%;
+    width: 33.33%;
   }
 }
 
@@ -1449,9 +1459,9 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c3 {
-    width: 50%;
+    width: 66.67%;
     padding-left: 1rem;
   }
 }
@@ -1463,29 +1473,25 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
-  .c0 {
-    padding: 1rem;
-  }
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c4 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c4 {
-    padding: 0 0 0.5rem 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0;
   }
 }
 
@@ -1503,13 +1509,14 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   }
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c7 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
     display: inline-flex;
     padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
   }
 }
 
@@ -1559,7 +1566,23 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       <span
         class="c8"
         dir="ltr"
-      />
+      >
+        <svg
+          aria-hidden="true"
+          class="c9"
+          focusable="false"
+          height="12px"
+          viewBox="0 0 13 12"
+          width="13px"
+        >
+          <path
+            d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+          />
+          <path
+            d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+          />
+        </svg>
+      </span>
       Listen
     </div>
   </div>

--- a/packages/components/psammead-bulletin/src/index.jsx
+++ b/packages/components/psammead-bulletin/src/index.jsx
@@ -222,14 +222,16 @@ const Bulletin = ({
             )}
           </Link>
         </BulletinHeading>
-        <BulletinSummary
-          script={script}
-          service={service}
-          bulletinType={bulletinType}
-          dir={dir}
-        >
-          {summaryText}
-        </BulletinSummary>
+        {summaryText && (
+          <BulletinSummary
+            script={script}
+            service={service}
+            bulletinType={bulletinType}
+            dir={dir}
+          >
+            {summaryText}
+          </BulletinSummary>
+        )}
         <PlayCTA
           isLive={isLive}
           service={service}
@@ -253,7 +255,7 @@ Bulletin.propTypes = {
   ctaText: string.isRequired,
   ctaLink: string.isRequired,
   image: node,
-  summaryText: string.isRequired,
+  summaryText: string,
   headlineText: string.isRequired,
   isLive: bool,
   liveText: string,
@@ -264,6 +266,7 @@ Bulletin.propTypes = {
 Bulletin.defaultProps = {
   dir: 'ltr',
   image: null,
+  summaryText: null,
   isLive: false,
   liveText: 'LIVE',
   lang: 'en-GB',

--- a/packages/components/psammead-bulletin/src/index.stories.jsx
+++ b/packages/components/psammead-bulletin/src/index.stories.jsx
@@ -18,6 +18,7 @@ const BulletinComponent = ({
   const ctaLink = 'https://bbc.co.uk';
 
   const isLive = boolean('Live', false);
+  const withSummary = boolean('With summary', true);
   const ctaText = mediaType === 'audio' ? 'Listen' : 'Watch';
   const offScreenText = isLive ? `${ctaText} Live` : ctaText;
 
@@ -36,7 +37,7 @@ const BulletinComponent = ({
       image={hasImage && image}
       mediaType={mediaType}
       headlineText={text}
-      summaryText={text}
+      summaryText={withSummary ? text : null}
       ctaLink={ctaLink}
       ctaText={ctaText}
       isLive={isLive}

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -5,7 +5,14 @@ import Image from '@bbc/psammead-image';
 import Bulletin from '.';
 
 /* eslint-disable react/prop-types */
-const BulletinComponent = ({ script, service, isLive, mediaType, ctaText }) => {
+const BulletinComponent = ({
+  script,
+  service,
+  isLive,
+  mediaType,
+  ctaText,
+  withSummary = true,
+}) => {
   const summaryText = 'This is the summary text';
   const headlineText = 'This is the headline';
   const ctaLink = 'https://bbc.co.uk';
@@ -26,7 +33,7 @@ const BulletinComponent = ({ script, service, isLive, mediaType, ctaText }) => {
       image={image}
       mediaType={mediaType}
       headlineText={headlineText}
-      summaryText={summaryText}
+      summaryText={withSummary ? summaryText : null}
       ctaLink={ctaLink}
       ctaText={playCtaText}
       isLive={isLive}
@@ -75,6 +82,17 @@ describe('Bulletin', () => {
       mediaType="video"
       ctaText="Watch"
       isLive
+    />,
+  );
+
+  shouldMatchSnapshot(
+    'should render radio bulletin without summary correctly',
+    <BulletinComponent
+      script={latin}
+      service="news"
+      mediaType="radio"
+      ctaText="Listen"
+      withSummary={false}
     />,
   );
 });

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -106,7 +106,7 @@ describe('Bulletin', () => {
     <BulletinComponent
       script={latin}
       service="news"
-      mediaType="radio"
+      mediaType="audio"
       ctaText="Listen"
       withSummary={false}
     />,


### PR DESCRIPTION
Resolves #3429

**Overall change:** 
If summary is not available for a Bulletin, a paragraph element is not rendered.

**Code changes:**

- Add condition not to render paragraph when summary is not available.
- Add storybook knobs for turning on/off summary.
- Added snapshot.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
