### PR TITLE
Simplify shouldMatchSnapshot

### DIFF
--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.0 | [PR#?](https://github.com/bbc/psammead/pull/?) shouldMatchSnapshot simplified to work with Emotion |
 | 4.0.0 | [PR#3636](https://github.com/bbc/psammead/pull/3636) Decouple from jest-styled-components |
 | 3.1.5 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |
 | 3.1.4 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.0 | [PR#?](https://github.com/bbc/psammead/pull/?) shouldMatchSnapshot simplified to work with Emotion |
+| 5.0.0 | [PR#3869](https://github.com/bbc/psammead/pull/3869) shouldMatchSnapshot simplified to work with Emotion |
 | 4.0.0 | [PR#3636](https://github.com/bbc/psammead/pull/3636) Decouple from jest-styled-components |
 | 3.1.5 | [PR#3388](https://github.com/bbc/psammead/pull/3388) Update react-helmet to 6.0.0 |
 | 3.1.4 | [PR#3270](https://github.com/bbc/psammead/pull/3270) Security fixes |

--- a/packages/utilities/psammead-test-helpers/README.md
+++ b/packages/utilities/psammead-test-helpers/README.md
@@ -1,6 +1,6 @@
 # psammead-test-helpers - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Futilities%2Fpsammead-test-helpers%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Futilities%2Fpsammead-test-helpers%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/utilities/psammead-test-helpers)](https://david-dm.org/bbc/psammead?path=packages/utilities/psammead-test-helpers) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/utilities/psammead-test-helpers)](https://david-dm.org/bbc/psammead?path=packages/utilities/psammead-test-helpers&type=peer) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-test-helpers.svg)](https://www.npmjs.com/package/@bbc/psammead-test-helpers) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
-This package provides a collection of helper methods for implementing Jest snapshot tests for styled-components, required by many Psammead components.
+This package provides a collection of helper methods for implementing Jest snapshot tests, required by many Psammead components.
 
 ## Exported Functions
 

--- a/packages/utilities/psammead-test-helpers/__snapshots__/index.test.jsx.snap
+++ b/packages/utilities/psammead-test-helpers/__snapshots__/index.test.jsx.snap
@@ -9,11 +9,13 @@ exports[`Psammead test helpers should create a snapshot from an async it() block
 `;
 
 exports[`Psammead test helpers should match the snapshot for the test component 1`] = `
-<main>
-  <h1>
-    Hello I am a test component
-  </h1>
-</main>
+<div>
+  <main>
+    <h1>
+      Hello I am a test component
+    </h1>
+  </main>
+</div>
 `;
 
 exports[`Psammead test helpers should match the snapshot for the test component 2`] = `
@@ -25,56 +27,4 @@ exports[`Psammead test helpers should match the snapshot for the test component 
     I am some test text.
   </p>
 </div>
-`;
-
-exports[`Psammead test helpers should match the snapshot for the test component with helmet and other content 1`] = `
-<html
-  dir="rtl"
-  lang="fa"
->
-  <head>
-    <title>
-      Snapshot with helmet and and other content
-    </title>
-    <meta
-      content="test content"
-      name="test name"
-    />
-    <script
-      src="test.js"
-    />
-  </head>
-  <body>
-    <div>
-      <main>
-        <h1>
-          Hello I am a test component with React Helmet
-        </h1>
-      </main>
-    </div>
-  </body>
-</html>
-`;
-
-exports[`Psammead test helpers should match the snapshot for the test component with helmet only 1`] = `
-<html
-  dir="rtl"
-  lang="fa"
->
-  <head>
-    <title>
-      Snapshot with helmet only
-    </title>
-    <meta
-      content="test content"
-      name="test name"
-    />
-    <script
-      src="test.js"
-    />
-  </head>
-  <body>
-    <div />
-  </body>
-</html>
 `;

--- a/packages/utilities/psammead-test-helpers/index.test.jsx
+++ b/packages/utilities/psammead-test-helpers/index.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import * as testHelpers from '.';
 import * as testHelpersFromSrc from './src/index';
 import renderWithHelmet from './src/renderWithHelmet';
@@ -162,76 +161,6 @@ describe('Psammead test helpers', () => {
   testHelpers.shouldMatchSnapshot(
     'should match the snapshot for the test component',
     <NoHelmetWithFragment />,
-  );
-
-  const HelmetOnly = () => (
-    <Helmet htmlAttributes={{ dir: 'rtl', lang: 'fa' }}>
-      <title>Snapshot with helmet only</title>
-      <meta name="test name" content="test content" />
-      <script src="test.js" />
-    </Helmet>
-  );
-
-  it('should return correct HTML for components using helmet only', async () => {
-    const actual = await renderWithHelmet(<HelmetOnly />);
-    const expected = serializeDomString(`
-    <html dir="rtl" lang="fa">
-      <head>
-        <title>Snapshot with helmet only</title>
-        <meta name="test name" content="test content"><script src="test.js"></script>
-      </head>
-      <body>
-        <div></div>
-      </body>
-    </html>
-    `);
-
-    expect(actual.container.outerHTML).toEqual(expected);
-  });
-
-  testHelpers.shouldMatchSnapshot(
-    'should match the snapshot for the test component with helmet only',
-    <HelmetOnly />,
-  );
-
-  const HelmetWithContent = () => (
-    <>
-      <Helmet htmlAttributes={{ dir: 'rtl', lang: 'fa' }}>
-        <title>Snapshot with helmet and and other content</title>
-        <meta name="test name" content="test content" />
-        <script src="test.js" />
-      </Helmet>
-      <main>
-        <h1>Hello I am a test component with React Helmet</h1>
-      </main>
-    </>
-  );
-
-  it('should return correct HTML for components using helmet only with other content', async () => {
-    const actual = await renderWithHelmet(<HelmetWithContent />);
-    const expected = serializeDomString(`
-    <html dir="rtl" lang="fa">
-      <head>
-        <title>Snapshot with helmet and and other content</title>
-        <meta name="test name" content="test content">
-        <script src="test.js"></script>
-      </head>
-      <body>
-        <div>
-          <main>
-            <h1>Hello I am a test component with React Helmet</h1>
-          </main>
-        </div>
-      </body>
-    </html>
-    `);
-
-    expect(actual.container.outerHTML).toEqual(expected);
-  });
-
-  testHelpers.shouldMatchSnapshot(
-    'should match the snapshot for the test component with helmet and other content',
-    <HelmetWithContent />,
   );
 
   it('should create a snapshot from an async it() block', async () => {

--- a/packages/utilities/psammead-test-helpers/index.test.jsx
+++ b/packages/utilities/psammead-test-helpers/index.test.jsx
@@ -115,14 +115,14 @@ describe('Psammead test helpers', () => {
     );
   });
 
-  const NoHelmet = () => (
+  const ExampleComponent = () => (
     <main>
       <h1>Hello I am a test component</h1>
     </main>
   );
 
-  it('should return correct HTML for components not using helmet', async () => {
-    const actual = await renderWithHelmet(<NoHelmet />);
+  it('should return correct HTML for components', async () => {
+    const actual = await renderWithHelmet(<ExampleComponent />);
     const expected = serializeDomString(`
     <div>
       <main>
@@ -136,18 +136,18 @@ describe('Psammead test helpers', () => {
 
   testHelpers.shouldMatchSnapshot(
     'should match the snapshot for the test component',
-    <NoHelmet />,
+    <ExampleComponent />,
   );
 
-  const NoHelmetWithFragment = () => (
+  const ExampleFragment = () => (
     <>
       <h1>Hello I am a test component</h1>
       <p>I am some test text.</p>
     </>
   );
 
-  it('should return correct HTML for components not using helmet and wrapped with fragment', async () => {
-    const actual = await renderWithHelmet(<NoHelmetWithFragment />);
+  it('should return correct HTML for components wrapped with fragment', async () => {
+    const actual = await renderWithHelmet(<ExampleFragment />);
     const expected = serializeDomString(`
     <div>
       <h1>Hello I am a test component</h1>
@@ -160,7 +160,7 @@ describe('Psammead test helpers', () => {
 
   testHelpers.shouldMatchSnapshot(
     'should match the snapshot for the test component',
-    <NoHelmetWithFragment />,
+    <ExampleFragment />,
   );
 
   it('should create a snapshot from an async it() block', async () => {

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/index.js
+++ b/packages/utilities/psammead-test-helpers/src/index.js
@@ -18,11 +18,9 @@ const createSnapshot = container => {
 };
 
 export const shouldMatchSnapshot = (title, component) => {
-  it(title, done => {
-    renderWithHelmet(component).then(({ container }) => {
-      createSnapshot(container);
-      done();
-    });
+  it(title, () => {
+    const { container } = render(component);
+    expect(container).toMatchSnapshot();
   });
 };
 


### PR DESCRIPTION
**Resolves** [No Ticket]

Simplify `shouldMatchSnapshot` in `psammead-test-helpers` to allow the Emotion migration to continue

### Context
- After implementing the `jest-emotion` snapshot serialiser - when using the `shouldMatchSnapshot` test-helper, no styles were being captured in the snapshots, and the className was making use of the styled component class - incl. the hash that regularly changes.  
- We identified that it was the existing `renderWithHelmet` causing a problem when rendering snapshots in emotion. 
- This was fixed by making `shouldMatchSnapshot` use the vanilla `react-testing-library`   `render(component)` method with .`toMatchSnapshot` assertion, and no longer use `renderWithHelmet`.
- v5.0.0 will no longer have snapshot testing for elements within the helmet
- This package is widely used within Simorgh and so a solution to enabling helmet snapshots with emotion will need identifying. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
