### PR TITLE
Create psammead-heading-index package

### DIFF
--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Psammead Heading Index Changelog
+
+<!-- prettier-ignore -->
+| Version | Description |
+|---------|-------------|
+| 1.0.0   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Initial creation of package. |

--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,4 +3,4 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#XXX](https://github.com/BBC-News/psammead/pull/XXX) Initial creation of package. |
+| 1.0.0   | [PR#3501](https://github.com/BBC-News/psammead/pull/3501) Initial creation of package. |

--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,4 +3,4 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0   | [PR#3501](https://github.com/BBC-News/psammead/pull/3501) Initial creation of package. |
+| 1.0.0-alpha.1 | [PR#3501](https://github.com/BBC-News/psammead/pull/3501) Initial creation of package. |

--- a/packages/components/psammead-heading-index/README.md
+++ b/packages/components/psammead-heading-index/README.md
@@ -1,0 +1,69 @@
+<!-- prettier-ignore -->
+# ⛔️ This is an alpha component ⛔️
+
+This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
+
+# psammead-heading-index - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-heading-index%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-heading-index%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-heading-index)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-heading-index) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-heading-index)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-heading-index&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/headline--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-heading-index.svg)](https://www.npmjs.com/package/@bbc/psammead-heading-index) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
+
+## Description
+
+The `IndexH1` uses a `h1` HTML element and is used on index pages, such as IDX, FIX and Most Read.
+
+## Installation
+
+`npm install @bbc/psammead-heading-index`
+
+## Props
+
+<!-- prettier-ignore -->
+| Argument  | Type | Required | Default | Example |
+| --------- | ---- | -------- | ------- | ------- |
+| script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
+| service | string | yes | N/A | `'news'` |
+
+## Usage
+
+```jsx
+import { IndexH1 } from '@bbc/psammead-heading-index';
+import { latin } from '@bbc/gel-foundations/scripts';
+
+const Wrapper = () => (
+  <Fragment>
+    <IndexH1 script={script} service={service}>
+      Heading
+    </IndexH1>
+  </Fragment>
+);
+```
+
+### When to use this component
+
+This component is designed to be used once at the top of the page.
+
+The `IndexH1` can take an optional `id` attribute which can be used as an anchor when referencing content.
+
+```jsx
+<IndexH1 id="content" script={latin} service="news">
+  Heading
+</IndexH1>
+```
+
+<!-- ### When not to use this component -->
+
+### Accessibility notes
+
+The `IndexH1` component has a tabindex of `-1`, this ensures that it is focusable by assitive technology.
+
+<!-- ## Roadmap -->
+
+## Contributing
+
+Psammead is completely open source. We are grateful for any contributions, whether they be new components, bug fixes or general improvements. Please see our primary contributing guide which can be found at [the root of the Psammead respository](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md).
+
+### [Code of Conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md)
+
+We welcome feedback and help on this work. By participating in this project, you agree to abide by the [code of conduct](https://github.com/bbc/psammead/blob/latest/CODE_OF_CONDUCT.md). Please take a moment to read it.
+
+### License
+
+Psammead is [Apache 2.0 licensed](https://github.com/bbc/psammead/blob/latest/LICENSE).

--- a/packages/components/psammead-heading-index/README.md
+++ b/packages/components/psammead-heading-index/README.md
@@ -7,7 +7,7 @@ This component is currently tagged as alpha and is not suitable for production u
 
 ## Description
 
-The `IndexH1` uses a `h1` HTML element and is used on index pages, such as IDX, FIX and Most Read.
+The `HeadingIndex` uses a `h1` HTML element and is used on index pages, such as IDX, FIX and Most Read.
 
 ## Installation
 
@@ -24,14 +24,14 @@ The `IndexH1` uses a `h1` HTML element and is used on index pages, such as IDX, 
 ## Usage
 
 ```jsx
-import { IndexH1 } from '@bbc/psammead-heading-index';
+import HeadingIndex from '@bbc/psammead-heading-index';
 import { latin } from '@bbc/gel-foundations/scripts';
 
 const Wrapper = () => (
   <Fragment>
-    <IndexH1 script={script} service={service}>
+    <HeadingIndex script={script} service={service}>
       Heading
-    </IndexH1>
+    </HeadingIndex>
   </Fragment>
 );
 ```
@@ -40,19 +40,19 @@ const Wrapper = () => (
 
 This component is designed to be used once at the top of the page.
 
-The `IndexH1` can take an optional `id` attribute which can be used as an anchor when referencing content.
+The `HeadingIndex` can take an optional `id` attribute which can be used as an anchor when referencing content.
 
 ```jsx
-<IndexH1 id="content" script={latin} service="news">
+<HeadingIndex id="content" script={latin} service="news">
   Heading
-</IndexH1>
+</HeadingIndex>
 ```
 
 <!-- ### When not to use this component -->
 
 ### Accessibility notes
 
-The `IndexH1` component has a tabindex of `-1`, this ensures that it is focusable by assitive technology.
+The `HeadingIndex` component has a tabindex of `-1`, this ensures that it is focusable by assitive technology.
 
 <!-- ## Roadmap -->
 

--- a/packages/components/psammead-heading-index/README.md
+++ b/packages/components/psammead-heading-index/README.md
@@ -29,7 +29,7 @@ import { latin } from '@bbc/gel-foundations/scripts';
 
 const Wrapper = () => (
   <Fragment>
-    <HeadingIndex script={script} service={service}>
+    <HeadingIndex script={latin} service="news">
       Heading
     </HeadingIndex>
   </Fragment>

--- a/packages/components/psammead-heading-index/package-lock.json
+++ b/packages/components/psammead-heading-index/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "@bbc/psammead-heading-index",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bbc/gel-foundations": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.0.1.tgz",
+      "integrity": "sha512-0h3p8aG9sGbsEu0y8UOQ/d6VoLoFY0KdsOqwSTkIH0+IyDq9LzMLjP4ceDk+gK1qtAMb+SuqitFjllX/9KavCg=="
+    },
+    "@bbc/psammead-styles": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.4.0.tgz",
+      "integrity": "sha512-N6aC/ohJ09f3MfDAdI83md98cQkEzDrogH0N/wP8LdIzVfUHBmjquA07nbBLgF7w22zuFT0tQOXB+OoGwoQQag=="
+    }
+  }
+}

--- a/packages/components/psammead-heading-index/package-lock.json
+++ b/packages/components/psammead-heading-index/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -7,7 +7,7 @@
   "description": "A H1 to be used on Index Pages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bbc/psammead/tree/latest/packages/components/psammead-headings"
+    "url": "https://github.com/bbc/psammead/tree/latest/packages/components/psammead-heading-index"
   },
   "author": {
     "name": "Psammead Maintainers",
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/bbc/psammead/issues"
   },
-  "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
+  "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-heading-index/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^4.0.1",
     "@bbc/psammead-styles": "^4.4.0"
@@ -27,7 +27,7 @@
   },
   "keywords": [
     "bbc",
-    "headings",
+    "heading",
     "index"
   ],
   "publishConfig": {

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@bbc/psammead-heading-index",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "module": "esm/index.js",
+  "sideEffects": false,
+  "description": "A H1 to be used on Index Pages",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bbc/psammead/tree/latest/packages/components/psammead-headings"
+  },
+  "author": {
+    "name": "Psammead Maintainers",
+    "email": "PsammeadMaintainers@bbc.co.uk"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/bbc/psammead/issues"
+  },
+  "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
+  "dependencies": {
+    "@bbc/gel-foundations": "^4.0.1",
+    "@bbc/psammead-styles": "^4.4.0"
+  },
+  "peerDependencies": {
+    "styled-components": "^4.3.2"
+  },
+  "keywords": [
+    "bbc",
+    "headings",
+    "index"
+  ],
+  "publishConfig": {
+    "tag": "alpha"
+  }
+}

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
-  "description": "A H1 to be used on Index Pages",
+  "description": "A h1 to be used on index pages",
   "repository": {
     "type": "git",
     "url": "https://github.com/bbc/psammead/tree/latest/packages/components/psammead-heading-index"

--- a/packages/components/psammead-heading-index/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-heading-index/src/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Index Heading should render correctly 1`] = `
+.c0 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #6E6E73;
+  margin: 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+<h1
+  class="c0"
+  tabindex="-1"
+>
+  This is a page heading
+</h1>
+`;
+
+exports[`Index Heading should render correctly with arabic script typography values 1`] = `
+.c0 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #6E6E73;
+  margin: 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.625rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1.75rem;
+    line-height: 2.25rem;
+  }
+}
+
+<h1
+  class="c0"
+  tabindex="-1"
+>
+  هذا عنوان الصفحة
+</h1>
+`;

--- a/packages/components/psammead-heading-index/src/index.jsx
+++ b/packages/components/psammead-heading-index/src/index.jsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { shape, string } from 'prop-types';
+import { scriptPropType } from '@bbc/gel-foundations/prop-types';
+import { C_METAL } from '@bbc/psammead-styles/colours';
+import { getDoublePica } from '@bbc/gel-foundations/typography';
+import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+
+const IndexH1 = styled.h1.attrs(() => ({
+  tabIndex: '-1',
+}))`
+  ${({ script }) => script && getDoublePica(script)};
+  ${({ service }) => getSansRegular(service)};
+  color: ${C_METAL};
+  margin: 0;
+`;
+
+IndexH1.propTypes = {
+  script: shape(scriptPropType).isRequired,
+  service: string.isRequired,
+};
+
+export default IndexH1;

--- a/packages/components/psammead-heading-index/src/index.jsx
+++ b/packages/components/psammead-heading-index/src/index.jsx
@@ -5,7 +5,7 @@ import { C_METAL } from '@bbc/psammead-styles/colours';
 import { getDoublePica } from '@bbc/gel-foundations/typography';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-const IndexH1 = styled.h1.attrs(() => ({
+const HeadingIndex = styled.h1.attrs(() => ({
   tabIndex: '-1',
 }))`
   ${({ script }) => script && getDoublePica(script)};
