### PR TITLE
Remove semver from resolutions and prevent `npm-force-resolutions` ru…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.1 | [PR#3767](https://github.com/bbc/psammead/pull/3767) Remove semver from resolutions and prevent `npm-force-resolutions` running in `npm ci` |
 | 2.4.0 | [PR#3762](https://github.com/bbc/psammead/pull/3762) Bumping dependencies |
 | 2.3.10 | [PR#3754](https://github.com/bbc/psammead/pull/3754) Force `prismjs` version again |
 | 2.3.9 | [PR#3753](https://github.com/bbc/psammead/pull/3753) Remove `prismjs` and `lodash` from forced resolutions |

--- a/package-lock.json
+++ b/package-lock.json
@@ -6742,7 +6742,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.2.0",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -7759,7 +7759,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -7827,7 +7827,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -7942,7 +7942,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8011,7 +8011,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -8136,7 +8136,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8206,7 +8206,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -8507,7 +8507,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -8570,7 +8570,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -9199,7 +9199,7 @@
           "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -9541,7 +9541,7 @@
                 "@babel/runtime": "^7.3.1",
                 "highlight.js": "~9.13.0",
                 "lowlight": "~1.11.0",
-                "prismjs": "^1.21.0",
+                "prismjs": "^1.8.4",
                 "refractor": "^2.4.1"
               },
               "dependencies": {
@@ -9663,7 +9663,7 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.15.1",
             "lowlight": "1.12.1",
-            "prismjs": "^1.21.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
@@ -13525,9 +13525,26 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^5.1.0"
       },
       "dependencies": {
+        "dot-prop": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
+            }
+          }
+        },
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -13571,7 +13588,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -13637,7 +13654,7 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -13744,17 +13761,23 @@
           "dev": true,
           "requires": {
             "array-ify": "^1.0.0",
-            "dot-prop": "^4.2.1"
+            "dot-prop": "^5.1.0"
           },
           "dependencies": {
             "dot-prop": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-              "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
               "dev": true,
               "requires": {
-                "is-obj": "^2.0.0"
+                "is-obj": "^1.0.0"
               }
+            },
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
             }
           }
         },
@@ -13766,8 +13789,7 @@
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         }
       }
     },
@@ -15130,23 +15152,6 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
-      }
-    },
-    "dot-prop": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-      "dev": true,
-      "requires": {
-        "is-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
-        }
       }
     },
     "dotenv": {
@@ -25630,15 +25635,6 @@
       "integrity": "sha512-VTy6t69sS1FavspBsodoF/x/eduPydUXyZH+++Jkun0VQ4X7lCZVvsfGsYKzkUan2PJNcV2mA4lAFcr7KKXD1g==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -26638,7 +26634,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -26909,13 +26905,13 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "^1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
           "requires": {
             "clipboard": "^2.0.0"
           }
@@ -28145,7 +28141,7 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "^4.2.1"
+        "dot-prop": "^4.1.1"
       },
       "dependencies": {
         "dot-prop": {
@@ -29765,7 +29761,7 @@
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.16.0",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "private": true,
   "resolutions": {
-    "dot-prop": "^4.2.1",
-    "prismjs": "^1.21.0"
+    "dot-prop": "4.2.1",
+    "prismjs": "1.21.0"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
@@ -21,7 +21,7 @@
     "deploy-storybook": "gh-pages -d storybook_dist",
     "install:packages": "npm i && lerna clean --yes && lerna bootstrap --hoist",
     "postshrinkwrap": "if test -z $CI; then \n ./scripts/forcePackageLockHttps.sh \n fi",
-    "preinstall": "sh scripts/enforceVersions.sh && npx npm-force-resolutions",
+    "preinstall": "sh scripts/enforceVersions.sh && [ \"$npm_config_refer\" != \"ci\" ] && npx npm-force-resolutions || exit 0",
     "postinstall": "npm run build",
     "publish": "npm run build && node scripts/publish",
     "regeneratePackageLocks": "node scripts/regeneratePackageLocks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
…nning in `npm ci`

No Issue

**Overall change:** 
- Removed semver as it does not appear to be how `npm-force-resolutions` is meant to be used, semver strings being reset in dependency constaints: https://github.com/bbc/psammead/commit/25b67b0d06b8f9dd4885ad7b62047de846bc420d#diff-32607347f8126e6534ebc7ebaec4853d
- Prevented `npm-force-resolutions` running on `npm ci`
  - Please see https://github.com/bbc/simorgh/pull/7840 for full context of why this change is necessary

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing

I have ran `npm ci` and `npm install` and experienced consistent results.