### PR TITLE
Section label: apply GHOST background to `See more` link

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.6 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Pass `backgroundColor` to `IndexLinkCta` |
 | 5.0.5 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.3 | [PR#3328](https://github.com/bbc/psammead/pull/3328) Replace a `div` with a `span` tag to fix invalid HTML syntax |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.6 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Pass `backgroundColor` to `IndexLinkCta` |
+| 5.0.6 | [PR#3470](https://github.com/bbc/psammead/pull/3470) Pass `backgroundColor` to `IndexLinkCta` |
 | 5.0.5 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.4 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.3 | [PR#3328](https://github.com/bbc/psammead/pull/3328) Replace a `div` with a `span` tag to fix invalid HTML syntax |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -204,14 +204,14 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 .c7 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-left: 1rem;
   display: -webkit-box;
@@ -427,14 +427,14 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 .c7 {
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-right: 1rem;
   display: -webkit-box;
@@ -650,14 +650,14 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 .c7 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-left: 1rem;
   display: -webkit-box;
@@ -873,14 +873,14 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 .c7 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-left: 1rem;
   display: -webkit-box;
@@ -1720,14 +1720,14 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
 }
 
 .c6 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-left: 1rem;
   display: -webkit-box;
@@ -1920,14 +1920,14 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .c6 {
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-right: 1rem;
   display: -webkit-box;
@@ -2120,14 +2120,14 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .c6 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
   margin: 1rem 0;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   white-space: nowrap;
   padding-left: 1rem;
   display: -webkit-box;

--- a/packages/components/psammead-section-label/src/titles.jsx
+++ b/packages/components/psammead-section-label/src/titles.jsx
@@ -9,7 +9,7 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { getLongPrimer, getDoublePica } from '@bbc/gel-foundations/typography';
-import { C_EBON, C_WHITE, C_GHOST } from '@bbc/psammead-styles/colours';
+import { C_EBON, C_GHOST } from '@bbc/psammead-styles/colours';
 import { getSansBold, getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 const minClickableHeightPx = 44;
@@ -77,7 +77,6 @@ const Title = styled.span`
   color: ${C_EBON};
   background-color: ${props => props.backgroundColor};
   ${titleMargins};
-
   ${paddingDir}: ${GEL_SPACING};
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
@@ -94,24 +93,16 @@ Title.propTypes = {
   id: string.isRequired,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
-  backgroundColor: string,
-};
-
-Title.defaultProps = {
-  backgroundColor: C_GHOST,
 };
 
 const IndexLinkCta = styled.span.attrs({
   'aria-hidden': 'true',
 })`
-  ${({ service }) => getSansBold(service)};
   ${({ script }) => script && getLongPrimer(script)};
-
+  ${({ service }) => getSansBold(service)};
   ${titleMargins};
-
   color: ${C_EBON};
-  background-color: ${C_WHITE};
-
+  background-color: ${props => props.backgroundColor};
   white-space: nowrap;
   ${paddingReverseDir}: ${GEL_SPACING_DBL};
 
@@ -184,7 +175,12 @@ export const LinkTitle = ({
         >
           {title}
         </Title>
-        <IndexLinkCta dir={dir} script={script} service={service}>
+        <IndexLinkCta
+          dir={dir}
+          script={script}
+          service={service}
+          backgroundColor={backgroundColor}
+        >
           {linkText}
         </IndexLinkCta>
       </FlexTextRow>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/6499

**Overall change:**
Apply `C_GHOST` as a default background color in the `See more` link.

**Code changes:**
- Pass `backgroundColor` prop to `IndexLinkCta` to use the `C_GHOST` color as a background.
- Remove  default `backgroundColor` prop from the `Title` as this is inherited from its parent `LinkTitle`.


---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
