### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.146 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.145 | [PR#3453](https://github.com/bbc/psammead/pull/3453) Import updated psammead-locales to storybook config |
 | 2.0.144 | [PR#3455](https://github.com/bbc/psammead/pull/3455) Dependency updates |
 | 2.0.143 | [PR#3456](https://github.com/bbc/psammead/pull/3456) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.145",
+  "version": "2.0.146",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1784,9 +1784,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.1.tgz",
-      "integrity": "sha512-dGpEIx9u6cm2nMSBY4uXsSnWYUfVATB3OBAQ0SDMeqoC+Au6ODo/Grpkh67caFhew1dvryvpp0nI6opFvdhWuw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.2.tgz",
+      "integrity": "sha512-/zLbb9G/Tyzd5XBdh+B2TlHFbS1w5zmq8Qrs4N3BbgOk8tCR/8jk2H7nn5HVMgR7MpNu7cqMbLUr1TgeKpXixw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.145",
+  "version": "2.0.146",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -88,7 +88,7 @@
     "@bbc/psammead-styles": "^4.3.1",
     "@bbc/psammead-test-helpers": "^3.1.5",
     "@bbc/psammead-timestamp": "^2.2.27",
-    "@bbc/psammead-timestamp-container": "^3.0.1",
+    "@bbc/psammead-timestamp-container": "^3.0.2",
     "@bbc/psammead-useful-links": "^1.0.17",
     "@bbc/psammead-visually-hidden-text": "^1.3.0",
     "@loadable/babel-plugin": "^5.12.0",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.2 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.0.1 | [PR#3454](https://github.com/bbc/psammead/pull/3454) Update radio schedule props |
 | 3.0.0 | [PR#3408](https://github.com/bbc/psammead/pull/3408) Use detokenizer to construct duration label |
 | 2.0.2 | [PR#3427](https://github.com/bbc/psammead/pull/3427) Updating tests with dependency bump |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,9 +39,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.1.tgz",
-      "integrity": "sha512-dGpEIx9u6cm2nMSBY4uXsSnWYUfVATB3OBAQ0SDMeqoC+Au6ODo/Grpkh67caFhew1dvryvpp0nI6opFvdhWuw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.2.tgz",
+      "integrity": "sha512-/zLbb9G/Tyzd5XBdh+B2TlHFbS1w5zmq8Qrs4N3BbgOk8tCR/8jk2H7nn5HVMgR7MpNu7cqMbLUr1TgeKpXixw==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-timestamp": "^2.2.27",
@@ -49,9 +49,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
     },
     "moment-timezone": {
       "version": "0.5.28",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^2.14.0",
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-styles": "^4.3.1",
-    "@bbc/psammead-timestamp-container": "^3.0.1",
+    "@bbc/psammead-timestamp-container": "^3.0.2",
     "@bbc/psammead-detokeniser": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.1  →  ^3.0.2

| Version | Description |
|---------|-------------|
| 3.0.2 | [PR#3453](https://github.com/bbc/psammead/pull/3453) Remove imported psammead-locales from storybook stories |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.1  →  ^3.0.2

| Version | Description |
|---------|-------------|
| 3.0.2 | [PR#3453](https://github.com/bbc/psammead/pull/3453) Remove imported psammead-locales from storybook stories |
</details>

