### PR TITLE
Force `prismjs` version again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.3.10 | [PR#3754](https://github.com/bbc/psammead/pull/3754) Force `prismjs` version again |
 | 2.3.9 | [PR#3753](https://github.com/bbc/psammead/pull/3753) Remove `prismjs` and `lodash` from forced resolutions |
 | 2.3.8 | [PR#3752](https://github.com/bbc/psammead/pull/3752) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 2.3.7 | [PR#3736](https://github.com/bbc/psammead/pull/3733) Psammead media player UX updates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7861,18 +7861,12 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.8.4",
+                "prismjs": "^1.21.0",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
                 "prismjs": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-                  "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-                  "dev": true,
-                  "requires": {
-                    "clipboard": "^2.0.0"
-                  }
+                  "version": "^1.21.0"
                 }
               }
             },
@@ -7929,17 +7923,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -8044,18 +8033,12 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.8.4",
+                "prismjs": "^1.21.0",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
                 "prismjs": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-                  "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-                  "dev": true,
-                  "requires": {
-                    "clipboard": "^2.0.0"
-                  }
+                  "version": "^1.21.0"
                 }
               }
             },
@@ -8113,17 +8096,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -8238,18 +8216,12 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.8.4",
+                "prismjs": "^1.21.0",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
                 "prismjs": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-                  "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-                  "dev": true,
-                  "requires": {
-                    "clipboard": "^2.0.0"
-                  }
+                  "version": "^1.21.0"
                 }
               }
             },
@@ -8308,17 +8280,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -8609,18 +8576,12 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.8.4",
+                "prismjs": "^1.21.0",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
                 "prismjs": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-                  "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-                  "dev": true,
-                  "requires": {
-                    "clipboard": "^2.0.0"
-                  }
+                  "version": "^1.21.0"
                 }
               }
             },
@@ -8672,17 +8633,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -9301,17 +9257,12 @@
           "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -9643,18 +9594,12 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.8.4",
+                "prismjs": "^1.21.0",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
                 "prismjs": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-                  "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-                  "dev": true,
-                  "requires": {
-                    "clipboard": "^2.0.0"
-                  }
+                  "version": "^1.21.0"
                 }
               }
             },
@@ -9765,17 +9710,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.8.4",
+            "prismjs": "^1.21.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.21.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-              "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-              "requires": {
-                "clipboard": "^2.0.0"
-              }
+              "version": "^1.21.0"
             }
           }
         },
@@ -25702,12 +25642,10 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
       "requires": {
         "clipboard": "^2.0.0"
-      }
+      },
+      "version": "^1.21.0"
     },
     "private": {
       "version": "0.1.8",
@@ -26708,18 +26646,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "^1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "^1.21.0"
         }
       }
     },
@@ -26979,7 +26911,12 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "^1.21.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "^1.21.0"
+        }
       }
     },
     "regenerate": {
@@ -29819,7 +29756,7 @@
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "^1.16.0",
+        "prismjs": "^1.21.0",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"
@@ -29832,13 +29769,7 @@
           "dev": true
         },
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "^1.21.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
   "resolutions": {
-    "dot-prop": "^4.2.1"
+    "dot-prop": "^4.2.1",
+    "prismjs": "^1.21.0"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",


### PR DESCRIPTION
No issue

**Overall change:**

I did not notice we still had a dependency with a fixed dependecy on `prismjs`: https://github.com/bbc/psammead/pull/3753#issuecomment-690307203 

Specifically `refractor`:
![image](https://user-images.githubusercontent.com/9645462/92752049-7905ad00-f380-11ea-9d60-792b6957b4d8.png)

This dependency has been forced again to resolve our security vulnerablity:
![image](https://user-images.githubusercontent.com/9645462/92752168-96d31200-f380-11ea-9786-d60d4eabc959.png)


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
