### PR TITLE
Fix white circle in psammead bulleted list bullet

### DIFF
--- a/packages/components/psammead-bulleted-list/CHANGELOG.md
+++ b/packages/components/psammead-bulleted-list/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.16 | [PR#3783](https://github.com/bbc/psammead/pull/3783) Fix circle in bullet |
 | 1.0.15 | [PR#3725](https://github.com/bbc/psammead/pull/3725) Create a bullet out of CSS rather than using a background image. |
 | 1.0.14 | [PR#3710](https://github.com/bbc/psammead/pull/3710) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.13 | [PR#3707](https://github.com/bbc/psammead/pull/3707) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-bulleted-list/package-lock.json
+++ b/packages/components/psammead-bulleted-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-bulleted-list/package.json
+++ b/packages/components/psammead-bulleted-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulleted-list/src/__snapshots__/index.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`PsammeadBulletedList should render correctly from ltr 1`] = `
   position: absolute;
   border-width: 1rem;
   border: 0.1875rem solid #3F3F42;
+  background-color: #3F3F42;
   border-radius: 50%;
   left: -1rem;
 }
@@ -90,6 +91,7 @@ exports[`PsammeadBulletedList should render correctly from rtl 1`] = `
   position: absolute;
   border-width: 1rem;
   border: 0.1875rem solid #3F3F42;
+  background-color: #3F3F42;
   border-radius: 50%;
   right: -1rem;
 }

--- a/packages/components/psammead-bulleted-list/src/index.jsx
+++ b/packages/components/psammead-bulleted-list/src/index.jsx
@@ -24,6 +24,7 @@ const BulletedList = styled.ul.attrs(() => ({
     position: absolute;
     border-width: 1rem;
     border: 0.1875rem solid ${C_SHADOW};
+    background-color: ${C_SHADOW};
     border-radius: 50%;
     ${({ dir }) => (dir === 'rtl' ? 'right: -1rem;' : 'left: -1rem;')}
   }


### PR DESCRIPTION
Resolves #3761

**Overall change:** Fix white circle in psammead bulleted list bullet

**Code changes:**

- Add a background color to bullet

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
