### PR TITLE
Psammead Timestamp, Paragraph and Heading Dark Mode

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,6 +7,7 @@ import {
   AMP_NO_SCRIPT,
 } from '@bbc/psammead-assets/amp-boilerplate';
 import * as fontFaces from '@bbc/psammead-styles/fonts';
+import { themes } from '@bbc/psammead-storybook-helpers';
 import GlobalStyles from '@bbc/psammead-styles/global-styles';
 
 // New locales
@@ -46,19 +47,11 @@ import '@bbc/psammead-locales/moment/yo';
 
 import { Helmet } from 'react-helmet';
 
-const theme = create({
-  base: 'light',
-  brandTitle: 'BBC Psammead',
-  brandUrl: 'https://github.com/bbc/psammead',
-  brandImage:
-    'https://user-images.githubusercontent.com/11341355/54079666-af202780-42d8-11e9-9108-e47ea27fddc5.png',
-});
-
 addParameters({
   options: {
     panelPosition: 'right',
     sidebarAnimations: true,
-    theme,
+    theme: themes.light,
   },
   a11y: {
     options: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.173 | [PR#3587](https://github.com/bbc/psammead/pull/3587) Bump Dependencies - @bbc/psammead-storybook-helpers |
 | 2.0.172 | [PR#3584](https://github.com/bbc/psammead/pull/3584) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.0.171 | [PR#3571](https://github.com/bbc/psammead/pull/3571) Adding new packages to the base package.json |
 | 2.0.170 | [PR#3570](https://github.com/bbc/psammead/pull/3570) Dependency updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4008,9 +4008,9 @@
       }
     },
     "@bbc/psammead-storybook-helpers": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-8.3.1.tgz",
-      "integrity": "sha512-ujPtxC6t0wwpq9kik0wL6Lk6DpgrdvgWoImPdr+bdWQd+WXjmxrgWGt0boqCKvV2b76CK1L1FfOSExloFacwUw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-8.3.2.tgz",
+      "integrity": "sha512-1ylNOPUAx6oqZlEV7PvUdBJhcLyKpi2xij/E+VEozcTwJ//vtVIHDKIzac7SSWzNE8KP9QjKcJaSrllaV2hGzg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.172",
+  "version": "2.0.173",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bbc/psammead-social-embed": "^1.1.3",
     "@bbc/psammead-story-promo": "^6.0.4",
     "@bbc/psammead-story-promo-list": "^4.0.8",
-    "@bbc/psammead-storybook-helpers": "^8.3.1",
+    "@bbc/psammead-storybook-helpers": "^8.3.2",
     "@bbc/psammead-styles": "^4.4.0",
     "@bbc/psammead-test-helpers": "^3.1.5",
     "@bbc/psammead-timestamp": "^2.2.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.172",
+  "version": "2.0.173",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.31 | [PR#3587](https://github.com/bbc/psammead/pull/3587) Add Dark Mode |
 | 3.1.30 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.29 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.28 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-headings/README.md
+++ b/packages/components/psammead-headings/README.md
@@ -16,6 +16,7 @@ The Headings are a set of two components, `Headline` and `SubHeading`. They use 
 | --------- | ---- | -------- | ------- | ------- |
 | script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 | service | string | yes | N/A | `'news'` |
+| darkMode | bool | no | false | true |
 
 ## Usage
 

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -40,6 +40,46 @@ exports[`Headline component should render correctly 1`] = `
 </h1>
 `;
 
+exports[`Headline component should render correctly in dark mode 1`] = `
+.c0 {
+  font-size: 1.75rem;
+  line-height: 2rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  color: #F2F2F2;
+  display: block;
+  margin: 0;
+  padding: 2rem 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2.75rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 2.5rem 0;
+  }
+}
+
+<h1
+  class="c0"
+>
+  This is my headline.
+</h1>
+`;
+
 exports[`Headline component should render correctly with arabic script typography values 1`] = `
 .c0 {
   font-size: 2rem;
@@ -88,6 +128,46 @@ exports[`SubHeading component should render correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #3F3F42;
+  margin: 0;
+  padding: 1.5rem 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    padding-top: 2rem;
+  }
+}
+
+<h2
+  class="c0"
+  tabindex="-1"
+>
+  This is a SubHeading
+</h2>
+`;
+
+exports[`SubHeading component should render correctly in dark mode 1`] = `
+.c0 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #F2F2F2;
   margin: 0;
   padding: 1.5rem 0;
 }

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { shape, string } from 'prop-types';
-import { C_SHADOW } from '@bbc/psammead-styles/colours';
+import { shape, string, bool } from 'prop-types';
+import { C_SHADOW, C_WHITE } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -14,7 +14,7 @@ import { getSansBold, getSerifMedium } from '@bbc/psammead-styles/font-styles';
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
   ${({ service }) => getSerifMedium(service)}
-  color: ${C_SHADOW};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
   display: block; /* Explicitly set */
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0;
@@ -28,7 +28,7 @@ export const SubHeading = styled.h2.attrs(() => ({
 }))`
   ${({ script }) => script && getTrafalgar(script)};
   ${({ service }) => getSansBold(service)}
-  color: ${C_SHADOW};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_TRPL} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
@@ -39,9 +39,19 @@ export const SubHeading = styled.h2.attrs(() => ({
 Headline.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  darkMode: bool,
+};
+
+Headline.defaultProps = {
+  darkMode: false,
 };
 
 SubHeading.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  darkMode: bool,
+};
+
+Headline.defaultProps = {
+  darkMode: false,
 };

--- a/packages/components/psammead-headings/src/index.jsx
+++ b/packages/components/psammead-headings/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { shape, string, bool } from 'prop-types';
-import { C_SHADOW, C_WHITE } from '@bbc/psammead-styles/colours';
+import { C_SHADOW, C_LUNAR } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -14,7 +14,7 @@ import { getSansBold, getSerifMedium } from '@bbc/psammead-styles/font-styles';
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
   ${({ service }) => getSerifMedium(service)}
-  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
   display: block; /* Explicitly set */
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0;
@@ -28,7 +28,7 @@ export const SubHeading = styled.h2.attrs(() => ({
 }))`
   ${({ script }) => script && getTrafalgar(script)};
   ${({ service }) => getSansBold(service)}
-  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_TRPL} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs';
-import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { withServicesKnob, themes } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import { Headline, SubHeading } from './index';
 
@@ -24,7 +24,7 @@ storiesOf('Components|Headline', module)
         {textSnippet}
       </Headline>
     ),
