### PR TITLE
Talos - Bump @bbc/psammead-media-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.189 | [PR#3635](https://github.com/bbc/psammead/pull/3635) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.0.188 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Bump version to include using new @bbc/psammead-image-placeholder |
 | 2.0.187 | [PR#3631](https://github.com/bbc/psammead/pull/3629) Update codeowners |
 | 2.0.186 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.187",
+  "version": "2.0.189",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3853,14 +3853,15 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.14.tgz",
-      "integrity": "sha512-XZ8j0PQkoQj+ECdx9qmJ/s/0krQ0BC4hahbmdX62gZVgYMcXNeTmdyrksloqzQJvSZ5VivicsEDdhS4Gw8ZRKQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.8.0.tgz",
+      "integrity": "sha512-JdJ789oqzXxoXcqnpiweLGShtLCRISwXfoVPFhVRXQYNCQCBrLRqhK2OV4D/woqnVlvMZYd+WmDP/QZ1S8Ih8A==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.14.0",
+        "@bbc/psammead-assets": "^2.14.1",
         "@bbc/psammead-image": "^1.2.4",
-        "@bbc/psammead-play-button": "^1.1.17"
+        "@bbc/psammead-image-placeholder": "^1.2.41",
+        "@bbc/psammead-play-button": "^1.1.19"
       }
     },
     "@bbc/psammead-most-read": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.188",
+  "version": "2.0.189",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -73,7 +73,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.10",
     "@bbc/psammead-media-indicator": "^4.0.10",
-    "@bbc/psammead-media-player": "^2.7.14",
+    "@bbc/psammead-media-player": "^2.8.0",
     "@bbc/psammead-most-read": "^4.1.7",
     "@bbc/psammead-navigation": "^6.0.15",
     "@bbc/psammead-paragraph": "^2.2.32",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-player  ^2.7.14  →  ^2.8.0

| Version       | Description                                                                                                                  |
| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| 2.8.0 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Implementing dark mode compatible placeholder with media player |
| 2.7.16 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-play-button |
| 2.7.15 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
</details>

