### PR TITLE
Running npm run install:packages on latest - for dependencies discussion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6742,7 +6742,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.2.0",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -7759,7 +7759,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -7827,7 +7827,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -7942,7 +7942,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8011,7 +8011,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -8136,7 +8136,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8206,7 +8206,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -8507,7 +8507,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8570,7 +8570,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -9199,7 +9199,7 @@
           "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -9541,7 +9541,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -9663,7 +9663,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -13525,9 +13525,26 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^5.1.0"
       },
       "dependencies": {
+        "dot-prop": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
+            }
+          }
+        },
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -13571,7 +13588,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -13637,7 +13654,7 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -13744,17 +13761,23 @@
           "dev": true,
           "requires": {
             "array-ify": "^1.0.0",
-            "dot-prop": "^4.2.1"
+            "dot-prop": "^5.1.0"
           },
           "dependencies": {
             "dot-prop": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-              "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
               "dev": true,
               "requires": {
-                "is-obj": "^2.0.0"
+                "is-obj": "^1.0.0"
               }
+            },
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
             }
           }
         },
@@ -13766,8 +13789,7 @@
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         }
       }
     },
@@ -15130,23 +15152,6 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
-      }
-    },
-    "dot-prop": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-      "dev": true,
-      "requires": {
-        "is-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
-        }
       }
     },
     "dotenv": {
@@ -25630,15 +25635,6 @@
       "integrity": "sha512-VTy6t69sS1FavspBsodoF/x/eduPydUXyZH+++Jkun0VQ4X7lCZVvsfGsYKzkUan2PJNcV2mA4lAFcr7KKXD1g==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -26638,7 +26634,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -26909,13 +26905,13 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "^1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
           "requires": {
             "clipboard": "^2.0.0"
           }
@@ -28145,7 +28141,7 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^4.1.1"
       },
       "dependencies": {
         "dot-prop": {
@@ -29765,7 +29761,7 @@
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.16.0",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"


### PR DESCRIPTION
**Code changes:**

- Pulled down latest
- Ran `npm run install:packages`
- Behold `dot-prop` downgrades (and the occasional `dot-prop` update)
- `prismjs` downgrades https://github.com/bbc/psammead/pull/3766/files#diff-32607347f8126e6534ebc7ebaec4853dL29768

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
