### PR TITLE
Top Stories headline promo spacing

### DIFF
--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.4 | [PR#3541](https://github.com/bbc/psammead/pull/3541) Remove `padding-top` in TextGridItem when no image displayed |
 | 6.0.3 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.2 | [PR#3410](https://github.com/bbc/psammead/pull/3410) Add `overflow-wrap` property to `Link` |
 | 6.0.1 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/TextStyles.jsx
+++ b/packages/components/psammead-story-promo/src/TextStyles.jsx
@@ -40,6 +40,7 @@ ${({ displayImage }) => !displayImage && `grid-column: 1 / span 6;`}
 
 @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
   padding-top: ${GEL_SPACING};
+  ${({ displayImage }) => !displayImage && `padding-top: 0;`}
 }
 `;
 

--- a/packages/components/psammead-story-promo/src/TextStyles.jsx
+++ b/packages/components/psammead-story-promo/src/TextStyles.jsx
@@ -39,7 +39,7 @@ grid-column: 3 / span 4;
 ${({ displayImage }) => !displayImage && `grid-column: 1 / span 6;`}
 
 @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-  padding-top: ${({ displayImage }) => (displayImage ? GEL_SPACING : 0)}
+  padding-top: ${({ displayImage }) => (displayImage ? GEL_SPACING : '0')}
 }
 `;
 

--- a/packages/components/psammead-story-promo/src/TextStyles.jsx
+++ b/packages/components/psammead-story-promo/src/TextStyles.jsx
@@ -39,8 +39,7 @@ grid-column: 3 / span 4;
 ${({ displayImage }) => !displayImage && `grid-column: 1 / span 6;`}
 
 @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-  padding-top: ${GEL_SPACING};
-  ${({ displayImage }) => !displayImage && `padding-top: 0;`}
+  padding-top: ${({ displayImage }) => (displayImage ? GEL_SPACING : 0)}
 }
 `;
 


### PR DESCRIPTION
Resolves #3540

**Overall change:** 
Resolve spacing between Top Stories headline and promo items

**Code changes:**

- Remove `padding-top` in TextGridItem when there is no image displayed

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
