### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.2.12 | [PR#3714](https://github.com/bbc/psammead/pull/3714) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.2.11 | [PR#3713](https://github.com/bbc/psammead/pull/3713) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 2.2.10 | [PR#3712](https://github.com/bbc/psammead/pull/3712) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-media-indicator, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |
 | 2.2.9 | [PR#3711](https://github.com/bbc/psammead/pull/3711) Update jenkinsfile so changescanner doesn't run on latest |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4894,9 +4894,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.16.tgz",
-      "integrity": "sha512-Kc4r6q7eq1v3G7haSg06RPq42FXN9aifBWmDZ7XQk+g2ENrElizUXWAYgspDEz0xFijyvSjrC5M/s165qa4Qpg==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.17.tgz",
+      "integrity": "sha512-0P9W3j6f6pBMmmOwD3TxvPZFE6oQ+TwQ/zePiX+7U8bpWK1cGh1uhsXvzkuEN85TcHA1lk8Ws5cdBfr1GybjfA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.2.0",
@@ -4904,7 +4904,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.3",
-        "@bbc/psammead-timestamp-container": "^4.0.7"
+        "@bbc/psammead-timestamp-container": "^4.0.8"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -83,7 +83,7 @@
     "@bbc/psammead-navigation": "^6.0.17",
     "@bbc/psammead-paragraph": "^2.2.34",
     "@bbc/psammead-play-button": "^1.1.21",
-    "@bbc/psammead-radio-schedule": "3.0.16",
+    "@bbc/psammead-radio-schedule": "3.0.17",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.19",
     "@bbc/psammead-section-label": "^5.0.12",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.16  →  3.0.17

| Version | Description |
|---------|-------------|
| 3.0.17 | [PR#3713](https://github.com/bbc/psammead/pull/3713) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

