### PR TITLE
Talos - Bump @bbc/psammead-media-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.1.1 | [PR#3642](https://github.com/bbc/psammead/pull/3642) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.1.0 | [PR#3638](https://github.com/bbc/psammead/pull/3638) 2/2 - Decouple jest-styled-components from @bbc/psammead-test-helpers |
 | 2.0.188 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Bump version to include using new @bbc/psammead-image-placeholder |
 | 2.0.187 | [PR#3631](https://github.com/bbc/psammead/pull/3629) Update codeowners |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3853,14 +3853,15 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.14.tgz",
-      "integrity": "sha512-XZ8j0PQkoQj+ECdx9qmJ/s/0krQ0BC4hahbmdX62gZVgYMcXNeTmdyrksloqzQJvSZ5VivicsEDdhS4Gw8ZRKQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.8.2.tgz",
+      "integrity": "sha512-YlLCrpN/FFuenxfyerxOe8gTfHY4vCjT326an3VU8DFZxQZD9hFEJ0e5VmDe4RBknxPnfDGk7k9Bs6mHaAYT/A==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.14.0",
+        "@bbc/psammead-assets": "^2.14.1",
         "@bbc/psammead-image": "^1.2.4",
-        "@bbc/psammead-play-button": "^1.1.17"
+        "@bbc/psammead-image-placeholder": "^1.2.41",
+        "@bbc/psammead-play-button": "^1.1.19"
       }
     },
     "@bbc/psammead-most-read": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -73,7 +73,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.10",
     "@bbc/psammead-media-indicator": "^4.0.10",
-    "@bbc/psammead-media-player": "^2.7.14",
+    "@bbc/psammead-media-player": "^2.8.2",
     "@bbc/psammead-most-read": "^4.1.7",
     "@bbc/psammead-navigation": "^6.0.15",
     "@bbc/psammead-paragraph": "^2.2.32",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-player  ^2.7.14  →  ^2.8.2

| Version       | Description                                                                                                                  |
| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| 2.8.2 | [PR#3641](https://github.com/bbc/psammead/pull/3641) Version bump & fixing PR link |
| 2.8.1 | [PR#3640](https://github.com/bbc/psammead/pull/3640) Make z-index styling be conditional based on whether loadingImage is used |
| 2.8.0 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Implementing dark mode compatible placeholder with media player |
| 2.7.16 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-play-button |
| 2.7.15 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
</details>

