### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.176 | [PR#3599](https://github.com/bbc/psammead/pull/3599) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.175 | [PR#3598](https://github.com/bbc/psammead/pull/3598) Talos - Bump Dependencies - @bbc/psammead-calendars, @bbc/psammead-timestamp-container |
 | 2.0.174 | [PR#3596](https://github.com/bbc/psammead/pull/3596) Talos - Bump Dependencies - @bbc/psammead-locales |
 | 2.0.173 | [PR#3587](https://github.com/bbc/psammead/pull/3587) Bump Dependencies - @bbc/psammead-storybook-helpers |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.175",
+  "version": "2.0.176",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3916,9 +3916,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.6.tgz",
-      "integrity": "sha512-sNYBhjjHI2yNjN44b+qeSDj7lb1KW8TU07a57mM7BZ8UgE5Bd9oHD6VdzpUJzsTvGXskfj0LcbzKVFMzd1VSpQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.7.tgz",
+      "integrity": "sha512-oujC4jg2A57Z5KUKPTmZ5Dll2Z/Dz1zFjMyChqXr3bHiLCKNRgEisNxgdgxlDkzgSYpRLhHb1bMYoZqk9l26nA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
@@ -3926,7 +3926,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
-        "@bbc/psammead-timestamp-container": "^4.0.1"
+        "@bbc/psammead-timestamp-container": "^4.0.2"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.175",
+  "version": "2.0.176",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -78,7 +78,7 @@
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",
     "@bbc/psammead-play-button": "^1.1.16",
-    "@bbc/psammead-radio-schedule": "3.0.6",
+    "@bbc/psammead-radio-schedule": "3.0.7",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.15",
     "@bbc/psammead-section-label": "^5.0.7",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.6  →  3.0.7

| Version | Description |
|---------|-------------|
| 3.0.7 | [PR#3598](https://github.com/bbc/psammead/pull/3598) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

