### PR TITLE
Talos - Bump @bbc/psammead-amp-geo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.165 | [PR#3542](https://github.com/bbc/psammead/pull/3542) Talos - Bump Dependencies - @bbc/psammead-amp-geo |
 | 2.0.164 | [PR#3529](https://github.com/bbc/psammead/pull/3529) Adding a security policy |
 | 2.0.163 | [PR#3528](https://github.com/bbc/psammead/pull/3528) Talos - Bump Dependencies - @bbc/psammead-section-label |
 | 2.0.162 | [PR#3526](https://github.com/bbc/psammead/pull/3526) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.164",
+  "version": "2.0.165",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1249,9 +1249,9 @@
       }
     },
     "@bbc/psammead-amp-geo": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-amp-geo/-/psammead-amp-geo-1.1.2.tgz",
-      "integrity": "sha512-Jjkk9ieEa0WXK4Wvw82YVvMhP4yi0pBOftwNhQGOVLx1Av8KSHFHacFxHEiVcVxoXCPpdeWaLYrKm0fcyoxlKA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-amp-geo/-/psammead-amp-geo-1.2.0.tgz",
+      "integrity": "sha512-MO4cc0dtsTAaVer+/nkjLBqnB1YEZDNAphpeyYDbEZWNUAtTqgiTems7iXCV5qgawLyIcchbWISLulptutegSg==",
       "dev": true
     },
     "@bbc/psammead-assets": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.164",
+  "version": "2.0.165",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.10.1",
     "@bbc/gel-foundations": "^4.0.1",
     "@bbc/moment-timezone-include": "^1.1.4",
-    "@bbc/psammead-amp-geo": "^1.1.2",
+    "@bbc/psammead-amp-geo": "^1.2.0",
     "@bbc/psammead-assets": "^2.14.0",
     "@bbc/psammead-brand": "^5.1.22",
     "@bbc/psammead-bulleted-list": "^1.0.10",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-amp-geo  ^1.1.2  →  ^1.2.0

| Version | Description |
|---------|-------------|
| 1.2.0 | [PR#3539](https://github.com/bbc/psammead/pull/3539) Add gbOrUnknown group to AMP Geo component |
</details>

