### PR TITLE
Add Themes to Storybook Helpers

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 8.3.2 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Add Storybook themes |
+| 8.3.2 | [PR#3586](https://github.com/bbc/psammead/pull/3586) Add Storybook themes |
 | 8.3.1 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |
 | 8.3.0 | [PR#3376](https://github.com/bbc/psammead/pull/3376) Adding timezone to withServicesKnob helper |
 | 8.2.7 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |

--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 8.3.2 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Add Storybook themes |
 | 8.3.1 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |
 | 8.3.0 | [PR#3376](https://github.com/bbc/psammead/pull/3376) Adding timezone to withServicesKnob helper |
 | 8.2.7 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |

--- a/packages/utilities/psammead-storybook-helpers/README.md
+++ b/packages/utilities/psammead-storybook-helpers/README.md
@@ -6,6 +6,8 @@ This package provides a collection of common values that are used in storybook b
 
 `TEXT_VARIANTS` - A list of text samples in different languages, with the script and direction that should be used for that language.
 
+`themes` - An object containing the Storybook themes we use.
+
 `withServicesKnob` - Is a function that returns a storybook decorator function that adds a `Select a service` dropdown to the knobs panel. When a service is selected from the dropdown it does 2 things:
 
 1. Provides the decorated stories with the following properties that can be passed into components:

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/index.js
+++ b/packages/utilities/psammead-storybook-helpers/src/index.js
@@ -1,5 +1,6 @@
 import withServicesKnob from './withServicesKnob';
 import { buildRTLSubstories } from './buildRTLSubstories';
 import TEXT_VARIANTS from './text-variants';
+import themes from './themes';
 
-export { TEXT_VARIANTS, withServicesKnob, buildRTLSubstories };
+export { TEXT_VARIANTS, withServicesKnob, buildRTLSubstories, themes };

--- a/packages/utilities/psammead-storybook-helpers/src/themes.js
+++ b/packages/utilities/psammead-storybook-helpers/src/themes.js
@@ -9,5 +9,7 @@ const createTheme = props =>
     ...props,
   });
 
-export const light = createTheme({ base: 'light' });
-export const dark = createTheme({ base: 'dark' });
+export default {
+  light: createTheme({ base: 'light' }),
+  dark: createTheme({ base: 'dark' }),
+};

--- a/packages/utilities/psammead-storybook-helpers/src/themes.js
+++ b/packages/utilities/psammead-storybook-helpers/src/themes.js
@@ -1,0 +1,13 @@
+import { create } from '@storybook/theming';
+
+const createTheme = props =>
+  create({
+    brandTitle: 'BBC Psammead',
+    brandUrl: 'https://github.com/bbc/psammead',
+    brandImage:
+      'https://user-images.githubusercontent.com/11341355/54079666-af202780-42d8-11e9-9108-e47ea27fddc5.png',
+    ...props,
+  });
+
+export const light = createTheme({ base: 'light' });
+export const dark = createTheme({ base: 'dark' });


### PR DESCRIPTION
Requirement for https://github.com/bbc/simorgh/issues/7178

**Overall change:**
Move storybook themes into psammead-helpers

Preparation work for allowing individual stories to change the storybook theme, when using dark mode

**Code changes:**

- _Move storybook themes into psammead-helpers_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
