### PR TITLE
Talos - Bump @bbc/psammead-image-placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.187 | [PR#3634](https://github.com/bbc/psammead/pull/3634) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 2.0.186 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |
 | 2.0.185 | [PR#3629](https://github.com/bbc/psammead/pull/3629) Talos - Bump Dependencies - @bbc/psammead-embed-error, @bbc/psammead-navigation |
 | 2.0.184 | [PR#3623](https://github.com/bbc/psammead/pull/3623) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.186",
+  "version": "2.0.187",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3807,12 +3807,12 @@
       "dev": true
     },
     "@bbc/psammead-image-placeholder": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.36.tgz",
-      "integrity": "sha512-j9yi9vmfxDS4NmNOXqznRX6Js6vVvwfk6HUbhUojB0l0zb4LSLBvXXACb4T50SVpGM8qgpINwTD3dk3If/CEAQ==",
+      "version": "1.2.41",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.41.tgz",
+      "integrity": "sha512-QKQHyyVouYe8DBjev6NRt/0TdDgstuN/xlva5HA+t2mtBgFvB5nDaa8oflsjCoXMoPBcleGkenu0NUHV9Nhliw==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.14.0",
+        "@bbc/psammead-assets": "^2.14.1",
         "@bbc/psammead-styles": "^4.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.186",
+  "version": "2.0.187",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -68,7 +68,7 @@
     "@bbc/psammead-heading-index": "^1.0.2",
     "@bbc/psammead-headings": "^3.1.33",
     "@bbc/psammead-image": "^1.2.4",
-    "@bbc/psammead-image-placeholder": "^1.2.36",
+    "@bbc/psammead-image-placeholder": "^1.2.41",
     "@bbc/psammead-inline-link": "^1.3.22",
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.10",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^1.2.36  →  ^1.2.41

| Version | Description |
|---------|-------------|
| 1.2.41 | [PR#3633](https://github.com/bbc/psammead/pull/3633) Removing white space in changelog to retrigger deploy |
| 1.2.4 | [PR#3611](https://github.com/bbc/psammead/pull/3611) Make placeholder darkmode compatible |
| 1.2.37 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
</details>

