### PR TITLE
Talos - Bump @bbc/psammead-media-indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.3.15 | [PR#3932](https://github.com/bbc/psammead/pull/3932) Talos - Bump Dependencies - @bbc/psammead-media-indicator |
 | 3.3.14 | [PR#3931](https://github.com/bbc/psammead/pull/3931) Talos - Bump Dependencies - @bbc/psammead-bulletin |
 | 3.3.13 | [PR#3930](https://github.com/bbc/psammead/pull/3930) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-story-promo |
 | 3.3.12 | [PR#3928](https://github.com/bbc/psammead/pull/3928) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-byline, @bbc/psammead-bulletin, @bbc/psammead-calendars, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1624,9 +1624,9 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-5.0.4.tgz",
-      "integrity": "sha512-PC+zoHaReR740/tUhy1boiVBK4i0ERBOflPVtIqFIC7tjBeXFkGq8SrgsIukP6UAUUAZ4dj8+Lk3i91wqUje2w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-6.0.1.tgz",
+      "integrity": "sha512-0akX35ec09UMzqnWMIb2FTJgl0yCJ0pZ2LTeUeb5emvpo7jwnIhPCuDwyfmj7thzs++LO+ie62xe8dpU7opNOA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -81,7 +81,7 @@
     "@bbc/psammead-inline-link": "^3.0.1",
     "@bbc/psammead-live-label": "^2.0.2",
     "@bbc/psammead-locales": "^5.0.0",
-    "@bbc/psammead-media-indicator": "^5.0.4",
+    "@bbc/psammead-media-indicator": "^6.0.1",
     "@bbc/psammead-media-player": "^5.0.2",
     "@bbc/psammead-most-read": "^6.0.2",
     "@bbc/psammead-navigation": "^8.0.1",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-media-indicator  ^5.0.4  →  ^6.0.1

| Version | Description |
| ------- | ----------- |
| 6.0.1 | [PR#3929](https://github.com/bbc/psammead/pull/3929) Resolve versioning mismatch |
| 6.0.0 | [PR#3898](https://github.com/bbc/psammead/pull/3898) Migrate to Emotion |
</details>

