### PR TITLE
Talos - Bump @bbc/psammead-media-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.4 | [PR#3705](https://github.com/bbc/psammead/pull/3705) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.2.3 | [PR#3679](https://github.com/bbc/psammead/pull/3679) Fix package-lock |
 | 2.2.2 | [PR#3678](https://github.com/bbc/psammead/pull/3678) Adding a dependabot config file |
 | 2.2.1 | [PR#3689](https://github.com/bbc/psammead/pull/3689) Force dependencies dot-prop@^4.2.1, prismjs@^1.21.0, lodash@^4.17.20 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,14 +15,17 @@
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -71,7 +74,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -94,12 +97,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -180,11 +186,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -195,12 +204,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -216,7 +228,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
@@ -233,12 +248,14 @@
       "requires": {
         "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -273,12 +290,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -316,12 +336,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -369,12 +392,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -448,12 +474,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -467,7 +496,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -540,12 +569,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -561,7 +593,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -592,12 +627,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -678,11 +716,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -693,12 +734,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -755,12 +799,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -795,7 +842,7 @@
         "@babel/helper-split-export-declaration": "^7.10.4",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.10.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -815,12 +862,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -940,11 +990,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -955,12 +1008,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -976,7 +1032,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -1001,11 +1060,14 @@
       "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -1039,12 +1101,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1134,11 +1199,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1149,12 +1217,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1243,12 +1314,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1307,12 +1381,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1393,11 +1470,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1408,12 +1488,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1458,12 +1541,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1544,11 +1630,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1559,12 +1648,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1810,12 +1902,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1946,11 +2041,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1961,12 +2059,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2216,12 +2317,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -2251,7 +2355,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
@@ -2261,7 +2365,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -2298,12 +2405,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2429,11 +2539,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2444,12 +2557,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2666,12 +2782,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2852,12 +2971,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2974,11 +3096,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2989,12 +3114,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3177,12 +3305,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -3254,12 +3385,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3361,12 +3495,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -3513,12 +3650,15 @@
           "requires": {
             "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3707,11 +3847,14 @@
             "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3722,12 +3865,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3838,11 +3984,13 @@
         "@babel/types": "^7.10.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -3852,12 +4000,14 @@
       "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -4100,14 +4250,15 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.14.tgz",
-      "integrity": "sha512-XZ8j0PQkoQj+ECdx9qmJ/s/0krQ0BC4hahbmdX62gZVgYMcXNeTmdyrksloqzQJvSZ5VivicsEDdhS4Gw8ZRKQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.10.0.tgz",
+      "integrity": "sha512-NsAr8AihN6t4GHxkFuRZUBfdC0t2J9wAvbWJsweju/Hx9/omE7sqzcTb8zu98NUph5JhW7bVTH1JxPjVH2IvNA==",
       "dev": true,
       "requires": {
-        "@bbc/psammead-assets": "^2.14.0",
+        "@bbc/psammead-assets": "^2.14.1",
         "@bbc/psammead-image": "^1.2.4",
-        "@bbc/psammead-play-button": "^1.1.17"
+        "@bbc/psammead-image-placeholder": "^1.2.41",
+        "@bbc/psammead-play-button": "^1.1.19"
       }
     },
     "@bbc/psammead-most-read": {
@@ -6327,7 +6478,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.2.0",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -6359,7 +6510,13 @@
           }
         },
         "dot-prop": {
-          "version": "^4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -6533,7 +6690,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -6543,7 +6700,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -7306,7 +7466,7 @@
         "escape-html": "^1.0.3",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
         "react-color": "^2.17.0",
@@ -7315,7 +7475,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7391,7 +7554,7 @@
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.6.2",
         "react": "^16.8.3",
@@ -7403,7 +7566,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -7452,7 +7618,7 @@
         "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
         "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "stable": "^0.1.8",
@@ -7476,7 +7642,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7501,7 +7670,7 @@
         "@types/react-textarea-autosize": "^4.3.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -7519,7 +7688,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7769,11 +7941,14 @@
       "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7862,7 +8037,7 @@
         "babel-plugin-react-docgen": "^4.0.0",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mini-css-extract-plugin": "^0.7.0",
         "prop-types": "^15.7.2",
         "react-dev-utils": "^9.0.0",
@@ -7873,7 +8048,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -7894,14 +8072,17 @@
         "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7947,7 +8128,7 @@
         "fast-deep-equal": "^2.0.1",
         "fuse.js": "^3.4.6",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -7968,7 +8149,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -8237,7 +8421,7 @@
         "css.escape": "^1.5.1",
         "jest-diff": "^25.1.0",
         "jest-matcher-utils": "^25.1.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -8283,7 +8467,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
@@ -9438,11 +9625,14 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.14"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -9899,11 +10089,14 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -9986,13 +10179,16 @@
       "integrity": "sha512-vzpnBlfGv8XOhJM2zbPyyqw2OLEbelgZZsaaRRTpVwNKuYuc+pUg4+dy7i9gCRms0uOQn4osX571HRcCJMJCmA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "react-docgen": "^5.0.0",
         "recast": "^0.14.7"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -10010,11 +10206,13 @@
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -10151,11 +10349,14 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -11617,11 +11818,17 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^3.0.0"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "^4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         }
       }
     },
@@ -11661,7 +11868,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -11669,7 +11876,13 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "^4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "env-paths": {
           "version": "1.0.0",
@@ -11721,7 +11934,7 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -11730,7 +11943,13 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "^4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "make-dir": {
           "version": "1.3.0",
@@ -11828,7 +12047,7 @@
         "git-raw-commits": "2.0.0",
         "git-remote-origin-url": "^2.0.0",
         "git-semver-tags": "^2.0.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.2.1",
         "normalize-package-data": "^2.3.5",
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
@@ -11849,7 +12068,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
@@ -11925,7 +12147,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "meow": "^7.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -11933,7 +12155,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -11970,7 +12195,7 @@
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "meow": "^7.0.0",
         "split2": "^2.0.0",
         "through2": "^3.0.0",
@@ -11978,7 +12203,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "through2": {
           "version": "3.0.1",
@@ -13782,7 +14010,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -13842,7 +14070,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "path-key": {
           "version": "3.1.1",
@@ -14030,12 +14261,15 @@
       "integrity": "sha512-Ktsab8ij33V2KFLhh4alC1FYztdmbV32DeMZYYUCZm4kKLW1s4DrleKKgtbAHSJsmshCK5QGOZtfyc2r3jCRsg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "vscode-json-languageservice": "^3.5.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -16137,13 +16371,16 @@
       "dev": true,
       "requires": {
         "encodeurl": "^1.0.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.10",
         "npm-conf": "^1.1.3",
         "tunnel": "^0.0.6"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -16254,11 +16491,14 @@
       "integrity": "sha512-rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -16653,14 +16893,17 @@
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
         "util.promisify": "1.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -17042,7 +17285,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
@@ -17105,7 +17348,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.0",
@@ -17199,7 +17445,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -17209,7 +17455,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -23137,7 +23386,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       },
@@ -23154,7 +23403,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",
@@ -23710,7 +23962,7 @@
       "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "material-colors": "^1.2.1",
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
@@ -23718,7 +23970,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -23862,7 +24117,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -23872,7 +24127,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -24267,12 +24525,18 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "^1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -24316,11 +24580,14 @@
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.0.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -24530,11 +24797,17 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "^1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "^1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -24855,11 +25128,14 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -25761,11 +26037,17 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^4.1.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "^4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         }
       }
     },
@@ -27371,22 +27653,31 @@
         "@storybook/components": "^5.0.6",
         "@storybook/core-events": "^5.0.6",
         "html-loader": "^0.5.5",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "markdown-loader": "^5.0.0",
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.16.0",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "prismjs": {
-          "version": "^1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -27796,7 +28087,7 @@
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^7.0.1",
@@ -27934,7 +28225,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "micromatch": {
           "version": "4.0.2",
@@ -28298,7 +28592,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -28316,7 +28610,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -28443,7 +28740,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^1.1.0",
             "figures": "^1.3.5",
-            "lodash": "^4.17.20",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.6",
             "pinkie-promise": "^2.0.0",
             "run-async": "^2.2.0",
@@ -28454,7 +28751,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -28595,7 +28895,7 @@
         "is-regex": "^1.0.4",
         "is-symbol": "^1.0.3",
         "isobject": "^4.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3"
       },
       "dependencies": {
@@ -28606,7 +28906,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -31027,7 +31330,7 @@
         "grouped-queue": "^1.1.0",
         "inquirer": "^7.1.0",
         "is-scoped": "^1.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.10",
         "log-symbols": "^2.2.0",
         "mem-fs": "^1.1.0",
         "mem-fs-editor": "^6.0.0",
@@ -31115,7 +31418,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",
@@ -31195,7 +31501,7 @@
         "github-username": "^3.0.0",
         "grouped-queue": "^1.1.0",
         "istextorbinary": "^2.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "make-dir": "^3.0.0",
         "mem-fs-editor": "^7.0.1",
         "minimist": "^1.2.5",
@@ -31300,7 +31606,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "make-dir": {
           "version": "3.1.0",
@@ -31476,7 +31785,7 @@
         "humanize-string": "^1.0.2",
         "inquirer": "^6.0.0",
         "insight": "^0.10.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "meow": "^3.0.0",
         "npm-keyword": "^5.0.0",
         "open": "^6.3.0",
@@ -31621,7 +31930,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -31631,7 +31940,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -31681,7 +31993,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "map-obj": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -78,7 +78,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.10",
     "@bbc/psammead-media-indicator": "^4.0.10",
-    "@bbc/psammead-media-player": "^2.7.14",
+    "@bbc/psammead-media-player": "^2.10.0",
     "@bbc/psammead-most-read": "^4.1.7",
     "@bbc/psammead-navigation": "^6.0.15",
     "@bbc/psammead-paragraph": "^2.2.32",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-player  ^2.7.14  →  ^2.10.0

| Version       | Description                                                                                                                  |
| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| 2.10.0 | [PR#3679](https://github.com/bbc/psammead/pull/3679) Add bindings for media playback events |
| 2.9.0 | [PR#3666](https://github.com/bbc/psammead/pull/3666) Adding story for media message and removing bottom border from strong el |
| 2.8.2 | [PR#3641](https://github.com/bbc/psammead/pull/3641) Version bump & fixing PR link |
| 2.8.1 | [PR#3640](https://github.com/bbc/psammead/pull/3640) Make z-index styling be conditional based on whether loadingImage is used |
| 2.8.0 | [PR#3600](https://github.com/bbc/psammead/pull/3600) Implementing dark mode compatible placeholder with media player |
| 2.7.16 | [PR#3626](https://github.com/bbc/psammead/pull/3626) Talos - Bump Dependencies - @bbc/psammead-play-button |
| 2.7.15 | [PR#3613](https://github.com/bbc/psammead/pull/3613) Talos - Bump Dependencies - @bbc/psammead-assets |
</details>

