### PR TITLE
Most read item padding bottom

### DIFF
--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.3 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Fix padding bottom bug |
 | 4.1.2 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-grid |
 | 4.1.1 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.1.0 | [PR#3409](https://github.com/bbc/psammead/pull/3409) Added size prop for item and rank |

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.1.3 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Fix padding bottom bug |
+| 4.1.3 | [PR#3502](https://github.com/bbc/psammead/pull/3502) Fix padding bottom bug |
 | 4.1.2 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-grid |
 | 4.1.1 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.1.0 | [PR#3409](https://github.com/bbc/psammead/pull/3409) Added size prop for item and rank |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/Item/__snapshots__/index.test.jsx.snap
@@ -34,7 +34,6 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 .c5 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -53,6 +52,7 @@ exports[`MostReadItemWrapper should render ltr correctly with 10 items 1`] = `
 
 .c1 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c4 {
@@ -726,7 +726,6 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 .c5 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
@@ -745,6 +744,7 @@ exports[`MostReadItemWrapper should render rtl correctly with 10 items 1`] = `
 
 .c1 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c4 {
@@ -1418,7 +1418,6 @@ exports[`MostReadLink should render ltr correctly 1`] = `
 
 .c0 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -1497,7 +1496,6 @@ exports[`MostReadLink should render rtl correctly 1`] = `
 
 .c0 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
@@ -1576,7 +1574,6 @@ exports[`MostReadLink should render with last updated date correctly 1`] = `
 
 .c0 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }

--- a/packages/components/psammead-most-read/src/Item/index.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.jsx
@@ -71,7 +71,6 @@ const getRankPaddingStart = size =>
 
 const StyledItem = styled.div`
   padding-top: ${({ size }) => getRankPaddingTop(size)};
-  padding-bottom: ${GEL_SPACING_TRPL};
   ${paddingStart}: ${({ size }) => getRankPaddingStart(size)};
   ${paddingEnd}: ${GEL_SPACING_DBL};
 
@@ -128,6 +127,7 @@ const StyledGrid = styled(Grid).attrs({
   role: 'listitem',
 })`
   position: relative;
+  padding-bottom: ${GEL_SPACING_TRPL};
 `;
 
 export const MostReadItemWrapper = ({ dir, children, columnLayout }) => (

--- a/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-most-read/src/List/__snapshots__/index.test.jsx.snap
@@ -42,7 +42,6 @@ exports[`MostReadList should render with ltr bengali items with correct dir 1`] 
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -61,6 +60,7 @@ exports[`MostReadList should render with ltr bengali items with correct dir 1`] 
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -765,7 +765,6 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -784,6 +783,7 @@ exports[`MostReadList should render with ltr burmese items with correct dir 1`] 
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -1488,7 +1488,6 @@ exports[`MostReadList should render with ltr news items with a max of one column
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -1507,6 +1506,7 @@ exports[`MostReadList should render with ltr news items with a max of one column
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -2199,7 +2199,6 @@ exports[`MostReadList should render with ltr news items with a max of two column
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -2218,6 +2217,7 @@ exports[`MostReadList should render with ltr news items with a max of two column
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -2916,7 +2916,6 @@ exports[`MostReadList should render with ltr news items with a multi column layo
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -2935,6 +2934,7 @@ exports[`MostReadList should render with ltr news items with a multi column layo
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -3639,7 +3639,6 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -3658,6 +3657,7 @@ exports[`MostReadList should render with ltr news items with correct dir 1`] = `
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {
@@ -4362,7 +4362,6 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 .c7 {
   padding-top: 0.375rem;
-  padding-bottom: 1.5rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
@@ -4381,6 +4380,7 @@ exports[`MostReadList should render with rtl arabic items with correct dir 1`] =
 
 .c3 {
   position: relative;
+  padding-bottom: 1.5rem;
 }
 
 .c6 {


### PR DESCRIPTION
Resolves #3437

**Overall change:** _Update the padding bottom for the most read items_

Currently on LIVE, if the titles do not wrap, then there is a smaller space between item and the next. This is because the padding bottom is being applied to the title itself and not the itemWrapper (which includes the rank).
![image](https://user-images.githubusercontent.com/30599794/83165650-bdd54300-a105-11ea-8df1-f111d0f9be87.png)

Tested locally on Simorgh (with changes from this PR):

![image](https://user-images.githubusercontent.com/30599794/83167249-e8280000-a107-11ea-956e-4aca2d18115c.png)


Simorgh Locally (without psammead changes):
![image](https://user-images.githubusercontent.com/30599794/83167267-efe7a480-a107-11ea-83fb-7e4ce39827c4.png)



**Code changes:**

- _Move padding bottom from MostReadLink element to the MostReadItemWrapper element._
- _Update snapshots._
- _Update changelog_
- _Update package.json_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
