### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.182 | [PR#3609](https://github.com/bbc/psammead/pull/3609) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.0.181 | [PR#3608](https://github.com/bbc/psammead/pull/3608) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 2.0.180 | [PR#3605](https://github.com/bbc/psammead/pull/3605) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |
 | 2.0.179 | [PR#3604](https://github.com/bbc/psammead/pull/3604) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.181",
+  "version": "2.0.182",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3916,9 +3916,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.9.tgz",
-      "integrity": "sha512-//1cHSLGZ7r0bjk86mNw5Mal1BXhvMdY5ihN8m6BSE1i88wKj9+uQl9cTxzPZI4NGbv1/+Efod5FLSH1B1JOPA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.10.tgz",
+      "integrity": "sha512-XCTBb+2Hb8xS5WyJ3bYAhFv4NyoQ1IMGV7O6A0jdjSP+uhsVbNQdVq6twXNqCmC+CrN/4pdwGko/OnmXnaeYOQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.1.0",
@@ -3926,7 +3926,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
-        "@bbc/psammead-timestamp-container": "^4.0.3"
+        "@bbc/psammead-timestamp-container": "^4.0.4"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.181",
+  "version": "2.0.182",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -78,7 +78,7 @@
     "@bbc/psammead-navigation": "^6.0.12",
     "@bbc/psammead-paragraph": "^2.2.31",
     "@bbc/psammead-play-button": "^1.1.17",
-    "@bbc/psammead-radio-schedule": "3.0.9",
+    "@bbc/psammead-radio-schedule": "3.0.10",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.16",
     "@bbc/psammead-section-label": "^5.0.9",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.9  →  3.0.10

| Version | Description |
|---------|-------------|
| 3.0.10 | [PR#3608](https://github.com/bbc/psammead/pull/3608) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

