### PR TITLE
Update radio time indicator styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.9",
     "@bbc/psammead-media-indicator": "^4.0.7",
-    "@bbc/psammead-media-player": "^2.7.11",
+    "@bbc/psammead-media-player": "^2.7.10",
     "@bbc/psammead-most-read": "^4.1.4",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.9",
     "@bbc/psammead-media-indicator": "^4.0.7",
-    "@bbc/psammead-media-player": "^2.7.10",
+    "@bbc/psammead-media-player": "^2.7.11",
     "@bbc/psammead-most-read": "^4.1.4",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.7.11 | [PR#3559](https://github.com/bbc/psammead/pull/3559) Removed overflow for AudioPlayer |
 | 2.7.10 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.7.9 | [PR#3398](https://github.com/bbc/psammead/pull/3398) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.7.8 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -105,7 +105,6 @@ exports[`Media Player: AMP Entry renders the audio skin 1`] = `
     .c0 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 
@@ -726,7 +725,6 @@ exports[`Media Player: Canonical Entry renders the audio skin 1`] = `
 .c0 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 

--- a/packages/components/psammead-media-player/src/index.jsx
+++ b/packages/components/psammead-media-player/src/index.jsx
@@ -23,7 +23,6 @@ const StyledVideoContainer = styled.div`
 const StyledAudioContainer = styled.div`
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: ${GEL_SPACING_DBL};
 
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {


### PR DESCRIPTION
Related to #6881

**Overall change:** Removed `overflow:hidden` to fix current time indicator on OD Radio and Live Radio as they are being partially chopped off.

**Code changes:**

- Removed `overflow:hidden` from `StyledAudioContainer`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
