### PR TITLE
Create `PageHeading` component

### DIFF
--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.2.0 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Add `PageHeading` component |
+| 3.2.0 | [PR#3489](https://github.com/bbc/psammead/pull/3489) Add `PageHeading` component |
 | 3.1.30 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.29 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.28 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.2.0 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Add `PageHeading` component |
 | 3.1.30 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.29 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.28 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.2.0 | [PR#3489](https://github.com/bbc/psammead/pull/3489) Add `PageHeading` component |
+| 3.2.0 | [PR#3489](https://github.com/bbc/psammead/pull/3489) Add `IndexH1` component |
 | 3.1.30 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.29 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.28 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -57,9 +57,7 @@ These components can be used at any point on the page, however the `Headline` an
 
 ### Accessibility notes
 
-The `SubHeading` component has a tabindex of `-1` so that it works correctly with screen readers when navigated to via a skip link.
-
-The `Heading` has an id of `content` so it can be announced by screen readers when activating the `Skip to content` link.
+The `SubHeading` and `PageHeading` component have a tabindex of `-1` so that they work correctly with screen readers when navigated to via a skip link.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -39,7 +39,7 @@ const Wrapper = () => (
 );
 ```
 
-`SubHeading` components can be used as page anchors when passed an `id` prop. To take the above usage as an example:
+`SubHeading` and `PageHeading` components can be used as page anchors when passed an `id` attribute. To take the above usage as an example:
 
 ```jsx
 <SubHeading id="some-subheadline" script={latin} service="news">
@@ -51,7 +51,9 @@ This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#
 
 ### When to use this component
 
-These components can be used at any point on the page, however the `Headline` and `PageHeading` are designed to be used once at the top of the page. The `SubHeading` takes an optional `id` value and passes it to the `h2` which can be used as an anchor when referencing content.
+These components can be used at any point on the page, however the `Headline` and `PageHeading` are designed to be used once at the top of the page.
+
+The `SubHeading` and `PageHeading` can take an optional `id` attribute to be passed to the `h2` which can be used as an anchor when referencing content.
 
 <!-- ### When not to use this component -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -59,7 +59,7 @@ The `SubHeading` and `PageHeading` can take an optional `id` attribute which can
 
 ### Accessibility notes
 
-The `SubHeading` and `PageHeading` component have a tabindex of `-1` so that they work correctly with screen readers when navigated to via a skip link.
+The `SubHeading` and `PageHeading` components have a tabindex of `-1`, this ensures that these elements are focusable by assitive technology.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -3,11 +3,11 @@
 
 ## Description
 
-The Headings are a set of three components, `Headline`, `SubHeading` and `PageHeading`.
+The Headings are a set of three components, `Headline`, `SubHeading` and `IndexH1`.
 
-They `Headline` and `SubHeading` use a `h1` and `h2` HTML element respectively, with the `Headline` being designed for a single use on the page, with `SubHeading` being aimed at repeated use.
+The `Headline` and `SubHeading` use a `h1` and `h2` HTML elements respectively, these are used on Article and STY (story) pages.
 
-On the other hand, the `PageHeading` use a `h1` and is designed to be the title of a page, like for example IDX, FIX and Most Read pages.
+`IndexH1` uses a `h1` HTML element and is used on index pages, such as IDX, FIX and Most Read.
 
 ## Installation
 
@@ -39,7 +39,7 @@ const Wrapper = () => (
 );
 ```
 
-`SubHeading` and `PageHeading` components can be used as page anchors when passed an `id` attribute. To take the above usage as an example:
+`SubHeading` and `IndexH1` components can be used as page anchors when passed an `id` attribute. To take the above usage as an example:
 
 ```jsx
 <SubHeading id="some-subheadline" script={latin} service="news">
@@ -51,15 +51,15 @@ This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#
 
 ### When to use this component
 
-These components can be used at any point on the page, however the `Headline` and `PageHeading` are designed to be used once at the top of the page.
+These components can be used at any point on the page, however the `Headline` and `IndexH1` are designed to be used once at the top of the page.
 
-The `SubHeading` and `PageHeading` can take an optional `id` attribute which can be used as an anchor when referencing content.
+The `SubHeading` and `IndexH1` can take an optional `id` attribute which can be used as an anchor when referencing content.
 
 <!-- ### When not to use this component -->
 
 ### Accessibility notes
 
-The `SubHeading` and `PageHeading` components have a tabindex of `-1`, this ensures that these elements are focusable by assitive technology.
+The `SubHeading` and `IndexH1` components have a tabindex of `-1`, this ensures that these elements are focusable by assitive technology.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -3,7 +3,11 @@
 
 ## Description
 
-The Headings are a set of two components, `Headline` and `SubHeading`. They use a `h1` and `h2` HTML element respectively, with the `Headline` being designed for a single use on the page, with `SubHeading` being aimed at repeated use.
+The Headings are a set of three components, `Headline`, `SubHeading` and `PageHeading`.
+
+They `Headline` and `SubHeading` use a `h1` and `h2` HTML element respectively, with the `Headline` being designed for a single use on the page, with `SubHeading` being aimed at repeated use.
+
+On the other hand, the `PageHeading` use a `h1` and is designed to be the title of a page, like for example IDX, FIX and Most Read pages.
 
 ## Installation
 
@@ -47,13 +51,15 @@ This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#
 
 ### When to use this component
 
-These components can be used at any point on the page, however the `Headline` is designed to be used once at the top of the page. The `SubHeading` takes an optional `id` value and passes it to the `h2` which can be used as an anchor when referencing content.
+These components can be used at any point on the page, however the `Headline` and `PageHeading` are designed to be used once at the top of the page. The `SubHeading` takes an optional `id` value and passes it to the `h2` which can be used as an anchor when referencing content.
 
 <!-- ### When not to use this component -->
 
 ### Accessibility notes
 
 The `SubHeading` component has a tabindex of `-1` so that it works correctly with screen readers when navigated to via a skip link.
+
+The `Heading` has an id of `content` so it can be announced by screen readers when activating the `Skip to content` link.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -53,7 +53,7 @@ This usage will allow for the page anchor: `www.bbc.com/news/articles/articleID#
 
 These components can be used at any point on the page, however the `Headline` and `PageHeading` are designed to be used once at the top of the page.
 
-The `SubHeading` and `PageHeading` can take an optional `id` attribute to be passed to the `h2` which can be used as an anchor when referencing content.
+The `SubHeading` and `PageHeading` can take an optional `id` attribute which can be used as an anchor when referencing content.
 
 <!-- ### When not to use this component -->
 

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.30",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.30",
+  "version": "3.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -79,8 +79,8 @@ exports[`Headline component should render correctly with arabic script typograph
 exports[`Page Heading should render correctly 1`] = `
 .c0 {
   color: #6E6E73;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -90,15 +90,15 @@ exports[`Page Heading should render correctly 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
-    font-size: 1.375rem;
-    line-height: 1.625rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c0 {
-    font-size: 1.75rem;
-    line-height: 2rem;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
   }
 }
 
@@ -126,7 +126,7 @@ exports[`Page Heading should render correctly with arabic script typography valu
 .c0 {
   color: #6E6E73;
   font-size: 1.5rem;
-  line-height: 1.875rem;
+  line-height: 2rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -136,15 +136,15 @@ exports[`Page Heading should render correctly with arabic script typography valu
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
-    font-size: 1.75rem;
-    line-height: 2.5rem;
+    font-size: 1.625rem;
+    line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .c0 {
-    font-size: 2rem;
-    line-height: 2.5rem;
+    font-size: 1.75rem;
+    line-height: 2.25rem;
   }
 }
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -13,10 +13,6 @@ exports[`Headline component should render correctly 1`] = `
   padding: 2rem 0;
 }
 
-.c0 37.5rem {
-  padding: 2.5rem 0;
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2rem;
@@ -28,6 +24,12 @@ exports[`Headline component should render correctly 1`] = `
   .c0 {
     font-size: 2.75rem;
     line-height: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 2.5rem 0;
   }
 }
 
@@ -51,10 +53,6 @@ exports[`Headline component should render correctly with arabic script typograph
   padding: 2rem 0;
 }
 
-.c0 37.5rem {
-  padding: 2.5rem 0;
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2.375rem;
@@ -66,6 +64,12 @@ exports[`Headline component should render correctly with arabic script typograph
   .c0 {
     font-size: 2.75rem;
     line-height: 3.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 2.5rem 0;
   }
 }
 
@@ -156,10 +160,6 @@ exports[`SubHeading component should render correctly 1`] = `
   padding: 1.5rem 0;
 }
 
-.c0 37.5rem {
-  padding-top: 2rem;
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
@@ -171,6 +171,12 @@ exports[`SubHeading component should render correctly 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 
@@ -194,10 +200,6 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   padding: 1.5rem 0;
 }
 
