### PR TITLE
Revert premature release of psammead-styles v5.0.0

### DIFF
--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.2 | [PR#3851](https://github.com/bbc/psammead/pull/3851) Revert to 4.5.1 to fix premature release of 5.0.0. |
 | 5.0.1-alpha.0 | [PR#3839](https://github.com/bbc/psammead/pull/3839) Set package to an alpha version v5.0.1-alpha.0 |
 | 5.0.0 | [PR#3804](https://github.com/bbc/psammead/pull/3804) BBC Reith Qalam v1.100. Removal of BBC Nassim fonts for Arabic, Pashto, Persian and Urdu |
 | 4.5.1 | [PR#3728](https://github.com/bbc/psammead/pull/3728) Tweaks following Storybook v5.3.19 to v6.0.22 update |

--- a/packages/utilities/psammead-styles/README.md
+++ b/packages/utilities/psammead-styles/README.md
@@ -88,7 +88,7 @@ const someGridUsingComponent = css`
 
 ### global-styles
 
-We export a global styles component which uses `styled-normalize` and defines css rules for `box-sizing`. 
+We export a global styles component which uses `styled-normalize` and defines css rules for `box-sizing`.
 This component accepts an optional `fonts` prop which is an array of font styles to be applied in the global styles.
 
 ```js
@@ -107,9 +107,7 @@ import {
 
 ## Contributing
 
-When **adding** a new export to this utility package the [export tests](https://github.com/bbc/psammead/blob/latest/packages/utilities/psammead-styles/index.test.jsx#L3-L45) also need to be updated.
-
-When **removing** an existing export from this utility package the [export tests](https://github.com/bbc/psammead/blob/latest/packages/utilities/psammead-styles/index.test.jsx#L3-L45) need to be updated and the package version requires a major change (e.g. 1.2.1 -> 2.0.0) as this would be considered a breaking change due to functionality being removed.
+When **adding** a new export to this utility package the [export tests](https://github.com/bbc/psammead/blob/5d7395fd60bd8d73796d5a23775b4b5b36db1445/packages/utilities/psammead-styles/index.test.jsx#L11-L35) also need to be updated. When **removing** an exisiting export from this utility package the [export tests](https://github.com/bbc/psammead/blob/5d7395fd60bd8d73796d5a23775b4b5b36db1445/packages/utilities/psammead-styles/index.test.jsx#L11-L35) need to be updated and the package version requires a major change (EG: 1.2.1 -> 2.0.0) as this would be considered a breaking change due to functionality being removed.
 
 Psammead is completely open source. We are grateful for any contributions, whether they be new components, bug fixes or general improvements. Please see our primary contributing guide which can be found at [the root of the Psammead respository](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md).
 

--- a/packages/utilities/psammead-styles/index.test.jsx
+++ b/packages/utilities/psammead-styles/index.test.jsx
@@ -1,8 +1,6 @@
 import { testUtilityPackages } from '@bbc/psammead-test-helpers';
 
 const fontsExpectedExports = {
-  F_REITH_QALAM_REGULAR: 'function',
-  F_REITH_QALAM_BOLD: 'function',
   F_REITH_SERIF_REGULAR: 'function',
   F_REITH_SERIF_ITALIC: 'function',
   F_REITH_SERIF_BOLD: 'function',
@@ -25,6 +23,14 @@ const fontsExpectedExports = {
   F_REITH_SANS_EXTRA_BOLD_ITALIC: 'function',
   F_REITH_SANS_CONDENSED_REGULAR: 'function',
   F_REITH_SANS_CONDENSED_BOLD: 'function',
+  F_NASSIM_ARABIC_REGULAR: 'function',
+  F_NASSIM_ARABIC_BOLD: 'function',
+  F_NASSIM_PASHTO_REGULAR: 'function',
+  F_NASSIM_PASHTO_BOLD: 'function',
+  F_NASSIM_PERSIAN_REGULAR: 'function',
+  F_NASSIM_PERSIAN_BOLD: 'function',
+  F_NASSIM_URDU_REGULAR: 'function',
+  F_NASSIM_URDU_BOLD: 'function',
   F_ISKOOLA_POTA_BBC_REGULAR: 'function',
   F_ISKOOLA_POTA_BBC_BOLD: 'function',
   F_LATHA_REGULAR: 'function',

--- a/packages/utilities/psammead-styles/package-lock.json
+++ b/packages/utilities/psammead-styles/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "5.0.1-alpha.0",
+  "version": "5.0.2",
   "lockfileVersion": 1
 }

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "5.0.1-alpha.0",
+  "version": "5.0.2",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/__snapshots__/font-families.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/font-families.test.js.snap
@@ -68,12 +68,12 @@ Object {
 exports[`Psammead Styles - Font Families should match arabic 1`] = `
 Object {
   "sansBold": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   ",
   "sansRegular": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   ",
@@ -713,12 +713,12 @@ Object {
 exports[`Psammead Styles - Font Families should match pashto 1`] = `
 Object {
   "sansBold": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   ",
   "sansRegular": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   ",
@@ -728,12 +728,12 @@ Object {
 exports[`Psammead Styles - Font Families should match persian 1`] = `
 Object {
   "sansBold": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   ",
   "sansRegular": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   ",
@@ -1193,12 +1193,12 @@ Object {
 exports[`Psammead Styles - Font Families should match urdu 1`] = `
 Object {
   "sansBold": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   ",
   "sansRegular": "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   ",

--- a/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/font-styles.test.js.snap
@@ -26,7 +26,7 @@ exports[`should render SansBold correctly for amharic 1`] = `
 
 exports[`should render SansBold correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -202,7 +202,7 @@ exports[`should render SansBold correctly for optimobase 1`] = `
 
 exports[`should render SansBold correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -210,7 +210,7 @@ exports[`should render SansBold correctly for pashto 1`] = `
 
 exports[`should render SansBold correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -346,7 +346,7 @@ exports[`should render SansBold correctly for ukrainian 1`] = `
 
 exports[`should render SansBold correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -418,7 +418,7 @@ exports[`should render SansBoldItalic correctly for amharic 1`] = `
 
 exports[`should render SansBoldItalic correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -594,7 +594,7 @@ exports[`should render SansBoldItalic correctly for optimobase 1`] = `
 
 exports[`should render SansBoldItalic correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -602,7 +602,7 @@ exports[`should render SansBoldItalic correctly for pashto 1`] = `
 
 exports[`should render SansBoldItalic correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -738,7 +738,7 @@ exports[`should render SansBoldItalic correctly for ukrainian 1`] = `
 
 exports[`should render SansBoldItalic correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -810,7 +810,7 @@ exports[`should render SansLight correctly for amharic 1`] = `
 
 exports[`should render SansLight correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -986,7 +986,7 @@ exports[`should render SansLight correctly for optimobase 1`] = `
 
 exports[`should render SansLight correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -994,7 +994,7 @@ exports[`should render SansLight correctly for pashto 1`] = `
 
 exports[`should render SansLight correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1130,7 +1130,7 @@ exports[`should render SansLight correctly for ukrainian 1`] = `
 
 exports[`should render SansLight correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1202,7 +1202,7 @@ exports[`should render SansRegular correctly for amharic 1`] = `
 
 exports[`should render SansRegular correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1378,7 +1378,7 @@ exports[`should render SansRegular correctly for optimobase 1`] = `
 
 exports[`should render SansRegular correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1386,7 +1386,7 @@ exports[`should render SansRegular correctly for pashto 1`] = `
 
 exports[`should render SansRegular correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1522,7 +1522,7 @@ exports[`should render SansRegular correctly for ukrainian 1`] = `
 
 exports[`should render SansRegular correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1594,7 +1594,7 @@ exports[`should render SansRegularItalic correctly for amharic 1`] = `
 
 exports[`should render SansRegularItalic correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1770,7 +1770,7 @@ exports[`should render SansRegularItalic correctly for optimobase 1`] = `
 
 exports[`should render SansRegularItalic correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1778,7 +1778,7 @@ exports[`should render SansRegularItalic correctly for pashto 1`] = `
 
 exports[`should render SansRegularItalic correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1914,7 +1914,7 @@ exports[`should render SansRegularItalic correctly for ukrainian 1`] = `
 
 exports[`should render SansRegularItalic correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -1986,7 +1986,7 @@ exports[`should render SerifBold correctly for amharic 1`] = `
 
 exports[`should render SerifBold correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2162,7 +2162,7 @@ exports[`should render SerifBold correctly for optimobase 1`] = `
 
 exports[`should render SerifBold correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2170,7 +2170,7 @@ exports[`should render SerifBold correctly for pashto 1`] = `
 
 exports[`should render SerifBold correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2306,7 +2306,7 @@ exports[`should render SerifBold correctly for ukrainian 1`] = `
 
 exports[`should render SerifBold correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2378,7 +2378,7 @@ exports[`should render SerifLight correctly for amharic 1`] = `
 
 exports[`should render SerifLight correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -2554,7 +2554,7 @@ exports[`should render SerifLight correctly for optimobase 1`] = `
 
 exports[`should render SerifLight correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -2562,7 +2562,7 @@ exports[`should render SerifLight correctly for pashto 1`] = `
 
 exports[`should render SerifLight correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -2698,7 +2698,7 @@ exports[`should render SerifLight correctly for ukrainian 1`] = `
 
 exports[`should render SerifLight correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -2770,7 +2770,7 @@ exports[`should render SerifMedium correctly for amharic 1`] = `
 
 exports[`should render SerifMedium correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2946,7 +2946,7 @@ exports[`should render SerifMedium correctly for optimobase 1`] = `
 
 exports[`should render SerifMedium correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -2954,7 +2954,7 @@ exports[`should render SerifMedium correctly for pashto 1`] = `
 
 exports[`should render SerifMedium correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3090,7 +3090,7 @@ exports[`should render SerifMedium correctly for ukrainian 1`] = `
 
 exports[`should render SerifMedium correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3162,7 +3162,7 @@ exports[`should render SerifMediumItalic correctly for amharic 1`] = `
 
 exports[`should render SerifMediumItalic correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3338,7 +3338,7 @@ exports[`should render SerifMediumItalic correctly for optimobase 1`] = `
 
 exports[`should render SerifMediumItalic correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3346,7 +3346,7 @@ exports[`should render SerifMediumItalic correctly for pashto 1`] = `
 
 exports[`should render SerifMediumItalic correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3482,7 +3482,7 @@ exports[`should render SerifMediumItalic correctly for ukrainian 1`] = `
 
 exports[`should render SerifMediumItalic correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 700;
    font-style: normal;
   "
@@ -3554,7 +3554,7 @@ exports[`should render SerifRegular correctly for amharic 1`] = `
 
 exports[`should render SerifRegular correctly for arabic 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Arabic\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -3730,7 +3730,7 @@ exports[`should render SerifRegular correctly for optimobase 1`] = `
 
 exports[`should render SerifRegular correctly for pashto 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Pashto\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -3738,7 +3738,7 @@ exports[`should render SerifRegular correctly for pashto 1`] = `
 
 exports[`should render SerifRegular correctly for persian 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Persian\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "
@@ -3874,7 +3874,7 @@ exports[`should render SerifRegular correctly for ukrainian 1`] = `
 
 exports[`should render SerifRegular correctly for urdu 1`] = `
 "
-    font-family: \\"BBC Reith Qalam\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
+    font-family: \\"BBC Nassim Urdu\\", Arial, Verdana, Geneva, Helvetica, sans-serif;
     font-weight: 400;
    font-style: normal;
   "

--- a/packages/utilities/psammead-styles/src/__snapshots__/fonts.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/fonts.test.js.snap
@@ -116,6 +116,198 @@ exports[`Psammead Styles - Fonts should match MALLANNA REGULAR with overridden u
 "
 `;
 
+exports[`Psammead Styles - Fonts should match NASSIM ARABIC BOLD base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Arabic\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/bold.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/bold.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM ARABIC BOLD with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Arabic\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://example.com/bold.woff') format('woff'), url('https://example.com/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM ARABIC REGULAR base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Arabic\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/normal.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM ARABIC REGULAR with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Arabic\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://example.com/normal.woff') format('woff'), url('https://example.com/normal.eot') format('eot'), url('https://example.com/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PASHTO BOLD base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Pashto\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/bold.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/bold.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PASHTO BOLD with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Pashto\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://example.com/bold.woff') format('woff'), url('https://example.com/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PASHTO REGULAR base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Pashto\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/normal.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PASHTO REGULAR with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Pashto\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://example.com/normal.woff') format('woff'), url('https://example.com/normal.eot') format('eot'), url('https://example.com/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PERSIAN BOLD base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Persian\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/bold.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/bold.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PERSIAN BOLD with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Persian\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://example.com/bold.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PERSIAN REGULAR base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Persian\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/normal.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM PERSIAN REGULAR with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Persian\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://example.com/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/normal.eot') format('eot'), url('https://example.com/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM URDU BOLD base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Urdu\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/bold.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/bold.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM URDU BOLD with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Urdu\\";
+    font-weight: 700;
+    font-style: normal;
+    src: url('https://example.com/bold.woff') format('woff'), url('https://example.com/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM URDU REGULAR base font url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Urdu\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/normal.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
+exports[`Psammead Styles - Fonts should match NASSIM URDU REGULAR with overridden url 1`] = `
+"
+  @font-face {
+    font-family: \\"BBC Nassim Urdu\\";
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://example.com/normal.woff') format('woff'), url('https://example.com/normal.eot') format('eot'), url('https://example.com/normal.ttf') format('ttf');
+    font-display: optional;
+  }
+"
+`;
+
 exports[`Psammead Styles - Fonts should match NOTO SANS ETHIOPIC BOLD base font url 1`] = `
 "
   @font-face {
@@ -195,7 +387,7 @@ exports[`Psammead Styles - Fonts should match PADAUK REGULAR base font url 1`] =
     font-weight: 400;
     font-style: normal;
     src: url('https://ws-downloads.files.bbci.co.uk/fonts/Padauk/v2.8/normal.woff') format('woff'), url('https://ws-downloads.files.bbci.co.uk/fonts/Padauk/v2.8/normal.eot') format('eot'), url('https://ws-downloads.files.bbci.co.uk/fonts/Padauk/v2.8/normal.ttf') format('ttf');
-    font-display: swap; 
+    font-display: swap;
   }"
 `;
 
@@ -206,56 +398,8 @@ exports[`Psammead Styles - Fonts should match PADAUK REGULAR with overridden url
     font-weight: 400;
     font-style: normal;
     src: url('https://example.com/normal.woff') format('woff'), url('https://example.com/normal.eot') format('eot'), url('https://example.com/normal.ttf') format('ttf');
-    font-display: swap; 
+    font-display: swap;
   }"
-`;
-
-exports[`Psammead Styles - Fonts should match REITH QALAM BOLD base font url 1`] = `
-"
-  @font-face {
-    font-family: \\"BBC Reith Qalam\\";
-    font-weight: 700;
-    font-style: normal;
-    src: url('https://ws-downloads.test.files.bbci.co.uk/fonts/ReithQalam/v1.100/bold.woff2') format('woff2'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/ReithQalam/v1.100/bold.woff') format('woff');
-    font-display: optional;
-  }
-"
-`;
-
-exports[`Psammead Styles - Fonts should match REITH QALAM BOLD with overridden url 1`] = `
-"
-  @font-face {
-    font-family: \\"BBC Reith Qalam\\";
-    font-weight: 700;
-    font-style: normal;
-    src: url('https://example.com/bold.woff2') format('woff2'), url('https://example.com/bold.woff') format('woff');
-    font-display: optional;
-  }
-"
-`;
-
-exports[`Psammead Styles - Fonts should match REITH QALAM REGULAR base font url 1`] = `
-"
-  @font-face {
-    font-family: \\"BBC Reith Qalam\\";
-    font-weight: 400;
-    font-style: normal;
-    src: url('https://ws-downloads.test.files.bbci.co.uk/fonts/ReithQalam/v1.100/normal.woff2') format('woff2'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/ReithQalam/v1.100/normal.woff') format('woff');
-    font-display: optional;
-  }
-"
-`;
-
-exports[`Psammead Styles - Fonts should match REITH QALAM REGULAR with overridden url 1`] = `
-"
-  @font-face {
-    font-family: \\"BBC Reith Qalam\\";
-    font-weight: 400;
-    font-style: normal;
-    src: url('https://example.com/normal.woff2') format('woff2'), url('https://example.com/normal.woff') format('woff');
-    font-display: optional;
-  }
-"
 `;
 
 exports[`Psammead Styles - Fonts should match REITH SANS BOLD ITALIC base font url 1`] = `

--- a/packages/utilities/psammead-styles/src/font-families.js
+++ b/packages/utilities/psammead-styles/src/font-families.js
@@ -79,6 +79,26 @@ const helmetFontStyles = {
 };
 
 /*
+ *  BBC NASSIM
+ */
+
+const nassimArabicFontFamily = `font-family: "BBC Nassim Arabic", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
+const nassimPashtoFontFamily = `font-family: "BBC Nassim Pashto", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
+const nassimPersianFontFamily = `font-family: "BBC Nassim Persian", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
+const nassimUrduFontFamily = `font-family: "BBC Nassim Urdu", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
+
+const nassimFontStyles = fontFamily => ({
+  sansRegular: `
+    ${fontFamily}
+    ${getFontStyleAndWeight('normal', 400)}
+  `,
+  sansBold: `
+    ${fontFamily}
+    ${getFontStyleAndWeight('normal', 700)}
+  `,
+});
+
+/*
  *  AMHARIC
  */
 const amharicFontFamily = `font-family: "Noto Sans Ethiopic", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
@@ -256,23 +276,6 @@ const punjabiStyles = {
 };
 
 /*
- *  QALAM
- */
-const qalamFallback = 'Arial, Verdana, Geneva, Helvetica, sans-serif;';
-const qalamFontFamily = `font-family: "BBC Reith Qalam", ${qalamFallback}`;
-
-const qalamStyles = {
-  sansRegular: `
-    ${qalamFontFamily}
-    ${getFontStyleAndWeight('normal', 400)}
-  `,
-  sansBold: `
-    ${qalamFontFamily}
-    ${getFontStyleAndWeight('normal', 700)}
-  `,
-};
-
-/*
  *  SINHALA
  */
 const sinhalaFontFamily = `font-family: "Iskoola Pota BBC", Arial, Verdana, Geneva, Helvetica, sans-serif;`;
@@ -366,7 +369,7 @@ const optimoBaseFontStyles = {
 export const afaanoromoo = helmetFontStyles;
 export const afrique = helmetFontStyles;
 export const amharic = amharicStyles;
-export const arabic = qalamStyles;
+export const arabic = nassimFontStyles(nassimArabicFontFamily);
 export const archive = latinReithFontStyles;
 export const azeri = helmetFontStyles;
 export const bengali = bengaliStyles;
@@ -388,8 +391,8 @@ export const naidheachdan = latinReithFontStyles;
 export const nepali = nepaliStyles;
 export const news = latinReithFontStyles;
 export const optimobase = optimoBaseFontStyles;
-export const pashto = qalamStyles;
-export const persian = qalamStyles;
+export const pashto = nassimFontStyles(nassimPashtoFontFamily);
+export const persian = nassimFontStyles(nassimPersianFontFamily);
 export const pidgin = helmetFontStyles;
 export const portuguese = latinReithFontStyles;
 export const punjabi = punjabiStyles;
@@ -406,7 +409,7 @@ export const tigrinya = tigrinyaStyles;
 export const turkce = latinReithFontStyles;
 export const ukchina = chineseFontStyles;
 export const ukrainian = helmetFontStyles;
-export const urdu = qalamStyles;
+export const urdu = nassimFontStyles(nassimUrduFontFamily);
 export const uzbek = helmetFontStyles;
 export const vietnamese = helmetFontStyles;
 export const weather = latinReithFontStyles;

--- a/packages/utilities/psammead-styles/src/fonts.js
+++ b/packages/utilities/psammead-styles/src/fonts.js
@@ -1,5 +1,17 @@
 const baseFontUrl = 'https://gel.files.bbci.co.uk/r2.511/';
 
+const baseUrlBBCNassimArabic =
+  'https://ws-downloads.files.bbci.co.uk/fonts/NassimArabic/v1.441/';
+
+const baseUrlBBCNassimPashto =
+  'https://ws-downloads.files.bbci.co.uk/fonts/NassimPashto/v1.57/';
+
+const baseUrlBBCNassimPersian =
+  'https://ws-downloads.files.bbci.co.uk/fonts/NassimPersian/v1.511/';
+
+const baseUrlBBCNassimUrdu =
+  'https://ws-downloads.files.bbci.co.uk/fonts/NassimUrdu/v1.60/';
+
 const baseUrlIskoolaPotaBBC =
   'https://ws-downloads.files.bbci.co.uk/fonts/IskoolaPota/v5.91/';
 
@@ -16,9 +28,6 @@ const baseUrlPadauk =
 
 const baseUrlShonarBangla =
   'https://ws-downloads.files.bbci.co.uk/fonts/ShonarBangla/v5.91/';
-
-const baseUrlBBCReithQalam =
-  'https://ws-downloads.test.files.bbci.co.uk/fonts/ReithQalam/v1.100/';
 
 // Reith Serif
 export const F_REITH_SERIF_REGULAR = baseUrlOverride => `
@@ -293,6 +302,142 @@ export const F_REITH_SANS_CONDENSED_BOLD = baseUrlOverride => `
       font-display: optional;
   }`;
 
+// BBC Nassim Arabic
+
+export const F_NASSIM_ARABIC_REGULAR = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Arabic";
+    font-weight: 400;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimArabic
+    }normal.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimArabic
+}normal.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimArabic
+}normal.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+export const F_NASSIM_ARABIC_BOLD = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Arabic";
+    font-weight: 700;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimArabic
+    }bold.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimArabic
+}bold.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimArabic
+}bold.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+// BBC Nassim Pashto
+
+export const F_NASSIM_PASHTO_REGULAR = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Pashto";
+    font-weight: 400;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimPashto
+    }normal.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimPashto
+}normal.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimPashto
+}normal.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+export const F_NASSIM_PASHTO_BOLD = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Pashto";
+    font-weight: 700;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimPashto
+    }bold.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimPashto
+}bold.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimPashto
+}bold.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+// BBC Nassim Persian
+
+export const F_NASSIM_PERSIAN_REGULAR = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Persian";
+    font-weight: 400;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimPersian
+    }normal.woff') format('woff'), url('${
+  baseUrlBBCNassimPersian || baseUrlOverride
+}normal.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimPersian
+}normal.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+export const F_NASSIM_PERSIAN_BOLD = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Persian";
+    font-weight: 700;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimPersian
+    }bold.woff') format('woff'), url('${
+  baseUrlBBCNassimPersian || baseUrlOverride
+}bold.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimPersian
+}bold.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+// BBC Nassim Urdu
+
+export const F_NASSIM_URDU_REGULAR = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Urdu";
+    font-weight: 400;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimUrdu
+    }normal.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimUrdu
+}normal.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimUrdu
+}normal.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
+export const F_NASSIM_URDU_BOLD = baseUrlOverride => `
+  @font-face {
+    font-family: "BBC Nassim Urdu";
+    font-weight: 700;
+    font-style: normal;
+    src: url('${
+      baseUrlOverride || baseUrlBBCNassimUrdu
+    }bold.woff') format('woff'), url('${
+  baseUrlOverride || baseUrlBBCNassimUrdu
+}bold.eot') format('eot'), url('${
+  baseUrlOverride || baseUrlBBCNassimUrdu
+}bold.ttf') format('ttf');
+    font-display: optional;
+  }
+`;
+
 // Iskoola Pota BBC
 
 export const F_ISKOOLA_POTA_BBC_REGULAR = baseUrlOverride => `
@@ -425,7 +570,7 @@ export const F_PADAUK_REGULAR = baseUrlOverride => `
 }normal.eot') format('eot'), url('${
   baseUrlOverride || baseUrlPadauk
 }normal.ttf') format('ttf');
