### PR TITLE
Add Emotion migration notice to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.2 | [PR#3769](https://github.com/bbc/psammead/pull/3769) Add Emotion migration notice to README |
 | 2.4.1 | [PR#3767](https://github.com/bbc/psammead/pull/3767) Remove semver from resolutions and prevent `npm-force-resolutions` running in `npm ci` |
 | 2.4.0 | [PR#3762](https://github.com/bbc/psammead/pull/3762) Bumping dependencies |
 | 2.3.10 | [PR#3754](https://github.com/bbc/psammead/pull/3754) Force `prismjs` version again |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Psammead packages are split into:
 - [Utilities](./packages/utilities) - Commonly shared Psammead dependencies, fundamentals to aid building additional GEL-compliant components, and aditional packages for use in building SPAs.
 
 # 🚨
-**Psammead is moving to Emotion**. Emotion is a performant CSS-in-JS solution that will replace Styled Components in Psammead. This migration follows a thorough investigation into server-side rendering performance by the Simorgh team. For more information, please see the following issue: https://github.com/bbc/simorgh/issues/7772. We expect this work to begin in September and complete in October. During this time, merges to `latest` may be blocked to minimise delays.
+**Psammead is moving to Emotion**. Emotion is a performant CSS-in-JS solution that will replace Styled Components in Psammead. This is a breaking change and follows a thorough investigation into server-side rendering performance by the Simorgh team. For more information, please see the following issue: https://github.com/bbc/simorgh/issues/7772. We expect this work to begin in September and complete in October. During this time, merges to `latest` may be blocked to minimise delays.
 
 ## Documentation index
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Psammead packages are split into:
 - [Containers](./packages/containers) - Functional components for optional use with presentational components of the same name.
 - [Utilities](./packages/utilities) - Commonly shared Psammead dependencies, fundamentals to aid building additional GEL-compliant components, and aditional packages for use in building SPAs.
 
+# 🚨
+**Psammead is moving to Emotion**. Emotion is a performant CSS-in-JS solution that will replace Styled Components in Psammead. This migration follows a thorough investigation into server-side rendering performance by the Simorgh team. For more information, please see the following issue: https://github.com/bbc/simorgh/issues/7772. We expect this work to begin in September and complete in October. During this time, merges to `latest` may be blocked to minimise delays.
+
 ## Documentation index
 
 Please familiarise yourself with our:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 <div align="center">
 
 [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg)](https://snyk.io/test/github/bbc/psammead)
-[![dependencies Status](https://david-dm.org/bbc/psammead/status.svg)](https://david-dm.org/bbc/psammead)
-[![devDependencies Status](https://david-dm.org/bbc/psammead/dev-status.svg)](https://david-dm.org/bbc/psammead?type=dev)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3f7b756f1358f3633362/maintainability)](https://codeclimate.com/github/bbc/psammead/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/3f7b756f1358f3633362/test_coverage)](https://codeclimate.com/github/bbc/psammead/test_coverage)
 [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/3765.

### Overall change:
Add a prominent notice to the readme notifying users of an imminent breaking change following the migration from Styled Components to Emotion.

### Code changes:
- Remove broken badges from https://david-dm.org.
- Add migration notice.

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~~[ ] Automated jest tests added (for new features) or updated (for existing features)~~
- ~~[ ] This PR requires manual testing~~
