### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.155 | [PR#3485](https://github.com/bbc/psammead/pull/3485) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 2.0.154 | [PR#3483](https://github.com/bbc/psammead/pull/3483) Dependency updates |
 | 2.0.153 | [PR#3482](https://github.com/bbc/psammead/pull/3482) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule |
 | 2.0.152 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.154",
+  "version": "2.0.155",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1678,6 +1678,19 @@
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
         "@bbc/psammead-timestamp-container": "^3.0.3"
+      },
+      "dependencies": {
+        "@bbc/psammead-timestamp-container": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
+          "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
+          "dev": true,
+          "requires": {
+            "@bbc/gel-foundations": "^4.0.1",
+            "@bbc/psammead-timestamp": "^2.2.28",
+            "moment-timezone": "^0.5.26"
+          }
+        }
       }
     },
     "@bbc/psammead-rich-text-transforms": {
@@ -1784,9 +1797,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
-      "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-4.0.0.tgz",
+      "integrity": "sha512-jgme3OH4urOv4kB4HC4kfJr2K7g481XN2og7Zi5YlKrPeKwHVdu38cwTGPoVB2OJjE1O8JztYgG6/iewzYKSLw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.154",
+  "version": "2.0.155",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -88,7 +88,7 @@
     "@bbc/psammead-styles": "^4.4.0",
     "@bbc/psammead-test-helpers": "^3.1.5",
     "@bbc/psammead-timestamp": "^2.2.28",
-    "@bbc/psammead-timestamp-container": "^3.0.3",
+    "@bbc/psammead-timestamp-container": "^4.0.0",
     "@bbc/psammead-useful-links": "^1.0.18",
     "@bbc/psammead-visually-hidden-text": "^1.3.0",
     "@loadable/babel-plugin": "^5.12.0",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.5 | [PR#3485](https://github.com/bbc/psammead/pull/3485) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.0.4 | [PR#3475](https://github.com/bbc/psammead/pull/3475) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.0.3 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.2 | [PR#3459](https://github.com/bbc/psammead/pull/3459) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,9 +39,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
-      "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-4.0.0.tgz",
+      "integrity": "sha512-jgme3OH4urOv4kB4HC4kfJr2K7g481XN2og7Zi5YlKrPeKwHVdu38cwTGPoVB2OJjE1O8JztYgG6/iewzYKSLw==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-timestamp": "^2.2.28",
@@ -49,14 +49,14 @@
       }
     },
     "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "moment-timezone": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^2.14.0",
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-styles": "^4.4.0",
-    "@bbc/psammead-timestamp-container": "^3.0.3",
+    "@bbc/psammead-timestamp-container": "^4.0.0",
     "@bbc/psammead-detokeniser": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.3  →  ^4.0.0

| Version | Description |
|---------|-------------|
| 4.0.0 | [PR#3472](https://github.com/bbc/psammead/pull/3472) Do not return current date in formatUnixTimestamp when timestamp is undefined |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^3.0.3  →  ^4.0.0

| Version | Description |
|---------|-------------|
| 4.0.0 | [PR#3472](https://github.com/bbc/psammead/pull/3472) Do not return current date in formatUnixTimestamp when timestamp is undefined |
</details>

