### PR TITLE
Update change scanner in jenkinsfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.9 | [PR#3711](https://github.com/bbc/psammead/pull/3711) Update jenkinsfile so changescanner doesn't run on latest |
 | 2.2.8 | [PR#3710](https://github.com/bbc/psammead/pull/3710) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-styles, @bbc/psammead-timestamp, @bbc/psammead-useful-links |
 | 2.2.7 | [PR#3707](https://github.com/bbc/psammead/pull/3707) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-styles, @bbc/psammead-timestamp-container |
 | 2.2.6 | [PR#3706](https://github.com/bbc/psammead/pull/3706) Bumping minor dependencies |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,9 @@ node {
                   sh 'make code-coverage-before-build'
                   sh 'make test'
                   sh 'make code-coverage-after-build'
-                  sh 'make change-scanner'
+                  if (env.BRANCH_NAME !== 'latest') {
+                    sh 'make change-scanner'
+                  }
                 },
                 'ChromaticQA Tests': {
                   withCredentials([string(credentialsId: 'psammead-chromatic-app-code', variable: 'CHROMATIC_APP_CODE')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,10 @@ node {
                   sh 'make code-coverage-before-build'
                   sh 'make test'
                   sh 'make code-coverage-after-build'
-                  if (env.BRANCH_NAME != 'latest') {
-                    sh 'make change-scanner'
+                  script {
+                    if (env.BRANCH_NAME != 'latest') {
+                      sh 'make change-scanner'
+                    }
                   }
                 },
                 'ChromaticQA Tests': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node {
                   sh 'make code-coverage-before-build'
                   sh 'make test'
                   sh 'make code-coverage-after-build'
-                  if (env.BRANCH_NAME !== 'latest') {
+                  if (env.BRANCH_NAME != 'latest') {
                     sh 'make change-scanner'
                   }
                 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
**Overall change:** Updates the jenkins file so the change scanner script doesn't run on latest. The rationale being that if you have made the necessary changes on your PR and it has passed CI, then we don't need to check again.

**Code changes:**

- jenkinsfile has been updated to only run the changescanner script when the branch isn't latest

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
