### PR TITLE
Dependency bumps 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.4.4 | [PR#3714](https://github.com/bbc/psammead/pull/3714) Talos - Bump Dependencies - lint-staged, browserslist, @loadable/babel-plugin, @loadable/component, @testing-library/react |
+| 2.4.4 | [PR#3780](https://github.com/bbc/psammead/pull/3780) Bump Dependencies - lint-staged, browserslist, @loadable/babel-plugin, @loadable/component, @testing-library/react |
 | 2.4.3 | [PR#3768](https://github.com/bbc/psammead/pull/3768) Update Node version |
 | 2.4.2 | [PR#3769](https://github.com/bbc/psammead/pull/3769) Add Emotion migration notice to README |
 | 2.4.1 | [PR#3767](https://github.com/bbc/psammead/pull/3767) Remove semver from resolutions and prevent `npm-force-resolutions` running in `npm ci` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.4 | [PR#3714](https://github.com/bbc/psammead/pull/3714) Talos - Bump Dependencies - lint-staged, browserslist, @loadable/babel-plugin, @loadable/component, @testing-library/react |
 | 2.4.3 | [PR#3768](https://github.com/bbc/psammead/pull/3768) Update Node version |
 | 2.4.2 | [PR#3769](https://github.com/bbc/psammead/pull/3769) Add Emotion migration notice to README |
 | 2.4.1 | [PR#3767](https://github.com/bbc/psammead/pull/3767) Remove semver from resolutions and prevent `npm-force-resolutions` running in `npm ci` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13528,23 +13528,6 @@
         "dot-prop": "^5.1.0"
       },
       "dependencies": {
-        "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "is-obj": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-              "dev": true
-            }
-          }
-        },
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -13765,19 +13748,13 @@
           },
           "dependencies": {
             "dot-prop": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+              "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
               "dev": true,
               "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "^2.0.0"
               }
-            },
-            "is-obj": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-              "dev": true
             }
           }
         },
@@ -13789,7 +13766,8 @@
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
         }
       }
     },
@@ -15152,6 +15130,23 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        }
       }
     },
     "dotenv": {
@@ -22344,9 +22339,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.3.0.tgz",
-      "integrity": "sha512-an3VgjHqmJk0TORB/sdQl0CTkRg4E5ybYCXTTCSJ5h9jFwZbcgKIx5oVma5e7wp/uKt17s1QYFmYqT9MGVosGw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.4.0.tgz",
+      "integrity": "sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -22538,9 +22533,9 @@
           }
         },
         "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
           "dev": true,
           "requires": {
             "tslib": "^1.9.0"
@@ -25635,6 +25630,14 @@
       "integrity": "sha512-VTy6t69sS1FavspBsodoF/x/eduPydUXyZH+++Jkun0VQ4X7lCZVvsfGsYKzkUan2PJNcV2mA4lAFcr7KKXD1g==",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -26906,16 +26909,6 @@
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
         "prismjs": "~1.17.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        }
       }
     },
     "regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13528,6 +13528,23 @@
         "dot-prop": "^5.1.0"
       },
       "dependencies": {
+        "dot-prop": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
+            }
+          }
+        },
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -13748,13 +13765,19 @@
           },
           "dependencies": {
             "dot-prop": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-              "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
               "dev": true,
               "requires": {
-                "is-obj": "^2.0.0"
+                "is-obj": "^1.0.0"
               }
+            },
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
             }
           }
         },
@@ -13766,8 +13789,7 @@
         "is-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         }
       }
     },
@@ -15130,23 +15152,6 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
-      }
-    },
-    "dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
-      "requires": {
-        "is-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
-        }
       }
     },
     "dotenv": {
@@ -25630,14 +25635,6 @@
       "integrity": "sha512-VTy6t69sS1FavspBsodoF/x/eduPydUXyZH+++Jkun0VQ4X7lCZVvsfGsYKzkUan2PJNcV2mA4lAFcr7KKXD1g==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -26909,6 +26906,16 @@
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
         "prismjs": "~1.17.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        }
       }
     },
     "regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7369,9 +7369,9 @@
       }
     },
     "@loadable/component": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.13.1.tgz",
