### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.152 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.151 | [PR#3471](https://github.com/bbc/psammead/pull/3471) Talos - Bump Dependencies - @bbc/psammead-section-label |
 | 2.0.150 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-grid, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |
 | 2.0.149 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.151",
+  "version": "2.0.152",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1784,13 +1784,13 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.2.tgz",
-      "integrity": "sha512-/zLbb9G/Tyzd5XBdh+B2TlHFbS1w5zmq8Qrs4N3BbgOk8tCR/8jk2H7nn5HVMgR7MpNu7cqMbLUr1TgeKpXixw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
+      "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
-        "@bbc/psammead-timestamp": "^2.2.27",
+        "@bbc/psammead-timestamp": "^2.2.28",
         "moment-timezone": "^0.5.26"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.151",
+  "version": "2.0.152",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -88,7 +88,7 @@
     "@bbc/psammead-styles": "^4.4.0",
     "@bbc/psammead-test-helpers": "^3.1.5",
     "@bbc/psammead-timestamp": "^2.2.28",
-    "@bbc/psammead-timestamp-container": "^3.0.2",
+    "@bbc/psammead-timestamp-container": "^3.0.3",
     "@bbc/psammead-useful-links": "^1.0.18",
     "@bbc/psammead-visually-hidden-text": "^1.3.0",
     "@loadable/babel-plugin": "^5.12.0",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.4 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.0.3 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.2 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.0.1 | [PR#3454](https://github.com/bbc/psammead/pull/3454) Update radio schedule props |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,21 +30,21 @@
       "integrity": "sha512-N6aC/ohJ09f3MfDAdI83md98cQkEzDrogH0N/wP8LdIzVfUHBmjquA07nbBLgF7w22zuFT0tQOXB+OoGwoQQag=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "2.2.27",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.27.tgz",
-      "integrity": "sha512-THQMjd5L5HtFqByDhkybVTIr7Hf3gQPv4Fqeq0uqUG86b87JdJTkhAzBuugoHjD3G7jzsazMSMVfJxduB/ZhOw==",
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.28.tgz",
+      "integrity": "sha512-u5yhY+Mwb8pVaUhGeAd0gP9lhpa+fPDvERCsvtIF3gJGEjbSHkAex/SKUgvuzGsYZ8NnvTQjImrY5Wc2kaDrfw==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
-        "@bbc/psammead-styles": "^4.3.1"
+        "@bbc/psammead-styles": "^4.4.0"
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.2.tgz",
-      "integrity": "sha512-/zLbb9G/Tyzd5XBdh+B2TlHFbS1w5zmq8Qrs4N3BbgOk8tCR/8jk2H7nn5HVMgR7MpNu7cqMbLUr1TgeKpXixw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
+      "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
-        "@bbc/psammead-timestamp": "^2.2.27",
+        "@bbc/psammead-timestamp": "^2.2.28",
         "moment-timezone": "^0.5.26"
       }
     },

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^2.14.0",
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-styles": "^4.4.0",
-    "@bbc/psammead-timestamp-container": "^3.0.2",
+    "@bbc/psammead-timestamp-container": "^3.0.3",
     "@bbc/psammead-detokeniser": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.2  →  ^3.0.3

| Version | Description |
|---------|-------------|
| 3.0.3 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-timestamp |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.2  →  ^3.0.3

| Version | Description |
|---------|-------------|
| 3.0.3 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-timestamp |
</details>

