### PR TITLE
Update fallback text colour in Social Embed

### DIFF
--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                           |
 | ------------- | ----------------------------------------------------------------------------------------------------- |
+| 1.1.3         | [PR#3513](https://github.com/bbc/psammead/pull/3513) Update fallback text colour in Social Embed.     |
 | 1.1.2         | [PR#3476](https://github.com/bbc/psammead/pull/3476) Resolve provider script bugs.                    |
 | 1.1.1         | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.1.0         | [PR#3450](https://github.com/bbc/psammead/pull/3450) Update Canonical provider styles                 |

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-social-embed/src/Notice/index.jsx
+++ b/packages/components/psammead-social-embed/src/Notice/index.jsx
@@ -1,7 +1,12 @@
 import React, { memo } from 'react';
 import { string } from 'prop-types';
 import styled from 'styled-components';
-import { C_PEBBLE, C_METAL, C_SHADOW } from '@bbc/psammead-styles/colours';
+import {
+  C_PEBBLE,
+  C_METAL,
+  C_EBON,
+  C_SHADOW,
+} from '@bbc/psammead-styles/colours';
 import { getSansRegular, getSansBold } from '@bbc/psammead-styles/font-styles';
 import { GEL_SPACING_DBL, GEL_SPACING } from '@bbc/gel-foundations/spacings';
 import { GEL_BODY_COPY, GEL_MINION } from '@bbc/gel-foundations/typography';
@@ -30,7 +35,7 @@ const Wrapper = styled.div`
 
   a {
     ${({ service }) => getSansBold(service)}
-    color: inherit;
+    color: ${C_EBON};
     text-decoration: none;
 
     &:visited {

--- a/packages/components/psammead-social-embed/src/Notice/index.jsx
+++ b/packages/components/psammead-social-embed/src/Notice/index.jsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { string } from 'prop-types';
 import styled from 'styled-components';
-import { C_EBON, C_PEBBLE, C_METAL } from '@bbc/psammead-styles/colours';
+import { C_PEBBLE, C_METAL, C_SHADOW } from '@bbc/psammead-styles/colours';
 import { getSansRegular, getSansBold } from '@bbc/psammead-styles/font-styles';
 import { GEL_SPACING_DBL, GEL_SPACING } from '@bbc/gel-foundations/spacings';
 import { GEL_BODY_COPY, GEL_MINION } from '@bbc/gel-foundations/typography';
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   ${GEL_BODY_COPY}
   border: ${BORDER_WEIGHT} solid ${C_PEBBLE};
   border-radius: ${GEL_SPACING};
-  color: ${C_EBON};
+  color: ${C_SHADOW};
   padding: ${GEL_SPACING_DBL};
 
   p {

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`AmpSocialEmbed should render a notice when the provider is unsupported 
   line-height: 1.25rem;
   border: 0.0625rem solid #AEAEB5;
   border-radius: 0.5rem;
-  color: #222222;
+  color: #3F3F42;
   padding: 1rem;
 }
 
@@ -552,7 +552,7 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
   line-height: 1.25rem;
   border: 0.0625rem solid #AEAEB5;
   border-radius: 0.5rem;
-  color: #222222;
+  color: #3F3F42;
   padding: 1rem;
 }
 
@@ -702,7 +702,7 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
   line-height: 1.25rem;
   border: 0.0625rem solid #AEAEB5;
   border-radius: 0.5rem;
-  color: #222222;
+  color: #3F3F42;
   padding: 1rem;
 }
 

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -75,7 +75,7 @@ exports[`AmpSocialEmbed should render a notice when the provider is unsupported 
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: inherit;
+  color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -570,7 +570,7 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: inherit;
+  color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -720,7 +720,7 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: inherit;
+  color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }


### PR DESCRIPTION
Resolves #3488

**Overall change:** _Update fallback text colour in the Social Embed component._

**Code changes:**

- _Change colour from `C_EBON` to `C_SHADOW`._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
