### PR TITLE
Put Talos to sleep prior to the Emotion migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.8 | [PR#3856](https://github.com/bbc/psammead/pull/3856) Put Talos to sleep prior to the Emotion migration. |
 | 3.0.7 | [PR#3770](https://github.com/bbc/psammead/pull/3770) Update code of conduct |
 | 3.0.6 | [PR#3842](https://github.com/bbc/psammead/pull/3842) Modifying Jenkins pipeline to improve running time |
 | 3.0.5 | [PR#3843](https://github.com/bbc/psammead/pull/3843) Bump Dependencies - @bbc/psammead-styles alpha version |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,12 +87,16 @@ node {
             }
           }
 
-          if (env.BRANCH_NAME == 'latest') {
-            stage ('Talos') {
-              sh 'git fetch --all'
-              sh "make talos ARGS='${params.TALOS_PACKAGES.replaceAll("[^a-zA-Z0-9._/@,-]+","")}'"
-            }
-          }
+          // 13/10/20.
+          // Talos is being temporarily disabled to prevent running during
+          // the migration of packages from Styled Components to Emotion.
+          // ---------------------------------------------------------------
+          // if (env.BRANCH_NAME == 'latest') {
+          //   stage ('Talos') {
+          //     sh 'git fetch --all'
+          //     sh "make talos ARGS='${params.TALOS_PACKAGES.replaceAll("[^a-zA-Z0-9._/@,-]+","")}'"
+          //   }
+          // }
         } catch (Throwable e) {
           echo "Pipeline Failed: ${e}"
           currentBuild.result = 'FAILURE'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
No issue.

**Overall change:**

Put Talos to sleep to prevent running during the migration of packages from Styled Components to Emotion. We will wake him up again when that is over.

**Code changes:**

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] ~This PR requires manual testing~
