### PR TITLE
Moves embed-error out of alpha with a11y fixes

### DIFF
--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                       |
 |---------------|-----------------------------------------------------------------------------------|
+| 1.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Resolve a11y issues and release of version 1.0. |
 | 1.0.0-alpha.21 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.0.0-alpha.20 | [PR#3604](https://github.com/bbc/psammead/pull/3604) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.0-alpha.19 | [PR#3573](https://github.com/bbc/psammead/pull/3573) Add option to render a link. |

--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version       | Description                                                                       |
 |---------------|-----------------------------------------------------------------------------------|
-| 1.0.0 | [PR#xxxx](https://github.com/bbc/psammead/pull/xxxx) Resolve a11y issues and release of version 1.0. |
+| 1.0.0 | [PR#3615](https://github.com/bbc/psammead/pull/3615) Resolve a11y issues and release of version 1.0. |
 | 1.0.0-alpha.21 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.0.0-alpha.20 | [PR#3604](https://github.com/bbc/psammead/pull/3604) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 1.0.0-alpha.19 | [PR#3573](https://github.com/bbc/psammead/pull/3573) Add option to render a link. |

--- a/packages/components/psammead-embed-error/README.md
+++ b/packages/components/psammead-embed-error/README.md
@@ -1,7 +1,3 @@
-# ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-embed-error - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-embed-error%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-embed-error%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-embed-error)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-embed-error) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-embed-error)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-embed-error&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/embed-error--containing-image) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-embed-error.svg)](https://www.npmjs.com/package/@bbc/psammead-embed-error) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-embed-error/package-lock.json
+++ b/packages/components/psammead-embed-error/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-embed-error/package.json
+++ b/packages/components/psammead-embed-error/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "1.0.0-alpha.21",
-  "publishConfig": {
-    "tag": "alpha"
-  },
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-embed-error/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-embed-error/src/__snapshots__/index.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`EmbedError renders a default embed error 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
-  border: 1px solid transparent;
+  border: 0.0625rem solid transparent;
 }
 
 .c1 {
@@ -105,7 +105,7 @@ exports[`EmbedError renders an embed error that fills the viewport 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
-  border: 1px solid transparent;
+  border: 0.0625rem solid transparent;
   background-position: center;
   background-size: 38.2%;
   height: 100vh;
@@ -187,7 +187,7 @@ exports[`EmbedError renders an embed error with a link 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
-  border: 1px solid transparent;
+  border: 0.0625rem solid transparent;
 }
 
 .c1 {

--- a/packages/components/psammead-embed-error/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-embed-error/src/__snapshots__/index.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`EmbedError renders a default embed error 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
+  border: 1px solid transparent;
 }
 
 .c1 {
@@ -104,6 +105,7 @@ exports[`EmbedError renders an embed error that fills the viewport 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
+  border: 1px solid transparent;
   background-position: center;
   background-size: 38.2%;
   height: 100vh;
@@ -185,6 +187,7 @@ exports[`EmbedError renders an embed error with a link 1`] = `
   justify-content: flex-end;
   padding-top: 6rem;
   padding-bottom: 1.5rem;
+  border: 1px solid transparent;
 }
 
 .c1 {

--- a/packages/components/psammead-embed-error/src/index.jsx
+++ b/packages/components/psammead-embed-error/src/index.jsx
@@ -36,7 +36,7 @@ const StyledEmbedError = styled.div`
   justify-content: flex-end;
   padding-top: ${FAUX_BBC_BLOCKS_SPACE};
   padding-bottom: ${GEL_SPACING_TRPL};
-  border: 1px solid transparent;
+  border: 0.0625rem solid transparent;
   ${({ fillViewport }) => fillViewport && FILL_VIEWPORT_STYLES}
 `;
 

--- a/packages/components/psammead-embed-error/src/index.jsx
+++ b/packages/components/psammead-embed-error/src/index.jsx
@@ -36,6 +36,7 @@ const StyledEmbedError = styled.div`
   justify-content: flex-end;
   padding-top: ${FAUX_BBC_BLOCKS_SPACE};
   padding-bottom: ${GEL_SPACING_TRPL};
+  border: 1px solid transparent;
   ${({ fillViewport }) => fillViewport && FILL_VIEWPORT_STYLES}
 `;
 


### PR DESCRIPTION
Resolves #3606

**Overall change:** After the a11y swarm completed in https://github.com/bbc/simorgh/pull/7180#issuecomment-659301442, this applies a11y fixes to move the component out of it's alpha state.

**Code changes:**

- Removed alpha tag.
- Updated to version 1.0.0.
- Applied transparent border for HCM a11y requirements.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
