### PR TITLE
Disabling chromatic tests for content anchor stories

### DIFF
--- a/packages/components/psammead-content-anchor/CHANGELOG.md
+++ b/packages/components/psammead-content-anchor/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0-alpha.6 | [PR#](https://github.com/bbc/psammead/pull/) Disabling chromatic tests |
+| 1.0.0-alpha.6 | [PR#3457](https://github.com/bbc/psammead/pull/3457) Disabling chromatic tests |
 | 1.0.0-alpha.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-headings |
 | 1.0.0-alpha.4 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |
 | 1.0.0-alpha.3 | [PR#3151](https://github.com/bbc/psammead/pull/3151) Talos - Bump Dependencies - @bbc/psammead-headings |

--- a/packages/components/psammead-content-anchor/CHANGELOG.md
+++ b/packages/components/psammead-content-anchor/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0-alpha.6 | [PR#](https://github.com/bbc/psammead/pull/) Disabling chromatic tests |
 | 1.0.0-alpha.5 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-headings |
 | 1.0.0-alpha.4 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |
 | 1.0.0-alpha.3 | [PR#3151](https://github.com/bbc/psammead/pull/3151) Talos - Bump Dependencies - @bbc/psammead-headings |

--- a/packages/components/psammead-content-anchor/package-lock.json
+++ b/packages/components/psammead-content-anchor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-content-anchor",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-content-anchor/package.json
+++ b/packages/components/psammead-content-anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-content-anchor",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-content-anchor/src/index.stories.jsx
+++ b/packages/components/psammead-content-anchor/src/index.stories.jsx
@@ -97,7 +97,7 @@ storiesOf('Components|ContentAnchor', module)
         </Wrapper>
       );
     },
-    { notes },
+    { notes, chromatic: { disable: true } },
   )
   .add(
     'article with multiple dynamic resize components',
@@ -116,7 +116,7 @@ storiesOf('Components|ContentAnchor', module)
         </Wrapper>
       );
     },
-    { notes },
+    { notes, chromatic: { disable: true } },
   )
   .add(
     'article with multiple time-staggered dynamic resize components',
@@ -135,7 +135,7 @@ storiesOf('Components|ContentAnchor', module)
         </Wrapper>
       );
     },
-    { notes },
+    { notes, chromatic: { disable: true } },
   )
   .add(
     'multiple time-staggered dynamic resize components',


### PR DESCRIPTION
**Overall change:** As the content anchor component uses a different random image, the story changes every time. This means we need to recheck the chromatic test every time which is cumbersome. Disabling these tests in chromatic for now, especially as the component is still an alpha one.

**Code changes:**

- Adds a chromatic disable flag to the stories for the content anchor component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