-    { notes, knobs: { escapeHTML: false } },
+    { notes, knobs: { escapeHTML: false }, options: { theme: themes.dark } },
   );
 
 storiesOf('Components|SubHeading', module)
@@ -46,7 +46,7 @@ storiesOf('Components|SubHeading', module)
         {textSnippet}
       </SubHeading>
     ),
-    { notes, knobs: { escapeHTML: false } },
+    { notes, knobs: { escapeHTML: false }, options: { theme: themes.dark } },
   )
   .add(
     'with optional ID',

--- a/packages/components/psammead-headings/src/index.stories.jsx
+++ b/packages/components/psammead-headings/src/index.stories.jsx
@@ -16,6 +16,15 @@ storiesOf('Components|Headline', module)
       </Headline>
     ),
     { notes, knobs: { escapeHTML: false } },
+  )
+  .add(
+    'dark mode',
+    ({ text: textSnippet, script, service }) => (
+      <Headline script={script} service={service} darkMode>
+        {textSnippet}
+      </Headline>
+    ),
+    { notes, knobs: { escapeHTML: false } },
   );
 
 storiesOf('Components|SubHeading', module)
@@ -25,6 +34,15 @@ storiesOf('Components|SubHeading', module)
     'default',
     ({ text: textSnippet, script, service }) => (
       <SubHeading script={script} service={service}>
+        {textSnippet}
+      </SubHeading>
+    ),
+    { notes, knobs: { escapeHTML: false } },
+  )
+  .add(
+    'darkMode',
+    ({ text: textSnippet, script, service }) => (
+      <SubHeading script={script} service={service} darkMode>
         {textSnippet}
       </SubHeading>
     ),

--- a/packages/components/psammead-headings/src/index.test.jsx
+++ b/packages/components/psammead-headings/src/index.test.jsx
@@ -12,6 +12,13 @@ describe('Headline component', () => {
   );
 
   shouldMatchSnapshot(
+    'should render correctly in dark mode',
+    <Headline script={latin} service="news" darkMode>
+      This is my headline.
+    </Headline>,
+  );
+
+  shouldMatchSnapshot(
     'should render correctly with arabic script typography values',
     <Headline script={arabic} service="persian">
       هذا هو العنوان الخاص بي
@@ -23,6 +30,13 @@ describe('SubHeading component', () => {
   shouldMatchSnapshot(
     'should render correctly',
     <SubHeading script={latin} service="news">
+      This is a SubHeading
+    </SubHeading>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly in dark mode',
+    <SubHeading script={latin} service="news" darkMode>
       This is a SubHeading
     </SubHeading>,
   );

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.29 | [PR#3587](https://github.com/bbc/psammead/pull/3587) Add Dark Mode |
 | 2.2.28 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.27 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.26 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-paragraph/README.md
+++ b/packages/components/psammead-paragraph/README.md
@@ -17,6 +17,7 @@ It uses `@bbc/psammead-styles` for colours and font family and `@bbc/gel-foundat
 | --------- | ---- | -------- | ------- | ------- |
 | Script    | object | yes | latin | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 | service | string | yes | N/A | `'news'` |
+| darkMode | bool | no | false | true |
 
 ## Usage
 

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "description": "React styled component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Paragraph should render a correctly 1`] = `
+exports[`Paragraph should render correctly 1`] = `
 .c0 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -8,6 +8,39 @@ exports[`Paragraph should render a correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #3F3F42;
+  padding-bottom: 1.5rem;
+  margin: 0;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+<p
+  class="c0"
+>
+  This is text in a paragraph.
+</p>
+`;
+
+exports[`Paragraph should render correctly in dark mode 1`] = `
+.c0 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #F2F2F2;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { shape, string } from 'prop-types';
-import { C_SHADOW } from '@bbc/psammead-styles/colours';
+import { shape, string, bool } from 'prop-types';
+import { C_SHADOW, C_WHITE } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import { getBodyCopy } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
@@ -9,7 +9,7 @@ import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 const Paragraph = styled.p`
   ${({ script }) => script && getBodyCopy(script)};
   ${({ service }) => getSansRegular(service)}
-  color: ${C_SHADOW};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
   padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
 `;
@@ -17,6 +17,13 @@ const Paragraph = styled.p`
 Paragraph.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  darkMode: bool,
+};
+
+Paragraph.propTypes = {
+  script: shape(scriptPropType).isRequired,
+  service: string.isRequired,
+  darkMode: false,
 };
 
 export default Paragraph;

--- a/packages/components/psammead-paragraph/src/index.jsx
+++ b/packages/components/psammead-paragraph/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { shape, string, bool } from 'prop-types';
-import { C_SHADOW, C_WHITE } from '@bbc/psammead-styles/colours';
+import { C_SHADOW, C_LUNAR } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import { getBodyCopy } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
@@ -9,7 +9,7 @@ import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 const Paragraph = styled.p`
   ${({ script }) => script && getBodyCopy(script)};
   ${({ service }) => getSansRegular(service)}
-  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
   padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
 `;

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -5,8 +5,17 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import InlineLink from '@bbc/psammead-inline-link';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { create } from '@storybook/theming';
 import notes from '../README.md';
 import Paragraph from './index';
+
+const theme = create({
+  base: 'dark',
+  brandTitle: 'BBC Psammead',
+  brandUrl: 'https://github.com/bbc/psammead',
+  brandImage:
+    'https://user-images.githubusercontent.com/11341355/54079666-af202780-42d8-11e9-9108-e47ea27fddc5.png',
+});
 
 storiesOf('Components|Paragraph', module)
   .addDecorator(withKnobs)
@@ -19,6 +28,15 @@ storiesOf('Components|Paragraph', module)
       </Paragraph>
     ),
     { notes, knobs: { escapeHTML: false } },
+  )
+  .add(
+    'dark mode',
+    ({ text, script, service }) => (
+      <Paragraph script={script} service={service} darkMode>
+        {text}
+      </Paragraph>
+    ),
+    { notes, knobs: { escapeHTML: false }, options: { theme } },
   )
   .add(
     'containing an inline link',

--- a/packages/components/psammead-paragraph/src/index.stories.jsx
+++ b/packages/components/psammead-paragraph/src/index.stories.jsx
@@ -4,18 +4,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import InlineLink from '@bbc/psammead-inline-link';
-import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
-import { create } from '@storybook/theming';
+import { withServicesKnob, themes } from '@bbc/psammead-storybook-helpers';
 import notes from '../README.md';
 import Paragraph from './index';
-
-const theme = create({
-  base: 'dark',
-  brandTitle: 'BBC Psammead',
-  brandUrl: 'https://github.com/bbc/psammead',
-  brandImage:
-    'https://user-images.githubusercontent.com/11341355/54079666-af202780-42d8-11e9-9108-e47ea27fddc5.png',
-});
 
 storiesOf('Components|Paragraph', module)
   .addDecorator(withKnobs)
@@ -36,7 +27,7 @@ storiesOf('Components|Paragraph', module)
         {text}
       </Paragraph>
     ),
-    { notes, knobs: { escapeHTML: false }, options: { theme } },
+    { notes, knobs: { escapeHTML: false }, options: { theme: themes.dark } },
   )
   .add(
     'containing an inline link',

--- a/packages/components/psammead-paragraph/src/index.test.jsx
+++ b/packages/components/psammead-paragraph/src/index.test.jsx
@@ -5,8 +5,15 @@ import Paragraph from './index';
 
 describe('Paragraph', () => {
   shouldMatchSnapshot(
-    'should render a correctly',
+    'should render correctly',
     <Paragraph script={latin} service="news">
+      This is text in a paragraph.
+    </Paragraph>,
+  );
+
+  shouldMatchSnapshot(
+    'should render correctly in dark mode',
+    <Paragraph script={latin} service="news" darkMode>
       This is text in a paragraph.
     </Paragraph>,
   );

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.29 | [PR#3587](https://github.com/bbc/psammead/pull/3587) Add Dark Mode |
 | 2.2.28 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.27 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.2.26 | [PR#3135](https://github.com/bbc/psammead/pull/3135) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-timestamp/README.md
+++ b/packages/components/psammead-timestamp/README.md
@@ -26,6 +26,7 @@ When a date or time is to be displayed inline inside a paragraph.
 | `padding` | boolean | No | `true` | `false` |
 | `script` | object | Yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, }|
 | service | string | Yes | N/A | `'news'` |
+| darkMode | bool | no | false | true |
 
 ## Usage
 

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -109,6 +109,44 @@ exports[`Timestamp should render Timestamp without padding 1`] = `
 </time>
 `;
 
+exports[`Timestamp should render dark mode Timestamp correctly 1`] = `
+.c0 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #F2F2F2;
+  display: block;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  padding-bottom: 0.25rem;
+}
+
+.c0:last-child {
+  padding-bottom: 1rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c0 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+<time
+  class="c0"
+  datetime="1530947227000"
+>
+  7 July 2018
+</time>
+`;
+
 exports[`Timestamp should render with the correct typography style applied 1`] = `
 .c0 {
   font-size: 0.9375rem;

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { getBrevier } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
-import { C_WHITE, C_METAL } from '@bbc/psammead-styles/colours';
+import { C_LUNAR, C_METAL } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 const PADDING = `
@@ -20,7 +20,7 @@ const PADDING = `
 const StyledTimestamp = styled.time`
   ${({ script, typographyFunc }) =>
     script && typographyFunc && typographyFunc(script)}
-  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_METAL)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_METAL)};
   display: block;
   ${({ service }) => getSansRegular(service)}
   ${props => props.padding && PADDING}

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { getBrevier } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
-import { C_METAL } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_METAL } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 const PADDING = `
@@ -20,7 +20,7 @@ const PADDING = `
 const StyledTimestamp = styled.time`
   ${({ script, typographyFunc }) =>
     script && typographyFunc && typographyFunc(script)}
-  color: ${C_METAL};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_METAL)};
   display: block;
   ${({ service }) => getSansRegular(service)}
   ${props => props.padding && PADDING}
@@ -33,6 +33,7 @@ const Timestamp = ({
   script,
   padding,
   service,
+  darkMode,
 }) => (
   <StyledTimestamp
     dateTime={datetime}
@@ -40,6 +41,7 @@ const Timestamp = ({
     script={script}
     padding={padding}
     service={service}
+    darkMode={darkMode}
   >
     {children}
   </StyledTimestamp>
@@ -48,6 +50,7 @@ const Timestamp = ({
 Timestamp.defaultProps = {
   typographyFunc: getBrevier,
   padding: true,
+  darkMode: false,
 };
 
 Timestamp.propTypes = {
@@ -57,6 +60,7 @@ Timestamp.propTypes = {
   padding: bool,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  darkMode: bool,
 };
 
 export default Timestamp;

--- a/packages/components/psammead-timestamp/src/index.stories.jsx
+++ b/packages/components/psammead-timestamp/src/index.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { text, select, boolean, withKnobs } from '@storybook/addon-knobs';
 import * as typography from '@bbc/gel-foundations/typography';
-import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { withServicesKnob, themes } from '@bbc/psammead-storybook-helpers';
 import { latin } from '@bbc/gel-foundations/scripts';
 import notes from '../README.md';
 import Timestamp from '.';
@@ -57,7 +57,7 @@ storiesOf('Components|Timestamp', module)
         {text('Timestamp Text', '7 July 2018')}
       </ExampleTimestamp>
     ),
-    { notes },
+    { notes, options: { theme: themes.dark } },
   )
   .add(
     'with "updated" prefix',

--- a/packages/components/psammead-timestamp/src/index.stories.jsx
+++ b/packages/components/psammead-timestamp/src/index.stories.jsx
@@ -19,48 +19,52 @@ const styles = Object.keys(typography)
   })
   .filter(style => style);
 
+// eslint-disable-next-line react/prop-types
+const ExampleTimestamp = ({ children, ...props }) => {
+  const padding = boolean('Padding', true);
+  const style = select('Typography', styles, 'Brevier');
+  const typographyFunc = typography[`get${style}`];
+
+  return (
+    <Timestamp
+      datetime="1530947227000"
+      typographyFunc={typographyFunc}
+      script={latin}
+      padding={padding}
+      {...props}
+    >
+      {children}
+    </Timestamp>
+  );
+};
+
 storiesOf('Components|Timestamp', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
   .add(
     'default',
-    ({ service }) => {
-      const padding = boolean('Padding', true);
-      const style = select('Typography', styles, 'Brevier');
-      const typographyFunc = typography[`get${style}`];
-
-      return (
-        <Timestamp
-          datetime="1530947227000"
-          typographyFunc={typographyFunc}
-          script={latin}
-          padding={padding}
-          service={service}
-        >
-          {text('Timestamp Text', '7 July 2018')}
-        </Timestamp>
-      );
-    },
+    ({ service }) => (
+      <ExampleTimestamp service={service}>
+        {text('Timestamp Text', '7 July 2018')}
+      </ExampleTimestamp>
+    ),
+    { notes },
+  )
+  .add(
+    'dark mode',
+    ({ service }) => (
+      <ExampleTimestamp service={service} darkMode>
+        {text('Timestamp Text', '7 July 2018')}
+      </ExampleTimestamp>
+    ),
     { notes },
   )
   .add(
     'with "updated" prefix',
-    ({ service }) => {
-      const padding = boolean('Padding', true);
-      const style = select('Typography', styles, 'Brevier');
-      const typographyFunc = typography[`get${style}`];
-
-      return (
-        <Timestamp
-          datetime="1530947227000"
-          typographyFunc={typographyFunc}
-          script={latin}
-          padding={padding}
-          service={service}
-        >
-          {text('Timestamp Text', 'Updated 7 July 2018')}
-        </Timestamp>
-      );
-    },
+    ({ service }) => (
+      <ExampleTimestamp service={service}>
+        {text('Timestamp Text', 'Updated 7 July 2018')}
+      </ExampleTimestamp>
+    ),
     { notes },
   );

--- a/packages/components/psammead-timestamp/src/index.test.jsx
+++ b/packages/components/psammead-timestamp/src/index.test.jsx
@@ -13,6 +13,13 @@ describe('Timestamp', () => {
   );
 
   shouldMatchSnapshot(
+    'should render dark mode Timestamp correctly',
+    <Timestamp datetime="1530947227000" script={latin} service="news" darkMode>
+      7 July 2018
+    </Timestamp>,
+  );
+
+  shouldMatchSnapshot(
     'should render with the correct typography style applied',
     <Timestamp
       datetime="1530947227000"


### PR DESCRIPTION
Requirement for bbc/simorgh#7178

**Overall change:** _Add `darkMode` prop to Timestamp, Paragraph and Headings_

**Code changes:**

- _Adding darkmode support to components used by on demand TV._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
