### PR TITLE
Remove `prismjs` and `lodash` from forced resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.9 | [PR#3753](https://github.com/bbc/psammead/pull/3753) Remove `prismjs` and `lodash` from forced resolutions |
 | 2.3.8 | [PR#3752](https://github.com/bbc/psammead/pull/3752) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.3.7 | [PR#3736](https://github.com/bbc/psammead/pull/3733) Psammead media player UX updates |
 | 2.3.6 | [PR#3748](https://github.com/bbc/psammead/pull/3748) Bump @testing-library/react from 10.4.9 to 11.0.2 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6850,7 +6850,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.0",
+        "dot-prop": "^4.2.1",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -6882,13 +6882,7 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "^4.2.1"
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -13627,25 +13621,11 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
+        "dot-prop": "^4.2.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "is-obj": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-              "dev": true
-            }
-          }
+          "version": "^4.2.1"
         },
         "is-obj": {
           "version": "2.0.0",
@@ -13690,7 +13670,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop": "^4.2.1",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -13698,13 +13678,7 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "^4.2.1"
         },
         "env-paths": {
           "version": "1.0.0",
@@ -13756,7 +13730,7 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop": "^4.2.1",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -13765,13 +13739,7 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "^4.2.1"
         },
         "make-dir": {
           "version": "1.3.0",
@@ -13863,17 +13831,11 @@
           "dev": true,
           "requires": {
             "array-ify": "^1.0.0",
-            "dot-prop": "^5.1.0"
+            "dot-prop": "^4.2.1"
           },
           "dependencies": {
             "dot-prop": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-              "dev": true,
-              "requires": {
-                "is-obj": "^1.0.0"
-              }
+              "version": "^4.2.1"
             },
             "is-obj": {
               "version": "1.0.1",
@@ -13884,9 +13846,7 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ=="
+          "version": "^4.2.1"
         },
         "is-obj": {
           "version": "2.0.0",
@@ -25741,6 +25701,14 @@
       "integrity": "sha512-VTy6t69sS1FavspBsodoF/x/eduPydUXyZH+++Jkun0VQ4X7lCZVvsfGsYKzkUan2PJNcV2mA4lAFcr7KKXD1g==",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -27012,16 +26980,6 @@
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
         "prismjs": "~1.17.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        }
       }
     },
     "regenerate": {
@@ -28247,17 +28205,11 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "^4.1.1"
+        "dot-prop": "^4.2.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "^4.2.1"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
   "resolutions": {
-    "dot-prop": "^4.2.1",
-    "prismjs": "^1.21.0",
-    "lodash": "^4.17.20"
+    "dot-prop": "^4.2.1"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",


### PR DESCRIPTION
No issue

**Overall change:** 

Removing `prismjs` and `lodash` from forced resolutions to minimize changes package-lock.json when packages are updated.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
