### PR TITLE
Talos - Bump @bbc/psammead-section-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.163 | [PR#3528](https://github.com/bbc/psammead/pull/3528) Talos - Bump Dependencies - @bbc/psammead-section-label |
 | 2.0.162 | [PR#3526](https://github.com/bbc/psammead/pull/3526) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.161 | [PR#3525](https://github.com/bbc/psammead/pull/3525) Talos - Bump Dependencies - @bbc/psammead-calendars, @bbc/psammead-timestamp-container |
 | 2.0.160 | [PR#3524](https://github.com/bbc/psammead/pull/3524) Talos - Bump Dependencies - @bbc/psammead-locales |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.162",
+  "version": "2.0.163",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1558,9 +1558,9 @@
       }
     },
     "@bbc/psammead-section-label": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-5.0.6.tgz",
-      "integrity": "sha512-Za5XqG9ZnmbSPke7YMFT33f70wLssP992PiIT4a+IR3cV8+6FThUgaGoukZZ6OQD5xcnjNRkQDrdbojGm08u9Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-5.0.7.tgz",
+      "integrity": "sha512-/RwxWed1GCpvGn5Z0VT5Xd4q9OoyZSUskAatvfyrFrHgPPNnKUptGgy03EaFhVF/zPfU0wVUjHJq8dReDJcfvA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.162",
+  "version": "2.0.163",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -80,7 +80,7 @@
     "@bbc/psammead-radio-schedule": "3.0.6",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.15",
-    "@bbc/psammead-section-label": "^5.0.6",
+    "@bbc/psammead-section-label": "^5.0.7",
     "@bbc/psammead-sitewide-links": "^4.0.12",
     "@bbc/psammead-story-promo": "^6.0.3",
     "@bbc/psammead-story-promo-list": "^4.0.8",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-section-label  ^5.0.6  →  ^5.0.7

| Version | Description |
|---------|-------------|
| 5.0.7 | [PR#3514](https://github.com/bbc/psammead/pull/3514) Update Section Label to use correct colour in secondary column |
</details>