-.c0 37.5rem {
-  padding-top: 2rem;
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
@@ -209,6 +211,12 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 
@@ -233,10 +241,6 @@ exports[`SubHeading component should render correctly with arabic script typogra
   padding: 1.5rem 0;
 }
 
-.c0 37.5rem {
-  padding-top: 2rem;
-}
-
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2rem;
@@ -248,6 +252,12 @@ exports[`SubHeading component should render correctly with arabic script typogra
   .c0 {
     font-size: 2.25rem;
     line-height: 3.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding-top: 2rem;
   }
 }
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -13,6 +13,10 @@ exports[`Headline component should render correctly 1`] = `
   padding: 2rem 0;
 }
 
+.c0 37.5rem {
+  padding: 2.5rem 0;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2rem;
@@ -24,12 +28,6 @@ exports[`Headline component should render correctly 1`] = `
   .c0 {
     font-size: 2.75rem;
     line-height: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding: 2.5rem 0;
   }
 }
 
@@ -53,6 +51,10 @@ exports[`Headline component should render correctly with arabic script typograph
   padding: 2rem 0;
 }
 
+.c0 37.5rem {
+  padding: 2.5rem 0;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2.375rem;
@@ -67,16 +69,102 @@ exports[`Headline component should render correctly with arabic script typograph
   }
 }
 
