### PR TITLE
[2/2] Decouple jest-styled-components from psammead-test-helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.0 | [PR#3638](https://github.com/bbc/psammead/pull/3638) 2/2 - Decouple jest-styled-components from @bbc/psammead-test-helpers |
 | 2.0.188 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Bump version to include using new @bbc/psammead-image-placeholder |
 | 2.0.187 | [PR#3631](https://github.com/bbc/psammead/pull/3629) Update codeowners |
 | 2.0.186 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  collectCoverageFrom: [
+    '**/packages/**/*.{js,jsx}',
+    'scripts/**',
+    '**/.yeoman/support/**',
+    '!**/*.stories.{js,jsx}',
+    '!**/.eslintrc.js',
+    '!**/dist/**',
+    '!**/esm/**',
+    '!**/moment-timezone-include/tz/**',
+  ],
+  transformIgnorePatterns: ['/node_modules/', '.yeoman/index.js'],
+  testMatch: ['**/*.test.{js,jsx}', '!**/.yeoman/templates/**'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFilesAfterEnv: ['jest-styled-components'],
   collectCoverageFrom: [
     '**/packages/**/*.{js,jsx}',
     'scripts/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.187",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4016,24 +4016,10 @@
       "dev": true
     },
     "@bbc/psammead-test-helpers": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-3.1.5.tgz",
-      "integrity": "sha512-6SUiCX9/lmWJQfYwSXCmU3M3lcy7YSxLrxnrpJnPJ225PFPAb4LO4TY0sfKHExtQYRhJYmF8TcioSdfVMVfyUg==",
-      "dev": true,
-      "requires": {
-        "jest-styled-components": "^6.3.3"
-      },
-      "dependencies": {
-        "jest-styled-components": {
-          "version": "6.3.4",
-          "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.4.tgz",
-          "integrity": "sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==",
-          "dev": true,
-          "requires": {
-            "css": "^2.2.4"
-          }
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-test-helpers/-/psammead-test-helpers-4.0.0.tgz",
+      "integrity": "sha512-bn+FxvpcVjrFA14vXYu8W5HxkxpsgEM1f2+kPstbYUJCYFVWdu0PhvTySUq/FkQqBLEn0cSYRZ9sc7M0Qi3CIQ==",
+      "dev": true
     },
     "@bbc/psammead-timestamp": {
       "version": "2.2.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4022,6 +4022,17 @@
       "dev": true,
       "requires": {
         "jest-styled-components": "^6.3.3"
+      },
+      "dependencies": {
+        "jest-styled-components": {
+          "version": "6.3.4",
+          "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.4.tgz",
+          "integrity": "sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==",
+          "dev": true,
+          "requires": {
+            "css": "^2.2.4"
+          }
+        }
       }
     },
     "@bbc/psammead-timestamp": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "glob-loader": "^0.3.0",
     "husky": "^4.2.5",
     "jest": "^26.1.0",
+    "jest-styled-components": "^6.3.4",
     "json5": "^2.1.3",
     "lerna": "^3.22.1",
     "lint-staged": "^10.2.11",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-story-promo-list": "^4.1.2",
     "@bbc/psammead-storybook-helpers": "^8.3.4",
     "@bbc/psammead-styles": "^4.4.0",
-    "@bbc/psammead-test-helpers": "^3.1.5",
+    "@bbc/psammead-test-helpers": "^4.0.0",
     "@bbc/psammead-timestamp": "^2.2.31",
     "@bbc/psammead-timestamp-container": "^4.0.5",
     "@bbc/psammead-useful-links": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.0.188",
+  "version": "2.1.0",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -160,26 +160,6 @@
       "pre-commit": "lint-staged",
       "pre-push": "sh scripts/enforceVersions.sh && npm run test:unit -- --changedSince=latest"
     }
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "**/packages/**/*.{js,jsx}",
-      "scripts/**",
-      "**/.yeoman/support/**",
-      "!**/*.stories.{js,jsx}",
-      "!**/.eslintrc.js",
-      "!**/dist/**",
-      "!**/esm/**",
-      "!**/moment-timezone-include/tz/**"
-    ],
-    "transformIgnorePatterns": [
-      "/node_modules/",
-      ".yeoman/index.js"
-    ],
-    "testMatch": [
-      "**/*.test.{js,jsx}",
-      "!**/.yeoman/templates/**"
-    ]
   },
   "spec": {
     "prune": false,


### PR DESCRIPTION
Part 2/2 of https://github.com/bbc/psammead/pull/3636

### Overall change:

This PR is a part of a series working towards improving [SSR performance](https://github.com/bbc/simorgh/issues/6922) – starting by upgrading to [Styled Components v5](https://github.com/bbc/simorgh/issues/5182).

It bumps `psammead-test-helpers` to v4, which removed its dependency on `jest-styled-components` in #3636, and reinstates `jest-styled-components` in the recommended way - inside in `jest.config.js`.

#### Aside
This will afford us more control over our testing configuration and help us work towards resolving long-unsolved issues:
- https://github.com/bbc/psammead/issues/3054
- https://github.com/bbc/psammead/pull/2976
- https://github.com/bbc/psammead/pull/3067

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- ~[ ] This PR requires manual testing~