@@ -14,9 +14,9 @@ const IndexH1 = styled.h1.attrs(() => ({
   margin: 0;
 `;
 
-IndexH1.propTypes = {
+HeadingIndex.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
 };
 
-export default IndexH1;
+export default HeadingIndex;

--- a/packages/components/psammead-heading-index/src/index.stories.jsx
+++ b/packages/components/psammead-heading-index/src/index.stories.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
-import IndexH1 from './index';
+import HeadingIndex from './index';
 
 storiesOf('Components|Index Heading', module)
   .addDecorator(withKnobs)
@@ -11,9 +11,9 @@ storiesOf('Components|Index Heading', module)
   .add(
     'default',
     ({ text: textSnippet, script, service }) => (
-      <IndexH1 script={script} service={service}>
+      <HeadingIndex script={script} service={service}>
         {textSnippet}
-      </IndexH1>
+      </HeadingIndex>
     ),
     { notes, knobs: { escapeHTML: false } },
   )
@@ -22,9 +22,9 @@ storiesOf('Components|Index Heading', module)
     ({ text: textSnippet, script, service }) => {
       const id = text('ID', 'content', 'Other');
       return (
-        <IndexH1 id={id} script={script} service={service}>
+        <HeadingIndex id={id} script={script} service={service}>
           {textSnippet}
-        </IndexH1>
+        </HeadingIndex>
       );
     },
     { notes, knobs: { escapeHTML: false } },

--- a/packages/components/psammead-heading-index/src/index.stories.jsx
+++ b/packages/components/psammead-heading-index/src/index.stories.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import notes from '../README.md';
+import IndexH1 from './index';
+
+storiesOf('Components|Index Heading', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withServicesKnob())
+  .add(
+    'default',
+    ({ text: textSnippet, script, service }) => (
+      <IndexH1 script={script} service={service}>
+        {textSnippet}
+      </IndexH1>
+    ),
+    { notes, knobs: { escapeHTML: false } },
+  )
+  .add(
+    'with optional ID',
+    ({ text: textSnippet, script, service }) => {
+      const id = text('ID', 'content', 'Other');
+      return (
+        <IndexH1 id={id} script={script} service={service}>
+          {textSnippet}
+        </IndexH1>
+      );
+    },
+    { notes, knobs: { escapeHTML: false } },
+  );

--- a/packages/components/psammead-heading-index/src/index.test.jsx
+++ b/packages/components/psammead-heading-index/src/index.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { latin, arabic } from '@bbc/gel-foundations/scripts';
+import IndexH1 from './index';
+
+describe('Index Heading', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <IndexH1 script={latin} service="news">
+      This is a page heading
+    </IndexH1>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly with arabic script typography values',
+    <IndexH1 script={arabic} service="persian">
+      هذا عنوان الصفحة
+    </IndexH1>,
+  );
+});

--- a/packages/components/psammead-heading-index/src/index.test.jsx
+++ b/packages/components/psammead-heading-index/src/index.test.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { latin, arabic } from '@bbc/gel-foundations/scripts';
-import IndexH1 from './index';
+import HeadingIndex from './index';
 
 describe('Index Heading', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <IndexH1 script={latin} service="news">
+    <HeadingIndex script={latin} service="news">
       This is a page heading
-    </IndexH1>,
+    </HeadingIndex>,
   );
 
   shouldMatchSnapshot(
     'should render correctly with arabic script typography values',
-    <IndexH1 script={arabic} service="persian">
+    <HeadingIndex script={arabic} service="persian">
       هذا عنوان الصفحة
-    </IndexH1>,
+    </HeadingIndex>,
   );
 });


### PR DESCRIPTION
Part of  bbc/simorgh#6414

**Overall change:** 
Create a new `psammead-heading-index` alpha package that exports a `H1` that can be reused on Index Pages such as IDX, FIX and Most Read.

**Code changes:**
- Add a new `HeadingIndex` component
- Add new story
- Add snapshots

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
