### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.3.19 | [PR#3937](https://github.com/bbc/psammead/pull/3937) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 3.3.18 | [PR#3936](https://github.com/bbc/psammead/pull/3936) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 3.3.17 | [PR#3934](https://github.com/bbc/psammead/pull/3934) Talos - Bump Dependencies - @bbc/psammead-brand |
 | 3.3.16 | [PR#3933](https://github.com/bbc/psammead/pull/3933) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-media-player, @bbc/psammead-navigation, @bbc/psammead-script-link, @bbc/psammead-test-helpers, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1691,9 +1691,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.2.tgz",
-      "integrity": "sha512-7qpd4TAx7NMfQ0CkkW3tXB60eIr7Va8Bbnz2t+7eeVkuUNJ9NhsCWSmvWQpI6DvBFGmNWcGb6vT10Ltj7OGoYA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.3.tgz",
+      "integrity": "sha512-YO7IkBn5JO0ZqsppWCvgr2UcUmsYA4KQ7D/FBLYd/pTh9s1xVGrQ1I2hLf032pfPQSuCBghPJmToTaTm80BENg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
@@ -1701,52 +1701,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^2.0.2",
         "@bbc/psammead-styles": "^6.0.1",
-        "@bbc/psammead-timestamp-container": "^4.0.13"
-      },
-      "dependencies": {
-        "@bbc/psammead-timestamp": {
-          "version": "2.2.38",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.38.tgz",
-          "integrity": "sha512-zmU70auH4EXC7OO1D7uzFqhshWtRtoBD+uBEQz4xipzYQTL6caHYWictHCYc84e80FhG3gbdEoid50kRVZM4Kw==",
-          "dev": true,
-          "requires": {
-            "@bbc/gel-foundations": "^4.3.0",
-            "@bbc/psammead-styles": "^5.0.0"
-          },
-          "dependencies": {
-            "@bbc/gel-foundations": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.3.0.tgz",
-              "integrity": "sha512-KyEDfA8ibVK6ZKhBABa+RLEkCNq7ixHxmJyz4pQwA+cqsqyW2F49CCZ6dNsHJ65HCfHa2k55rzvwnQAP21IP2Q==",
-              "dev": true
-            },
-            "@bbc/psammead-styles": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-5.0.2.tgz",
-              "integrity": "sha512-Oktz9d/p7awzFx7dwIvPg6gD2gcAvcUWsd7RfPcOga5TaS1+zp8rG9DH7nx812IsbTKih0+v9IR++JhG/7+i6w==",
-              "dev": true
-            }
-          }
-        },
-        "@bbc/psammead-timestamp-container": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-4.0.13.tgz",
-          "integrity": "sha512-ESGhoc1Zrh1UfmRS41Xblgc+sZ/J67eB32yysWsocmVCztmV6WHLJe2UREo1rUDAivPgo04lY3rI3e9brSGxwg==",
-          "dev": true,
-          "requires": {
-            "@bbc/gel-foundations": "^4.3.0",
-            "@bbc/psammead-timestamp": "^2.2.37",
-            "moment-timezone": "^0.5.26"
-          },
-          "dependencies": {
-            "@bbc/gel-foundations": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.3.0.tgz",
-              "integrity": "sha512-KyEDfA8ibVK6ZKhBABa+RLEkCNq7ixHxmJyz4pQwA+cqsqyW2F49CCZ6dNsHJ65HCfHa2k55rzvwnQAP21IP2Q==",
-              "dev": true
-            }
-          }
-        }
+        "@bbc/psammead-timestamp-container": "^5.0.8"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -87,7 +87,7 @@
     "@bbc/psammead-navigation": "^8.0.2",
     "@bbc/psammead-paragraph": "^4.0.1",
     "@bbc/psammead-play-button": "^3.0.1",
-    "@bbc/psammead-radio-schedule": "5.0.2",
+    "@bbc/psammead-radio-schedule": "5.0.3",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.2",
     "@bbc/psammead-section-label": "^7.0.2",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.0.2  →  5.0.3

| Version | Description |
|---------|-------------|
| 5.0.3 | [PR#3936](https://github.com/bbc/psammead/pull/3936) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

