### PR TITLE
Talos - Bump @bbc/psammead-embed-error, @bbc/psammead-media-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.172 | [PR#3576](https://github.com/bbc/psammead/pull/3576) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.0.171 | [PR#3571](https://github.com/bbc/psammead/pull/3571) Adding new packages to the base package.json |
 | 2.0.170 | [PR#3570](https://github.com/bbc/psammead/pull/3570) Dependency updates |
 | 2.0.169 | [PR#3560](https://github.com/bbc/psammead/pull/3560) Talos - Bump Dependencies - @bbc/psammead-media-player |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.171",
+  "version": "2.0.172",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3861,9 +3861,9 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.11.tgz",
-      "integrity": "sha512-AZF7U7O4tC1kbqjWDJHcL8F0tsfZMp3Ch+kHcexdUXHQi5CwWVDxSC2jx/Q9hzldahMupkODJQtFb/SuVlpMpQ==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.12.tgz",
+      "integrity": "sha512-kIFHwVZ/+RU5ZIMZ6OOF0u0N7f8CuhdLvSSGvs4FWCZhfgJG8L0xJV7NbzxHkGSmaBZYz4qBo4QmSYlz1rjmOg==",
       "dev": true,
       "requires": {
         "@bbc/psammead-assets": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.171",
+  "version": "2.0.172",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -73,7 +73,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.9",
     "@bbc/psammead-media-indicator": "^4.0.7",
-    "@bbc/psammead-media-player": "^2.7.11",
+    "@bbc/psammead-media-player": "^2.7.12",
     "@bbc/psammead-most-read": "^4.1.4",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-player  ^2.7.11  →  ^2.7.12

| Version       | Description                                                                                                                  |
| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| 2.7.12 | [PR#3575](https://github.com/bbc/psammead/pull/3575) Added bottom margin to video player |
</details>