+<h1
+  class="c0"
+>
+  هذا هو العنوان الخاص بي
+</h1>
+`;
+
+exports[`Page Heading should render correctly 1`] = `
+.c0 {
+  color: #6E6E73;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  margin: 0;
+  padding: 1rem 0 1.5rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.375rem;
+    line-height: 1.625rem;
+  }
+}
+
 @media (min-width:37.5rem) {
   .c0 {
-    padding: 2.5rem 0;
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 1.5rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    padding: 1.5rem 0 0.5rem;
   }
 }
 
 <h1
   class="c0"
+  id="content"
 >
-  هذا هو العنوان الخاص بي
+  This is a page heading
+</h1>
+`;
+
+exports[`Page Heading should render correctly with arabic script typography values 1`] = `
+.c0 {
+  color: #6E6E73;
+  font-size: 1.5rem;
+  line-height: 1.875rem;
+  font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  margin: 0;
+  padding: 1rem 0 1.5rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.75rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 1.5rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c0 {
+    padding: 1.5rem 0 0.5rem;
+  }
+}
+
+<h1
+  class="c0"
+  id="content"
+>
+  هذا عنوان الصفحة
 </h1>
 `;
 
@@ -92,6 +180,10 @@ exports[`SubHeading component should render correctly 1`] = `
   padding: 1.5rem 0;
 }
 
