### PR TITLE
Update Thai Canon typography

### DIFF
--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Thai Canon typography values |
 | 4.0.1 | [PR#3127](https://github.com/bbc/psammead/pull/3127) Restructured breakpoints.js to pair the consts which use one another. |
 | 4.0.0 | [PR#3128](https://github.com/bbc/psammead/pull/3128) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
 | 3.4.3 | [PR#2947](https://github.com/bbc/psammead/pull/2947) Added additional rem sizing for 40px - 58px spacing according to new MAP and OD Radio designs. |

--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.2 | [PR#3602](https://github.com/bbc/psammead/pull/3602) Update Thai Canon typography values |
+| 4.1.0 | [PR#3602](https://github.com/bbc/psammead/pull/3602) Update Thai Canon typography values |
 | 4.0.1 | [PR#3127](https://github.com/bbc/psammead/pull/3127) Restructured breakpoints.js to pair the consts which use one another. |
 | 4.0.0 | [PR#3128](https://github.com/bbc/psammead/pull/3128) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
 | 3.4.3 | [PR#2947](https://github.com/bbc/psammead/pull/2947) Added additional rem sizing for 40px - 58px spacing according to new MAP and OD Radio designs. |

--- a/packages/utilities/gel-foundations/CHANGELOG.md
+++ b/packages/utilities/gel-foundations/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.2 | [PR#XXX](https://github.com/bbc/psammead/pull/XXX) Update Thai Canon typography values |
+| 4.0.2 | [PR#3602](https://github.com/bbc/psammead/pull/3602) Update Thai Canon typography values |
 | 4.0.1 | [PR#3127](https://github.com/bbc/psammead/pull/3127) Restructured breakpoints.js to pair the consts which use one another. |
 | 4.0.0 | [PR#3128](https://github.com/bbc/psammead/pull/3128) Update `GEL_GROUP_4_SCREEN_WIDTH_MAX` value |
 | 3.4.3 | [PR#2947](https://github.com/bbc/psammead/pull/2947) Added additional rem sizing for 40px - 58px spacing according to new MAP and OD Radio designs. |

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1
 }

--- a/packages/utilities/gel-foundations/package-lock.json
+++ b/packages/utilities/gel-foundations/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1
 }

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "sideEffects": false,
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {

--- a/packages/utilities/gel-foundations/package.json
+++ b/packages/utilities/gel-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/gel-foundations",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "sideEffects": false,
   "description": "A range of string constants for use in CSS, intended to help implement BBC GEL-compliant webpages and components.",
   "repository": {

--- a/packages/utilities/gel-foundations/src/scripts/thai.js
+++ b/packages/utilities/gel-foundations/src/scripts/thai.js
@@ -71,16 +71,16 @@ const thaiTypography = {
   },
   canon: {
     groupA: {
-      fontSize: '28',
-      lineHeight: '32',
+      fontSize: '24',
+      lineHeight: '30',
     },
     groupB: {
-      fontSize: '32',
-      lineHeight: '42',
+      fontSize: '28',
+      lineHeight: '38',
     },
     groupD: {
-      fontSize: '46',
-      lineHeight: '58',
+      fontSize: '40',
+      lineHeight: '52',
     },
   },
   trafalgar: {


### PR DESCRIPTION
Resolves #3603

**Overall change:**
Off the back of editorial feedback, UX are recommending a font size reduction to the Thai Canon type spec.

<img width="410" alt="thai" src="https://user-images.githubusercontent.com/46446236/87412678-36fafd80-c5c1-11ea-9fc5-9d15b1227e47.png">

**Code changes:**
- Update `thai` Canon typography values

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
