### PR TITLE
Conditionally apply z-index change to psammead-media-player based on whether the loadingImage is being used

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2.8.1 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Make z-index styling be conditional based on whether loadingImage is used |
 | 2.8.0 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Implementing dark mode compatible placeholder with media player |
 | 2.7.16 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 2.7.15 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Media Player: Canonical should render an iframe 1`] = `
 .c0 {
-  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;

--- a/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Media Player: Canonical should render an iframe 1`] = `
 .c0 {
-  z-index: 1;
+  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;

--- a/packages/components/psammead-media-player/src/Canonical/index.jsx
+++ b/packages/components/psammead-media-player/src/Canonical/index.jsx
@@ -30,7 +30,7 @@ const Canonical = ({
   `;
 
   const StyledIframe = styled.iframe`
-    z-index: 1;
+    z-index: ${props => (props.showLoadingImage ? 1 : 0)};
     border: 0;
     left: 0;
     overflow: hidden;
@@ -50,6 +50,7 @@ const Canonical = ({
         scrolling="no"
         gesture="media"
         allowFullScreen
+        showLoadingImage={showLoadingImage}
       />
       {showLoadingImage && (
         <LoadingImageWrapper>

--- a/packages/components/psammead-media-player/src/Canonical/index.jsx
+++ b/packages/components/psammead-media-player/src/Canonical/index.jsx
@@ -30,7 +30,7 @@ const Canonical = ({
   `;
 
   const StyledIframe = styled.iframe`
-    z-index: ${props => (props.showLoadingImage ? 1 : 0)};
+    ${showLoadingImage ? `z-index: 1` : ''};
     border: 0;
     left: 0;
     overflow: hidden;
@@ -50,7 +50,6 @@ const Canonical = ({
         scrolling="no"
         gesture="media"
         allowFullScreen
-        showLoadingImage={showLoadingImage}
       />
       {showLoadingImage && (
         <LoadingImageWrapper>

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -733,7 +733,7 @@ exports[`Media Player: Canonical Entry renders an iframe when showPlaceholder is
 }
 
 .c1 {
-  z-index: 1;
+  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;
@@ -772,7 +772,7 @@ exports[`Media Player: Canonical Entry renders the audio skin 1`] = `
 }
 
 .c1 {
-  z-index: 1;
+  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -733,7 +733,6 @@ exports[`Media Player: Canonical Entry renders an iframe when showPlaceholder is
 }
 
 .c1 {
-  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;
@@ -772,7 +771,6 @@ exports[`Media Player: Canonical Entry renders the audio skin 1`] = `
 }
 
 .c1 {
-  z-index: auto;
   border: 0;
   left: 0;
   overflow: hidden;

--- a/packages/components/psammead-media-player/src/index.stories.jsx
+++ b/packages/components/psammead-media-player/src/index.stories.jsx
@@ -38,7 +38,7 @@ storiesOf('Components|Media Player', module)
           type: 'video',
           ...withDuration,
         }}
-        showLoadingImage
+        showLoadingImage={boolean('Show loading image', true)}
         darkMode={boolean('Dark mode', false)}
         title="Media player"
         noJsMessage="Dem no support media player for your device"


### PR DESCRIPTION
Resolves #https://github.com/bbc/simorgh/issues/7185

**Overall change:**

- Wrap z-index change to psammead-media-player in ternary based on whether the `loadingImage` prop is passed.
- Bumping version numbers and updating snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
