### PR TITLE
Update radio schedule prop types

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.1 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Update radio schedule props |
+| 3.0.1 | [PR#3454](https://github.com/bbc/psammead/pull/3454) Update radio schedule props |
 | 3.0.0 | [PR#3408](https://github.com/bbc/psammead/pull/3408) Use detokenizer to construct duration label |
 | 2.0.2 | [PR#3427](https://github.com/bbc/psammead/pull/3427) Updating tests with dependency bump |
 | 2.0.1 | [PR#3414](https://github.com/bbc/psammead/pull/3414) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.1 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Update radio schedule props |
 | 3.0.0 | [PR#3408](https://github.com/bbc/psammead/pull/3408) Use detokenizer to construct duration label |
 | 2.0.2 | [PR#3427](https://github.com/bbc/psammead/pull/3427) Updating tests with dependency bump |
 | 2.0.1 | [PR#3414](https://github.com/bbc/psammead/pull/3414) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/README.md
+++ b/packages/components/psammead-radio-schedule/README.md
@@ -63,6 +63,7 @@ const schedules = [
   dir="ltr"
   liveLabel="LIVE"
   nextLabel="NEXT"
+  durationLabel="Duration %duration%"
 />;
 ```
 

--- a/packages/components/psammead-radio-schedule/README.md
+++ b/packages/components/psammead-radio-schedule/README.md
@@ -23,7 +23,7 @@ npm install @bbc/psammead-radio-schedule --save
 <!-- prettier-ignore -->
 | Argument | Type | Required | Default | Example |
 | -------- | ---- | -------- | ------- | ------- |
-| schedules | array | yes | N/A | `[{ id: '1', state: 'live', stateLabel: 'Live', startTime: '1566914061212', link: 'www.bbc.co.uk', brandTitle: 'This is a brand title', episodeTitle: 'This is an episode title', summary: 'This is a summary', duration: '45:00', durationLabel: 'Duration %duration%'}]` |
+| schedules | array | yes | N/A | `[{ id: '1', state: 'live', stateLabel: 'Live', startTime: '1566914061212', link: 'www.bbc.co.uk', brandTitle: 'This is a brand title', episodeTitle: 'This is an episode title', summary: 'This is a summary', duration: '45:00'}]` |
 | service | string | yes | N/A | `'news'` |
 | script | object | yes | N/A | `{ canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }` |
 | locale | string | no | N/A | `'en-gb'` |
@@ -51,7 +51,6 @@ const schedules = [
     brandTitle: 'This is a brand title',
     summary: 'This is a summary',
     duration: '45:00',
-    durationLabel: 'Duration %duration%',
   },
 ];
 

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -290,7 +290,6 @@ const programCardPropTypes = {
   state: string.isRequired,
   nextLabel: string.isRequired,
   liveLabel: string.isRequired,
-  durationLabel: string.isRequired,
   startTime: number.isRequired,
   timezone: string,
   locale: string,
@@ -312,6 +311,7 @@ renderHeaderContent.defaultProps = {
 ProgramCard.propTypes = {
   dir: oneOf(['rtl', 'ltr']),
   duration: string.isRequired,
+  durationLabel: string.isRequired,
   summary: string,
   ...programCardPropTypes,
 };

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -137,7 +137,6 @@ const programPropTypes = shape({
   brandTitle: string.isRequired,
   summary: string,
   duration: string.isRequired,
-  durationLabel: string.isRequired,
 });
 
 const sharedProps = {
@@ -147,6 +146,7 @@ const sharedProps = {
   script: shape(scriptPropType).isRequired,
   nextLabel: string.isRequired,
   liveLabel: string.isRequired,
+  durationLabel: string.isRequired,
   dir: oneOf(['rtl', 'ltr']),
 };
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Updated `durationLabel` prop type in radio schedules.
This PR is needed because it should fix the warnings in Simorgh PR https://github.com/bbc/simorgh/pull/6397

**Code changes:**

- Updated `durationLabel` propType for Radio Schedule, Program Card and in Readme.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
