### PR TITLE
Export updated locales

### DIFF
--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 4.2.0 | [PR#3412](https://github.com/bbc/psammead/pull/3390) Export all updated moment locales |
+| 4.2.0 | [PR#3436](https://github.com/bbc/psammead/pull/3436) Export all updated moment locales |
 | 4.1.8 | [PR#3412](https://github.com/bbc/psammead/pull/3390) Update Swahili relative timestamps |
 | 4.1.7 | [PR#3390](https://github.com/bbc/psammead/pull/3390) Bump prettier major version and disable rule for brackets around a single prop |
 | 4.1.6 | [PR#3357](https://github.com/bbc/psammead/pull/3357) Update Pashto date format for LL & LLL |

--- a/packages/utilities/psammead-locales/CHANGELOG.md
+++ b/packages/utilities/psammead-locales/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 4.2.0 | [PR#3412](https://github.com/bbc/psammead/pull/3390) Export all updated moment locales |
 | 4.1.8 | [PR#3412](https://github.com/bbc/psammead/pull/3390) Update Swahili relative timestamps |
 | 4.1.7 | [PR#3390](https://github.com/bbc/psammead/pull/3390) Bump prettier major version and disable rule for brackets around a single prop |
 | 4.1.6 | [PR#3357](https://github.com/bbc/psammead/pull/3357) Update Pashto date format for LL & LLL |

--- a/packages/utilities/psammead-locales/moment/index.js
+++ b/packages/utilities/psammead-locales/moment/index.js
@@ -1,0 +1,34 @@
+// New locales
+require('./am');
+require('./ha');
+require('./ig');
+require('./om');
+require('./pcm');
+require('./ps');
+require('./rw');
+require('./so');
+require('./ti');
+
+// Updated locales
+require('./ar');
+require('./az');
+require('./bn');
+require('./es');
+require('./gu');
+require('./hi');
+require('./ky');
+require('./mr');
+require('./ne');
+require('./pa-in');
+require('./pt-br');
+require('./ru');
+require('./si');
+require('./sr');
+require('./sr-cyrl');
+require('./sw');
+require('./ta');
+require('./th');
+require('./uk');
+require('./ur');
+require('./uz');
+require('./yo');

--- a/packages/utilities/psammead-locales/package-lock.json
+++ b/packages/utilities/psammead-locales/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.1.8",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-locales/package.json
+++ b/packages/utilities/psammead-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-locales",
-  "version": "4.1.8",
+  "version": "4.2.0",
   "description": "A collection of locale configs, used in BBC World Service sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** _To use the updated moment locales, one has to import all moment locales as shown in this example https://github.com/bbc/psammead/blob/27e9d5ccbea6fe6bf85b164b776739a6fa220936/packages/containers/psammead-timestamp-container/src/index.stories.jsx#L15-L48.
This PR exports these files from a single index.js file in `psammead-locales` so that we don't have to update multiple files when a locale is updated._

**Code changes:**

- _Add `index.js` file which import all updated locales._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
