### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.153 | [PR#3477](https://github.com/bbc/psammead/pull/3477) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.152 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.151 | [PR#3471](https://github.com/bbc/psammead/pull/3471) Talos - Bump Dependencies - @bbc/psammead-section-label |
 | 2.0.150 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-grid, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1667,9 +1667,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.3.tgz",
-      "integrity": "sha512-6DsZSzUpMKcPkn2WTR8nIdaKikgasLffYEt6qiKtCmdxRdVTQkmBiUpEaVQysWuH6u7+vCy6NGNzph73MUy55w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.4.tgz",
+      "integrity": "sha512-qEdR3w4EYOupg2vxspnDCUYQ1/Mwa6uTq3Ex0JSWcWHcxAjp+XpnzZ+c042AauNgvZV5smVWJxOq7WAqdZsE2Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
@@ -1677,7 +1677,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
-        "@bbc/psammead-timestamp-container": "^3.0.2"
+        "@bbc/psammead-timestamp-container": "^3.0.3"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -77,7 +77,7 @@
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",
     "@bbc/psammead-play-button": "^1.1.16",
-    "@bbc/psammead-radio-schedule": "3.0.3",
+    "@bbc/psammead-radio-schedule": "3.0.4",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.15",
     "@bbc/psammead-section-label": "^5.0.6",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.3  →  3.0.4

| Version | Description |
|---------|-------------|
| 3.0.4 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

