### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.162 | [PR#3526](https://github.com/bbc/psammead/pull/3526) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.161 | [PR#3525](https://github.com/bbc/psammead/pull/3525) Talos - Bump Dependencies - @bbc/psammead-calendars, @bbc/psammead-timestamp-container |
 | 2.0.160 | [PR#3524](https://github.com/bbc/psammead/pull/3524) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.159 | [PR#3523](https://github.com/bbc/psammead/pull/3523) Dependency updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.161",
+  "version": "2.0.162",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1516,9 +1516,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.5.tgz",
-      "integrity": "sha512-QDrAfje80W5GHPOLEHZoG4b9gKh+GRso/4qIkuIBJsXhDaDCytV+4v0LLCTcHrcvKFS21z/qHqLP2EXkzq/3pA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.6.tgz",
+      "integrity": "sha512-sNYBhjjHI2yNjN44b+qeSDj7lb1KW8TU07a57mM7BZ8UgE5Bd9oHD6VdzpUJzsTvGXskfj0LcbzKVFMzd1VSpQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
@@ -1526,7 +1526,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
-        "@bbc/psammead-timestamp-container": "^4.0.0"
+        "@bbc/psammead-timestamp-container": "^4.0.1"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.161",
+  "version": "2.0.162",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -77,7 +77,7 @@
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",
     "@bbc/psammead-play-button": "^1.1.16",
-    "@bbc/psammead-radio-schedule": "3.0.5",
+    "@bbc/psammead-radio-schedule": "3.0.6",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.15",
     "@bbc/psammead-section-label": "^5.0.6",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.5  →  3.0.6

| Version | Description |
|---------|-------------|
| 3.0.6 | [PR#3525](https://github.com/bbc/psammead/pull/3525) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