-    font-display: swap; 
+    font-display: swap;
   }`;
 
 export const F_PADAUK_BOLD = baseUrlOverride => `
@@ -473,35 +618,6 @@ export const F_SHONAR_BANGLA_BOLD = baseUrlOverride => `
 }bold.eot') format('eot'), url('${
   baseUrlOverride || baseUrlShonarBangla
 }bold.ttf') format('ttf');
-    font-display: optional;
-  }
-`;
-
-// BBC Reith Qalam
-export const F_REITH_QALAM_REGULAR = baseUrlOverride => `
-  @font-face {
-    font-family: "BBC Reith Qalam";
-    font-weight: 400;
-    font-style: normal;
-    src: url('${
-      baseUrlOverride || baseUrlBBCReithQalam
-    }normal.woff2') format('woff2'), url('${
-  baseUrlOverride || baseUrlBBCReithQalam
-}normal.woff') format('woff');
-    font-display: optional;
-  }
-`;
-
-export const F_REITH_QALAM_BOLD = baseUrlOverride => `
-  @font-face {
-    font-family: "BBC Reith Qalam";
-    font-weight: 700;
-    font-style: normal;
-    src: url('${
-      baseUrlOverride || baseUrlBBCReithQalam
-    }bold.woff2') format('woff2'), url('${
-  baseUrlOverride || baseUrlBBCReithQalam
-}bold.woff') format('woff');
     font-display: optional;
   }
 `;


### PR DESCRIPTION
No issue.

**Overall change:** 
Revert the premature release of psammead-styles - this is a breaking change that will not be complete before the Emotion migration, which is beginning tomorrow 13th October.

**Revert the following PRs:**
- Support for BBC Reith Qalam - font & font family #3804
- set psammead-styles to alpha #3839

**Code changes:**


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] ~This PR requires manual testing~
