### PR TITLE
Talos - Bump @bbc/psammead-media-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.169 | [PR#3560](https://github.com/bbc/psammead/pull/3560) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.0.168 | [PR#3554](https://github.com/bbc/psammead/pull/3554) Dependency updates |
 | 2.0.167 | [PR#3558](https://github.com/bbc/psammead/pull/3558) Talos - Bump Dependencies - @bbc/psammead-bulletin |
 | 2.0.166 | [PR#3557](https://github.com/bbc/psammead/pull/3557) Talos - Bump Dependencies - @bbc/psammead-most-read, @bbc/psammead-story-promo |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.168",
+  "version": "2.0.169",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2149,9 +2149,9 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.10.tgz",
-      "integrity": "sha512-Qz/omqcCpgyF+25UlbV5uoYs/DlFFxDNiSqvDrt5o24YLPORzk4zLdoke5dJhAOdiItQAAGLeB+SrACjIRHEQA==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.11.tgz",
+      "integrity": "sha512-AZF7U7O4tC1kbqjWDJHcL8F0tsfZMp3Ch+kHcexdUXHQi5CwWVDxSC2jx/Q9hzldahMupkODJQtFb/SuVlpMpQ==",
       "dev": true,
       "requires": {
         "@bbc/psammead-assets": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.168",
+  "version": "2.0.169",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -72,7 +72,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.9",
     "@bbc/psammead-media-indicator": "^4.0.7",
-    "@bbc/psammead-media-player": "^2.7.10",
+    "@bbc/psammead-media-player": "^2.7.11",
     "@bbc/psammead-most-read": "^4.1.4",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-player  ^2.7.10  →  ^2.7.11

| Version       | Description                                                                                                                  |
| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| 2.7.11 | [PR#3559](https://github.com/bbc/psammead/pull/3559) Removed overflow for AudioPlayer |
</details>

