### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.147 | [PR#3464](https://github.com/bbc/psammead/pull/3464) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.146 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.145 | [PR#3453](https://github.com/bbc/psammead/pull/3453) Import updated psammead-locales to storybook config |
 | 2.0.144 | [PR#3455](https://github.com/bbc/psammead/pull/3455) Dependency updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.146",
+  "version": "2.0.147",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1667,9 +1667,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.1.tgz",
-      "integrity": "sha512-izQi5pTILLpLQkBeZe7v1hCTw1WfjqdwSI2HJCms+KKBBTuUOiKiVS2nGDuTIOSZbjmg7WPTPgxJMGbqWdfG8Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.2.tgz",
+      "integrity": "sha512-MhRrwEfeBpFCLm96A2AS6SQyCpuWKLo6JfkR3SzWvv7VuIhXWTgSORNsRnRoRPg0cVXKGwAx35RuPC5GHWhFCA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
@@ -1677,7 +1677,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.3.1",
-        "@bbc/psammead-timestamp-container": "^3.0.1"
+        "@bbc/psammead-timestamp-container": "^3.0.2"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.146",
+  "version": "2.0.147",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -77,7 +77,7 @@
     "@bbc/psammead-navigation": "^6.0.10",
     "@bbc/psammead-paragraph": "^2.2.27",
     "@bbc/psammead-play-button": "^1.1.15",
-    "@bbc/psammead-radio-schedule": "3.0.1",
+    "@bbc/psammead-radio-schedule": "3.0.2",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.14",
     "@bbc/psammead-section-label": "^5.0.4",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.1  →  3.0.2

| Version | Description |
|---------|-------------|
| 3.0.2 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

