### PR TITLE
Remove Index Alsos from Grid stories

### DIFF
--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.1.15 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Remove `Index Alsos` from Grid stories |
 | 1.1.14 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.1.13 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.1.12 | [PR#3390](https://github.com/bbc/psammead/pull/3290) Bump prettier major version and disable rule for brackets around a single prop |

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.1.15 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Remove `Index Alsos` from Grid stories |
+| 1.1.15 | [PR#3530](https://github.com/bbc/psammead/pull/3530) Remove `Index Alsos` from Grid stories |
 | 1.1.14 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.1.13 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.1.12 | [PR#3390](https://github.com/bbc/psammead/pull/3290) Bump prettier major version and disable rule for brackets around a single prop |

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/index.stories.jsx
+++ b/packages/components/psammead-grid/src/index.stories.jsx
@@ -7,8 +7,6 @@ import {
 } from '@bbc/psammead-storybook-helpers';
 import Image from '@bbc/psammead-image';
 import StoryPromo, { Headline, Summary, Link } from '@bbc/psammead-story-promo';
-import IndexAlsosContainer from '../../psammead-story-promo/testHelpers/IndexAlsosContainer';
-import relatedItems from '../../psammead-story-promo/testHelpers/relatedItems';
 import Grid from '.';
 import {
   ExampleImage,
@@ -1250,7 +1248,7 @@ storiesOf(STORY_KIND, module)
     'Example with Top story and regular promos',
     ({ service, script, dir, text }) => {
       // eslint-disable-next-line react/prop-types
-      const generateStory = ({ promoType, alsoItems = null, mediaType }) => {
+      const generateStory = ({ promoType, mediaType }) => {
         const MediaIndicatorComponent = () => (
           <ExampleMediaIndicator
             dir={dir}
@@ -1274,14 +1272,6 @@ storiesOf(STORY_KIND, module)
                 ? 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.'
                 : text}
             </Summary>
-            {promoType === 'top' && alsoItems && (
-              <IndexAlsosContainer
-                alsoItems={alsoItems}
-                script={script}
-                service={service}
-                dir={dir}
-              />
-            )}
           </>
         );
 
@@ -1340,13 +1330,7 @@ storiesOf(STORY_KIND, module)
               group5: 8,
             }}
           >
-            {generateStory({
-              promoType: 'top',
-              alsoItems: relatedItems.map(item => ({
-                ...item,
-                headlines: { headline: text },
-              })),
-            })}
+            {generateStory({ promoType: 'top' })}
           </Grid>
           <Grid
             dir={dir}


### PR DESCRIPTION
**Overall change:** 
In the Psammead Grid stories, we were importing the `IndexAlsosContainer` and `relatedItems` from a relative path outside the package which is wrong. 

The `relatedItems` can not be accessed directly from the `@bbc/psammead-story-promo`, so I've removed them since they are also irrelevant for the Grid stories we have. 

**Code changes:**
- Remove IndexAlsos from `Example with Top story and regular promos` story

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
