### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.142 | [PR#3451](https://github.com/bbc/psammead/pull/3451) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.141 | [PR#3408](https://github.com/bbc/psammead/pull/3408) Include @bbc/psammead-detokeniser in devDependencies |
 | 2.0.140 | [PR#3443](https://github.com/bbc/psammead/pull/3443) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-navigation, @bbc/psammead-radio-schedule |
 | 2.0.139 | [PR#3427](https://github.com/bbc/psammead/pull/3427) Dependency updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.141",
+  "version": "2.0.142",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1667,13 +1667,14 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-2.0.2.tgz",
-      "integrity": "sha512-JUBmkfKQNlcpn0A+MYMeWto2GadsfO/IoNmKWR82HItUpVK3SIOP0f17+KQmc+2l7oRV6kgirx7W8TnqQO1TCg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.0.tgz",
+      "integrity": "sha512-rRD+SXoG9ORFEzPmH28bBz2mjX30IBw2aFQqqULrLqw0dCILz1bGOxeZkNhcckMTMl8FL05DoZFPXUp0cc4TXg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.14.0",
+        "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.3.1",
         "@bbc/psammead-timestamp-container": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.141",
+  "version": "2.0.142",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -77,7 +77,7 @@
     "@bbc/psammead-navigation": "^6.0.10",
     "@bbc/psammead-paragraph": "^2.2.27",
     "@bbc/psammead-play-button": "^1.1.15",
-    "@bbc/psammead-radio-schedule": "2.0.2",
+    "@bbc/psammead-radio-schedule": "3.0.0",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.14",
     "@bbc/psammead-section-label": "^5.0.4",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  2.0.2  →  3.0.0

| Version | Description |
|---------|-------------|
| 3.0.0 | [PR#3408](https://github.com/bbc/psammead/pull/3408) Use detokenizer to construct duration label |
</details>

