### PR TITLE
Remove alpha tag from Index Heading component

### DIFF
--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,5 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Remove alpha tag |
+| 1.0.0 | [PR#3527](https://github.com/BBC/psammead/pull/3527) Remove alpha tag |
 | 1.0.0-alpha.1 | [PR#3501](https://github.com/BBC-News/psammead/pull/3501) Initial creation of package. |

--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#XXX](https://github.com/BBC/psammead/pull/XXX) Remove alpha tag |
 | 1.0.0-alpha.1 | [PR#3501](https://github.com/BBC-News/psammead/pull/3501) Initial creation of package. |

--- a/packages/components/psammead-heading-index/README.md
+++ b/packages/components/psammead-heading-index/README.md
@@ -1,8 +1,4 @@
 <!-- prettier-ignore -->
-# ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-heading-index - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-heading-index%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-heading-index%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-heading-index)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-heading-index) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-heading-index)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-heading-index&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/headline--default) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-heading-index.svg)](https://www.npmjs.com/package/@bbc/psammead-heading-index) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-heading-index/package-lock.json
+++ b/packages/components/psammead-heading-index/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -29,8 +29,5 @@
     "bbc",
     "heading",
     "index"
-  ],
-  "publishConfig": {
-    "tag": "alpha"
-  }
+  ]
 }


### PR DESCRIPTION
**Overall change:** 
After carried out an [Accessibility Swarm](https://github.com/bbc/simorgh/issues/6408) for the IDX page and tested that the new `IndexHeading` component is fine, we can move forward and remove the alpha tag from the component.

**Code changes:**
- Remove `alpha` tag from the `package.json`
- Bump package to a stable version
- Remove alpha text from `README`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
