### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.4.9 | [PR#3803](https://github.com/bbc/psammead/pull/3803) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 2.4.8 | [PR#3799](https://github.com/bbc/psammead/pull/3799) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 2.4.7 | [PR#3798](https://github.com/bbc/psammead/pull/3798) Talos - Bump Dependencies
 | 2.4.6 | [PR#3785](https://github.com/bbc/psammead/pull/3785) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-consent-banner, @bbc/psammead-locales, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-script-link, @bbc/psammead-story-promo |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4413,9 +4413,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.19",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.19.tgz",
-      "integrity": "sha512-GnqVFm7oOYk7cRx4ig3kakLJOV5kFvAz6MS+14eDEg1tLR5+PRnuFSqTj3Dtl1P39oYWnace75sb4Hp64MJUOQ==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.20.tgz",
+      "integrity": "sha512-BiHmRpXFUvEfm+x513IfpiFteMXQEBxlu81XawyjYAVkmMS9p8O0TfpUjRQn5v8tFHtO59n5qZO6FwktOgLMuQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^4.3.0",
@@ -4423,7 +4423,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.1",
         "@bbc/psammead-styles": "^4.4.3",
-        "@bbc/psammead-timestamp-container": "^4.0.9"
+        "@bbc/psammead-timestamp-container": "^4.0.10"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -82,7 +82,7 @@
     "@bbc/psammead-navigation": "^6.0.19",
     "@bbc/psammead-paragraph": "^2.2.35",
     "@bbc/psammead-play-button": "^1.1.22",
-    "@bbc/psammead-radio-schedule": "3.0.19",
+    "@bbc/psammead-radio-schedule": "3.0.20",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^1.0.21",
     "@bbc/psammead-section-label": "^5.0.13",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  3.0.19  →  3.0.20

| Version | Description |
|---------|-------------|
| 3.0.20 | [PR#3799](https://github.com/bbc/psammead/pull/3799) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

