### PR TITLE
Mediaplayer Margin fix 

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.7.13 | [PR#3575](https://github.com/bbc/psammead/pull/3575) Adjusted bottom margin by 0.5rem |
 | 2.7.12 | [PR#3575](https://github.com/bbc/psammead/pull/3575) Added bottom margin to video player |
 | 2.7.11 | [PR#3559](https://github.com/bbc/psammead/pull/3559) Removed overflow for AudioPlayer |
 | 2.7.10 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-play-button |

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 2.7.13 | [PR#3575](https://github.com/bbc/psammead/pull/3575) Adjusted bottom margin by 0.5rem |
+| 2.7.13 | [PR#3583](https://github.com/bbc/psammead/pull/3583) Adjusted bottom margin by 0.5rem |
 | 2.7.12 | [PR#3575](https://github.com/bbc/psammead/pull/3575) Added bottom margin to video player |
 | 2.7.11 | [PR#3559](https://github.com/bbc/psammead/pull/3559) Removed overflow for AudioPlayer |
 | 2.7.10 | [PR#3468](https://github.com/bbc/psammead/pull/3468) Talos - Bump Dependencies - @bbc/psammead-play-button |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`Media Player: AMP Entry renders a landscape container with an amp-ifram
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -72,7 +72,7 @@ exports[`Media Player: AMP Entry renders a portrait container with amp-iframe an
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -277,7 +277,7 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -481,7 +481,7 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -665,7 +665,7 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -744,7 +744,7 @@ exports[`Media Player: Canonical Entry renders an iframe when showPlaceholder is
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -968,7 +968,7 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
 
 @media (min-width:63rem) {
   .c0 {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/packages/components/psammead-media-player/src/index.jsx
+++ b/packages/components/psammead-media-player/src/index.jsx
@@ -5,6 +5,7 @@ import equals from 'ramda/src/equals';
 import {
   GEL_SPACING_DBL,
   GEL_SPACING_QUAD,
+  GEL_SPACING_TRPL,
 } from '@bbc/gel-foundations/spacings';
 import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import Placeholder from './Placeholder';
@@ -21,7 +22,7 @@ const StyledVideoContainer = styled.div`
   margin-bottom: ${GEL_SPACING_DBL};
 
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    margin-bottom: ${GEL_SPACING_QUAD};
+    margin-bottom: ${GEL_SPACING_TRPL};
   }
 `;
 


### PR DESCRIPTION
Overturns #https://github.com/bbc/psammead/pull/3575 to fix https://github.com/bbc/simorgh/issues/6950

**Overall change:** _Reduces media player bottom margin by 0.5rem._

Clarified from @lizcameron that; _"the last item in the column has 24px (1.5rem) beneath it, and the end of the column also has 32px margin (2.0rem)."_ The latter would be handled by https://github.com/bbc/simorgh/pull/7147 once this goes through.

**Code changes:**

- _Reduced media player bottom margin by 0.5rem._
---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
