### PR TITLE
Voice Over MacOS repeating bulleted list items

### DIFF
--- a/packages/components/psammead-bulleted-list/CHANGELOG.md
+++ b/packages/components/psammead-bulleted-list/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.10 | [PR#3484](https://github.com/bbc/psammead/pull/3484) Voice Over MacOS bug fix. |
 | 1.0.9 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.8 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.7 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-bulleted-list/package-lock.json
+++ b/packages/components/psammead-bulleted-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulleted-list/package.json
+++ b/packages/components/psammead-bulleted-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
@@ -13,8 +13,7 @@ exports[`PsammeadBulletedList should render correctly from ltr 1`] = `
 
 .c0 > li::before {
   content: ' ';
-  display: inline-block;
-  width: 2rem;
+  padding-left: 1.75rem;
   background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E') no-repeat center;
   margin-left: -2rem;
 }
@@ -76,8 +75,7 @@ exports[`PsammeadBulletedList should render correctly from rtl 1`] = `
 
 .c0 > li::before {
   content: ' ';
-  display: inline-block;
-  width: 2rem;
+  padding-left: 1.75rem;
   background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E') no-repeat center;
   margin-right: -2rem;
 }

--- a/packages/components/psammead-bulleted-list/src/index.jsx
+++ b/packages/components/psammead-bulleted-list/src/index.jsx
@@ -8,6 +8,8 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
+const BULLET_PADDING = '1.75rem';
+
 const BulletedList = styled.ul.attrs(() => ({
   role: 'list',
 }))`
@@ -17,8 +19,7 @@ const BulletedList = styled.ul.attrs(() => ({
   list-style-type: none;
   & > li::before {
     content: '\u00A0';
-    display: inline-block;
-    width: ${GEL_SPACING_QUAD};
+    padding-left: ${BULLET_PADDING};
     background: url('data:image/svg+xml,%3Csvg%20height%3D%2710%27%20width%3D%2710%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cstyle%3E%40media%20screen%20and%20%28-ms-high-contrast%3A%20active%29%7Bsvg%7Bfill%3A%20%23fff%7D%7D%3C%2Fstyle%3E%3Ccircle%20cx%3D%275%27%20cy%3D%275%27%20r%3D%273%27%3E%3C%2Fcircle%3E%3C%2Fsvg%3E')
       no-repeat center;
     ${({ dir }) =>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/6557

**Overall change:** 
Remove `display:inline-block` from pseudo-element to prevent VoiceOver MacOS repeating bulleted list items.

**Code changes:**

- Remove `display: inline-block`
- Add padding round bullet point.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing

**To manual test:**
- Use VoiceOver in Safari in Psammead Storybook on `BulletedList` component
- Use the `voiceover-list` branch in Simorgh. Link/copy the `psammead-bulleted-list` component into node_modules and test the bullet points on http://localhost:7080/gahuza/23302543