+.c0 37.5rem {
+  padding-top: 2rem;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
@@ -103,12 +195,6 @@ exports[`SubHeading component should render correctly 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
   }
 }
 
@@ -132,6 +218,10 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   padding: 1.5rem 0;
 }
 
+.c0 37.5rem {
+  padding-top: 2rem;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 1.5rem;
@@ -143,12 +233,6 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   .c0 {
     font-size: 2rem;
     line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
   }
 }
 
@@ -173,6 +257,10 @@ exports[`SubHeading component should render correctly with arabic script typogra
   padding: 1.5rem 0;
 }
 
+.c0 37.5rem {
+  padding-top: 2rem;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c0 {
     font-size: 2rem;
@@ -184,12 +272,6 @@ exports[`SubHeading component should render correctly with arabic script typogra
   .c0 {
     font-size: 2.25rem;
     line-height: 3.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c0 {
-    padding-top: 2rem;
   }
 }
 

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -117,6 +117,7 @@ exports[`Page Heading should render correctly 1`] = `
 <h1
   class="c0"
   id="content"
+  tabindex="-1"
 >
   This is a page heading
 </h1>
@@ -163,6 +164,7 @@ exports[`Page Heading should render correctly with arabic script typography valu
 <h1
   class="c0"
   id="content"
+  tabindex="-1"
 >
   هذا عنوان الصفحة
 </h1>
@@ -177,11 +179,6 @@ exports[`SubHeading component should render correctly 1`] = `
   font-style: normal;
   color: #3F3F42;
   margin: 0;
-  padding: 1.5rem 0;
-}
-
-.c0 37.5rem {
-  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -215,11 +212,6 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   font-style: normal;
   color: #3F3F42;
   margin: 0;
-  padding: 1.5rem 0;
-}
-
-.c0 37.5rem {
-  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -254,11 +246,6 @@ exports[`SubHeading component should render correctly with arabic script typogra
   font-style: normal;
   color: #3F3F42;
   margin: 0;
-  padding: 1.5rem 0;
-}
-
-.c0 37.5rem {
-  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,6 @@ exports[`Page Heading should render correctly 1`] = `
 
 <h1
   class="c0"
-  id="content"
   tabindex="-1"
 >
   This is a page heading
@@ -141,7 +140,6 @@ exports[`Page Heading should render correctly with arabic script typography valu
 
 <h1
   class="c0"
-  id="content"
   tabindex="-1"
 >
   هذا عنوان الصفحة

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -85,7 +85,6 @@ exports[`Page Heading should render correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   margin: 0;
-  padding: 1rem 0 1.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -99,18 +98,6 @@ exports[`Page Heading should render correctly 1`] = `
   .c0 {
     font-size: 1.5rem;
     line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 1.5rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c0 {
-    padding: 1.5rem 0 0.5rem;
   }
 }
 
@@ -132,7 +119,6 @@ exports[`Page Heading should render correctly with arabic script typography valu
   font-weight: 400;
   font-style: normal;
   margin: 0;
-  padding: 1rem 0 1.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -146,18 +132,6 @@ exports[`Page Heading should render correctly with arabic script typography valu
   .c0 {
     font-size: 1.75rem;
     line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 1.5rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c0 {
-    padding: 1.5rem 0 0.5rem;
   }
 }
 
@@ -179,6 +153,11 @@ exports[`SubHeading component should render correctly 1`] = `
   font-style: normal;
   color: #3F3F42;
   margin: 0;
+  padding: 1.5rem 0;
+}
+
+.c0 37.5rem {
+  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -212,6 +191,11 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   font-style: normal;
   color: #3F3F42;
   margin: 0;
+  padding: 1.5rem 0;
+}
+
+.c0 37.5rem {
+  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -246,6 +230,11 @@ exports[`SubHeading component should render correctly with arabic script typogra
   font-style: normal;
   color: #3F3F42;
   margin: 0;
+  padding: 1.5rem 0;
+}
+
+.c0 37.5rem {
+  padding-top: 2rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -3,8 +3,6 @@ import { shape, string } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { C_SHADOW, C_METAL } from '@bbc/psammead-styles/colours';
 import {
-  GEL_SPACING,
-  GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
@@ -19,11 +17,7 @@ import {
   getSerifMedium,
   getSansRegular,
 } from '@bbc/psammead-styles/font-styles';
-import {
-  GEL_GROUP_3_SCREEN_WIDTH_MIN,
-  GEL_GROUP_3_SCREEN_WIDTH_MAX,
-  GEL_GROUP_4_SCREEN_WIDTH_MIN,
-} from '@bbc/gel-foundations/breakpoints';
+import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
@@ -44,6 +38,10 @@ export const SubHeading = styled.h2.attrs(() => ({
   ${({ service }) => getSansBold(service)}
   color: ${C_SHADOW};
   margin: 0; /* Reset */
+  padding: ${GEL_SPACING_TRPL} 0;
+  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
+    padding-top: ${GEL_SPACING_QUAD};
+  }
 `;
 
 Headline.propTypes = {
@@ -64,11 +62,4 @@ export const PageHeading = styled.h1.attrs(() => ({
   ${({ script }) => script && getDoublePica(script)};
   ${({ service }) => getSansRegular(service)};
   margin: 0;
-  padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING_TRPL};
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    padding: ${GEL_SPACING_TRPL} 0 ${GEL_SPACING_DBL};
-  }
-  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    padding: ${GEL_SPACING_TRPL} 0 ${GEL_SPACING};
-  }
 `;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -44,10 +44,6 @@ export const SubHeading = styled.h2.attrs(() => ({
   ${({ service }) => getSansBold(service)}
   color: ${C_SHADOW};
   margin: 0; /* Reset */
-  padding: ${GEL_SPACING_TRPL} 0;
-  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
-    padding-top: ${GEL_SPACING_QUAD};
-  }
 `;
 
 Headline.propTypes = {

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -54,7 +54,7 @@ SubHeading.propTypes = {
   service: string.isRequired,
 };
 
-export const PageHeading = styled.h1.attrs(() => ({
+export const IndexH1 = styled.h1.attrs(() => ({
   tabIndex: '-1',
 }))`
   color: ${C_METAL};
@@ -63,7 +63,7 @@ export const PageHeading = styled.h1.attrs(() => ({
   margin: 0;
 `;
 
-PageHeading.propTypes = {
+IndexH1.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
 };

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -26,7 +26,7 @@ export const Headline = styled.h1`
   display: block; /* Explicitly set */
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0;
-  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding: ${GEL_SPACING_QUIN} 0;
   }
 `;
@@ -39,7 +39,7 @@ export const SubHeading = styled.h2.attrs(() => ({
   color: ${C_SHADOW};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_TRPL} 0;
-  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding-top: ${GEL_SPACING_QUAD};
   }
 `;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,15 +1,29 @@
 import styled from 'styled-components';
 import { shape, string } from 'prop-types';
-import { C_SHADOW } from '@bbc/psammead-styles/colours';
+import { scriptPropType } from '@bbc/gel-foundations/prop-types';
+import { C_SHADOW, C_METAL } from '@bbc/psammead-styles/colours';
 import {
+  GEL_SPACING,
+  GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
 } from '@bbc/gel-foundations/spacings';
-import { getCanon, getTrafalgar } from '@bbc/gel-foundations/typography';
-import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
-import { scriptPropType } from '@bbc/gel-foundations/prop-types';
-import { getSansBold, getSerifMedium } from '@bbc/psammead-styles/font-styles';
+import {
+  getCanon,
+  getTrafalgar,
+  getDoublePica,
+} from '@bbc/gel-foundations/typography';
+import {
+  getSansBold,
+  getSerifMedium,
+  getSansRegular,
+} from '@bbc/psammead-styles/font-styles';
+import {
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MAX,
+  GEL_GROUP_4_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
@@ -18,7 +32,7 @@ export const Headline = styled.h1`
   display: block; /* Explicitly set */
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0;
-  ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
+  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
     padding: ${GEL_SPACING_QUIN} 0;
   }
 `;
@@ -31,7 +45,7 @@ export const SubHeading = styled.h2.attrs(() => ({
   color: ${C_SHADOW};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_TRPL} 0;
-  ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
+  ${GEL_GROUP_3_SCREEN_WIDTH_MIN} {
     padding-top: ${GEL_SPACING_QUAD};
   }
 `;
@@ -45,3 +59,19 @@ SubHeading.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
 };
+
+export const PageHeading = styled.h1.attrs(() => ({
+  id: 'content',
+}))`
+  color: ${C_METAL};
+  ${({ script }) => script && getDoublePica(script)};
+  ${({ service }) => getSansRegular(service)};
+  margin: 0;
+  padding: ${GEL_SPACING_DBL} 0 ${GEL_SPACING_TRPL};
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    padding: ${GEL_SPACING_TRPL} 0 ${GEL_SPACING_DBL};
+  }
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    padding: ${GEL_SPACING_TRPL} 0 ${GEL_SPACING};
+  }
+`;

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -62,6 +62,7 @@ SubHeading.propTypes = {
 
 export const PageHeading = styled.h1.attrs(() => ({
   id: 'content',
+  tabIndex: '-1',
 }))`
   color: ${C_METAL};
   ${({ script }) => script && getDoublePica(script)};

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -31,6 +31,11 @@ export const Headline = styled.h1`
   }
 `;
 
+Headline.propTypes = {
+  script: shape(scriptPropType).isRequired,
+  service: string.isRequired,
+};
+
 export const SubHeading = styled.h2.attrs(() => ({
   tabIndex: '-1',
 }))`
@@ -44,18 +49,12 @@ export const SubHeading = styled.h2.attrs(() => ({
   }
 `;
 
-Headline.propTypes = {
-  script: shape(scriptPropType).isRequired,
-  service: string.isRequired,
-};
-
 SubHeading.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
 };
 
 export const PageHeading = styled.h1.attrs(() => ({
-  id: 'content',
   tabIndex: '-1',
 }))`
   color: ${C_METAL};
@@ -63,3 +62,8 @@ export const PageHeading = styled.h1.attrs(() => ({
   ${({ service }) => getSansRegular(service)};
   margin: 0;
 `;
+
+PageHeading.propTypes = {
+  script: shape(scriptPropType).isRequired,
+  service: string.isRequired,
+};

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -5,7 +5,7 @@ import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import { Headline, SubHeading, PageHeading } from './index';
 
-storiesOf('Components|Headline', module)
+storiesOf('Components|Headings/Headline', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
   .add(
@@ -18,7 +18,7 @@ storiesOf('Components|Headline', module)
     { notes, knobs: { escapeHTML: false } },
   );
 
-storiesOf('Components|SubHeading', module)
+storiesOf('Components|Headings/SubHeading', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
   .add(
@@ -43,7 +43,7 @@ storiesOf('Components|SubHeading', module)
     { notes, knobs: { escapeHTML: false } },
   );
 
-storiesOf('Components|Page Heading', module)
+storiesOf('Components|Headings/Page Heading', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
   .add(

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -54,4 +54,16 @@ storiesOf('Components|Headings/Page Heading', module)
       </PageHeading>
     ),
     { notes, knobs: { escapeHTML: false } },
+  )
+  .add(
+    'with optional ID',
+    ({ text: textSnippet, script, service }) => {
+      const id = text('ID', 'content', 'Other');
+      return (
+        <PageHeading id={id} script={script} service={service}>
+          {textSnippet}
+        </PageHeading>
+      );
+    },
+    { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
-import { Headline, SubHeading } from './index';
+import { Headline, SubHeading, PageHeading } from './index';
 
 storiesOf('Components|Headline', module)
   .addDecorator(withKnobs)
@@ -40,5 +40,18 @@ storiesOf('Components|SubHeading', module)
         </SubHeading>
       );
     },
+    { notes, knobs: { escapeHTML: false } },
+  );
+
+storiesOf('Components|Page Heading', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withServicesKnob())
+  .add(
+    'default',
+    ({ text: textSnippet, script, service }) => (
+      <PageHeading script={script} service={service}>
+        {textSnippet}
+      </PageHeading>
+    ),
     { notes, knobs: { escapeHTML: false } },
   );

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
-import { Headline, SubHeading, PageHeading } from './index';
+import { Headline, SubHeading, IndexH1 } from './index';
 
 storiesOf('Components|Headings/Headline', module)
   .addDecorator(withKnobs)
@@ -49,9 +49,9 @@ storiesOf('Components|Headings/Page Heading', module)
   .add(
     'default',
     ({ text: textSnippet, script, service }) => (
-      <PageHeading script={script} service={service}>
+      <IndexH1 script={script} service={service}>
         {textSnippet}
-      </PageHeading>
+      </IndexH1>
     ),
     { notes, knobs: { escapeHTML: false } },
   )
@@ -60,9 +60,9 @@ storiesOf('Components|Headings/Page Heading', module)
     ({ text: textSnippet, script, service }) => {
       const id = text('ID', 'content', 'Other');
       return (
-        <PageHeading id={id} script={script} service={service}>
+        <IndexH1 id={id} script={script} service={service}>
           {textSnippet}
-        </PageHeading>
+        </IndexH1>
       );
     },
     { notes, knobs: { escapeHTML: false } },

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { latin, arabic } from '@bbc/gel-foundations/scripts';
-import { Headline, SubHeading, PageHeading } from './index';
+import { Headline, SubHeading, IndexH1 } from './index';
 
 describe('Headline component', () => {
   shouldMatchSnapshot(
@@ -45,15 +45,15 @@ describe('SubHeading component', () => {
 describe('Page Heading', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <PageHeading script={latin} service="news">
+    <IndexH1 script={latin} service="news">
       This is a page heading
-    </PageHeading>,
+    </IndexH1>,
   );
 
   shouldMatchSnapshot(
     'should render correctly with arabic script typography values',
-    <PageHeading script={arabic} service="persian">
+    <IndexH1 script={arabic} service="persian">
       هذا عنوان الصفحة
-    </PageHeading>,
+    </IndexH1>,
   );
 });

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { latin, arabic } from '@bbc/gel-foundations/scripts';
-import { Headline, SubHeading } from './index';
+import { Headline, SubHeading, PageHeading } from './index';
 
 describe('Headline component', () => {
   shouldMatchSnapshot(
@@ -39,5 +39,21 @@ describe('SubHeading component', () => {
     <SubHeading id="This-is-a-SubHeading" script={latin} service="news">
       This is a SubHeading
     </SubHeading>,
+  );
+});
+
+describe('Page Heading', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <PageHeading script={latin} service="news">
+      This is a page heading
+    </PageHeading>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with arabic script typography values',
+    <PageHeading script={arabic} service="persian">
+      هذا عنوان الصفحة
+    </PageHeading>,
   );
 });


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/6414

**Overall change:** 
Create a new `PageHeading` component so it can be reused on different page types as `IDX` and `Most Read`.

**Code changes:**
- Add the new `PageHeading` component within the existing `psammead-headings` package
- Add a new story
- Add snapshots

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
