### PR TITLE
Removed extra whitespace in psammead-image-placeholder Changelog

### DIFF
--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.2.41 | [PR#3633](https://github.com/bbc/psammead/pull/3633) Removing white space in changelog to retrigger deploy |
 | 1.2.4 | [PR#3611](https://github.com/bbc/psammead/pull/3611) Make placeholder darkmode compatible |
 | 1.2.37 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.2.36 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 1.2.4  | [PR#3611](https://github.com/bbc/psammead/pull/3611) Make placeholder darkmode compatible |
+| 1.2.4 | [PR#3611](https://github.com/bbc/psammead/pull/3611) Make placeholder darkmode compatible |
 | 1.2.37 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 1.2.36 | [PR#3467](https://github.com/bbc/psammead/pull/3467) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.2.35 | [PR#3397](https://github.com/bbc/psammead/pull/3397) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.4",
+  "version": "1.2.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "1.2.4",
+  "version": "1.2.41",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
**Overall change:**

This PR -> https://github.com/bbc/psammead/pull/3611/files
Has not updated this package to 1.2.4 -> https://registry.npmjs.org/@bbc/psammead-image-placeholder

The only thing I can see is that I’ve double-spaced something in the changelog…
`|-1.2.4--|`

rather than:
`|-1.2.37-|`

**Code changes:**

- This PR removes that additional white space
- Version bump to hopefully fix any NPM flakes

---

- [x] I have assigned myself to this PR and the corresponding issues
