### PR TITLE
[1/2] Decouple jest-styled-components from psammead-test-helpers

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.0 | [PR#3636](https://github.com/bbc/psammead/pull/3636) Decouple from jest-styled-components |
 | 3.1.5 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |
 | 3.1.4 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |
 | 3.1.3 | [PR#3155](https://github.com/bbc/psammead/pull/3155) add matchSnapshotAsync method to README |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -4,40 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-    },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "jest-styled-components": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.4.tgz",
-      "integrity": "sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==",
-      "requires": {
-        "css": "^2.2.4"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -99,38 +65,6 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
       "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==",
       "dev": true
-    },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     }
   }
 }

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.5",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -26,9 +26,7 @@
     "jest",
     "snapshot"
   ],
-  "dependencies": {
-    "jest-styled-components": "^6.3.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "react-helmet": "^6.0.0"
   }

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "3.1.5",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import 'jest-styled-components';
 import deepClone from 'ramda/src/clone';
 import renderWithHelmet from './renderWithHelmet';
 


### PR DESCRIPTION
No issue.

### Overall change:

This PR is a part of a series working towards improving [SSR performance](https://github.com/bbc/simorgh/issues/6922) – starting by upgrading to [Styled Components v5](https://github.com/bbc/simorgh/issues/5182).

It decouples `jest-styled-components` from `psammead-test-helpers`, so that it can be reinstated in the recommended way - in `jest.config.js` in both Psammead and Simorgh. This will happen in a follow-up PR.

#### Aside
This will afford us more control over our testing configuration and help us work towards resolving long-unsolved issues:
- https://github.com/bbc/psammead/issues/3054
- https://github.com/bbc/psammead/pull/2976
- https://github.com/bbc/psammead/pull/3067

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~[ ] This PR requires manual testing~