-      "integrity": "sha512-qTNfTv5bVfb9eTKNUOMzPweRnxzNaxCmLZEsFEMn+kxpd86iXae+IpibXFJlnb052Q4fVkcWM2tvmWLc/+HzLg==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.13.2.tgz",
+      "integrity": "sha512-eCtJhCFfUg7dzEBc5O4ZNfG0wftCLVSzpfOw9qPYJ16T/bmvrGRDdY8q/ARM4o90MOFlJzIRepnuXnqxB5ZUyQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7360,9 +7360,9 @@
       }
     },
     "@loadable/babel-plugin": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@loadable/babel-plugin/-/babel-plugin-5.13.0.tgz",
-      "integrity": "sha512-SlwrjW9xnsQJI96aRKcNJwhwjWB1I/zDdm8Viz4/+MELEdd8TXBIfopa2PgoOMNORaXpTgan6DQ8u4Bf0lWJjQ==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@loadable/babel-plugin/-/babel-plugin-5.13.2.tgz",
+      "integrity": "sha512-vSZUVeTH1S1sDbk8Tzft0plZSkN7W4zmVR5w/Bmy4UmvBiu9lin7ztrDpoUTUzxpoups+OJbTc/OosvN0aMXWg==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-dynamic-import": "^7.7.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9916,9 +9916,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.1.tgz",
-      "integrity": "sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+      "integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -10149,13 +10149,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.2.tgz",
-      "integrity": "sha512-iOuNNHt4ZgMH5trSKC4kaWDcKzUOf7e7KQIcu7xvGCd68/w1EegbW89F9T5sZ4IjS0gAXdvOfZbG9ESZ7YjOug==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.4.tgz",
+      "integrity": "sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.2",
-        "@testing-library/dom": "^7.23.0"
+        "@testing-library/dom": "^7.24.2"
       },
       "dependencies": {
         "@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12588,27 +12588,27 @@
       }
     },
     "browserslist": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
-      "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.3.tgz",
+      "integrity": "sha512-GcZPC5+YqyPO4SFnz48/B0YaCwS47Q9iPChRGi6t7HhflKBcINzFrJvRfC+jp30sRMKxF+d4EHGs27Z0XP1NaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001125",
-        "electron-to-chromium": "^1.3.564",
-        "escalade": "^3.0.2",
+        "caniuse-lite": "^1.0.30001131",
+        "electron-to-chromium": "^1.3.570",
+        "escalade": "^3.1.0",
         "node-releases": "^1.1.61"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001126",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001126.tgz",
-          "integrity": "sha512-l2odlsr1zB8PLR/rMyX+pi6/bWsDyCT1MrKyIgIUtJxkDkNY5bxq+hu1yOA7EwZ2O5PiLsJUopqLP/2d5xqXhA==",
+          "version": "1.0.30001133",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz",
+          "integrity": "sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.567",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.567.tgz",
-          "integrity": "sha512-1aKkw0Hha1Bw9JA5K5PT5eFXC/TXbkJvUfNSNEciPUMgSIsRJZM1hF2GUEAGZpAbgvd8En21EA+Lv820KOhvqA==",
+          "version": "1.3.570",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
+          "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==",
           "dev": true
         },
         "node-releases": {
@@ -15700,9 +15700,9 @@
       }
     },
     "escalade": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
       "dev": true
     },
     "escape-html": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves 
-  Bump @testing-library/react from 11.0.2 to 11.0.4 #3773 
-  Bump @loadable/component from 5.13.1 to 5.13.2 #3774 
-  Bump @loadable/babel-plugin from 5.13.0 to 5.13.2 #3775 
-  Bump lint-staged from 10.3.0 to 10.4.0 #3777 
-  Bump browserslist from 4.14.2 to 4.14.3 #3776 

**Overall change:** _Dependency bumps ._

**Code changes:**

- _Dependency bumps ._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
