### PR TITLE
Add lunar light colour

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.4.0 | [PR#3466](https://github.com/bbc/psammead/pull/3466) Add C_LUNAR_LIGHT |
 | 4.3.1 | [PR#3390](https://github.com/bbc/psammead/pull/3390) Bump prettier major version and disable rule for brackets around a single prop |
 | 4.3.0 | [PR#3020](https://github.com/bbc/psammead/pull/3020) Add colour C_LE_TEAL and set font families to Latin Reith for Learning English |
 | 4.2.0 | [PR#2943](https://github.com/bbc/psammead/pull/2943) Add colour C_KINGFISHER |

--- a/packages/utilities/psammead-styles/index.test.jsx
+++ b/packages/utilities/psammead-styles/index.test.jsx
@@ -65,6 +65,7 @@ const coloursExpectedExports = {
   C_CLOUD_DARK: 'string',
   C_CLOUD_LIGHT: 'string',
   C_LUNAR: 'string',
+  C_LUNAR_LIGHT: 'string',
   C_GHOST: 'string',
   C_METAL: 'string',
   C_CONSENT_BACKGROUND: 'string',

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/__snapshots__/colours.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/colours.test.js.snap
@@ -48,6 +48,8 @@ exports[`Psammead Styles - Colours should match #F5F3F1 for C_OAT_LHT 1`] = `"C_
 
 exports[`Psammead Styles - Colours should match #F6A21D for C_CONSENT_ACTION 1`] = `"C_CONSENT_ACTION"`;
 
+exports[`Psammead Styles - Colours should match #F6F6F6 for C_LUNAR_LIGHT 1`] = `"C_LUNAR_LIGHT"`;
+
 exports[`Psammead Styles - Colours should match #FDFDFD for C_GHOST 1`] = `"C_GHOST"`;
 
 exports[`Psammead Styles - Colours should match #FFFFFF for C_WHITE 1`] = `"C_WHITE"`;

--- a/packages/utilities/psammead-styles/src/colours.js
+++ b/packages/utilities/psammead-styles/src/colours.js
@@ -14,6 +14,7 @@ export const C_SHADOW = '#3F3F42';
 export const C_CLOUD_DARK = '#757575';
 export const C_CLOUD_LIGHT = '#BABABA';
 export const C_LUNAR = '#F2F2F2';
+export const C_LUNAR_LIGHT = '#F6F6F6';
 export const C_GHOST = '#FDFDFD';
 export const C_METAL = '#6E6E73';
 export const C_KINGFISHER = '#11708C';


### PR DESCRIPTION
Resolves #3458

**Overall change:** _Added lunar_light to psamemad-styles to be used for the Ads background in simorgh_

**Code changes:**

- _Export `#F6F6F6` in packages/utilities/psammead-styles/src/colours.js with name of `C_LUNAR_LIGHT`_
- _Update snapshot_
- _Update package.json and change log_

![image](https://user-images.githubusercontent.com/30599794/81679589-3bccf500-944a-11ea-86ad-1fc89494e6b6.png)


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
