### PR TITLE
Export visually hidden text styles

### DIFF
--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 1.3.0 | [PR#2404](https://github.com/bbc/psammead/pull/2404) Export visually hidden text styles |
+| 1.3.0 | [PR#3438](https://github.com/bbc/psammead/pull/3438) Export visually hidden text styles |
 | 1.2.3 | [PR#2404](https://github.com/bbc/psammead/pull/2404) replace inputProvider and dirDecorator with withServicesInput |
 | 1.2.2 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update component storybook to use latest inputProvider changes |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-visually-hidden-text/CHANGELOG.md
+++ b/packages/components/psammead-visually-hidden-text/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 1.3.0 | [PR#2404](https://github.com/bbc/psammead/pull/2404) Export visually hidden text styles |
 | 1.2.3 | [PR#2404](https://github.com/bbc/psammead/pull/2404) replace inputProvider and dirDecorator with withServicesInput |
 | 1.2.2 | [PR#1926](https://github.com/bbc/psammead/pull/1926) Update component storybook to use latest inputProvider changes |
 | 1.2.1 | [PR#1803](https://github.com/bbc/psammead/pull/1803/) Patches broken links on badges in documentation |

--- a/packages/components/psammead-visually-hidden-text/package-lock.json
+++ b/packages/components/psammead-visually-hidden-text/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1
 }

--- a/packages/components/psammead-visually-hidden-text/package.json
+++ b/packages/components/psammead-visually-hidden-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-visually-hidden-text",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-visually-hidden-text/src/index.jsx
+++ b/packages/components/psammead-visually-hidden-text/src/index.jsx
@@ -1,6 +1,6 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-export const VisuallyHiddenTextStyle = css`
+export const visuallyHiddenTextStyle = `
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
@@ -11,7 +11,7 @@ export const VisuallyHiddenTextStyle = css`
 `;
 
 const VisuallyHiddenText = styled.span`
-  ${VisuallyHiddenTextStyle};
+  ${visuallyHiddenTextStyle};
 `;
 
 export default VisuallyHiddenText;

--- a/packages/components/psammead-visually-hidden-text/src/index.jsx
+++ b/packages/components/psammead-visually-hidden-text/src/index.jsx
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const VisuallyHiddenText = styled.span`
+export const VisuallyHiddenTextStyle = css`
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
@@ -8,6 +8,10 @@ const VisuallyHiddenText = styled.span`
   position: absolute;
   width: 1px;
   margin: 0;
+`;
+
+const VisuallyHiddenText = styled.span`
+  ${VisuallyHiddenTextStyle};
 `;
 
 export default VisuallyHiddenText;


### PR DESCRIPTION
Resolves #3361 

**Overall change:** _Export visually hidden text styles separate from the `visuallyHiddenText`._

**Code changes:**

- _Export visually hidden text styles._
- _Bump package._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
