### PR TITLE
Ensure we monitor all events for getCLS and getLCP

### DIFF
--- a/packages/utilities/web-vitals/CHANGELOG.md
+++ b/packages/utilities/web-vitals/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.2   | [PR#3960](https://github.com/bbc/psammead/pull/3960) Add extra prop to always report on CLS and LCP |
 | 1.0.1   | [PR#3866](https://github.com/bbc/psammead/pull/3866) Rewrite async function to prevent regeneratorRuntime errors |
 | 1.0.0   | [PR#3784](https://github.com/bbc/psammead/pull/3784) Initial creation of package. |

--- a/packages/utilities/web-vitals/package-lock.json
+++ b/packages/utilities/web-vitals/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/web-vitals",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/web-vitals/package.json
+++ b/packages/utilities/web-vitals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/web-vitals",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/web-vitals/src/index.js
+++ b/packages/utilities/web-vitals/src/index.js
@@ -100,6 +100,9 @@ const useWebVitals = ({
     const pageExitTime = Date.now();
     const pageAge = pageExitTime - pageLoadTime;
 
+    // Last chance to get the CLS before sending the beacon.
+    getCLS(updateWebVitals, true);
+
     const beacon = [
       { ...webVitalsBase, age: pageAge, body: { ...vitals, ...deviceMetrics } },
     ];

--- a/packages/utilities/web-vitals/src/index.js
+++ b/packages/utilities/web-vitals/src/index.js
@@ -117,9 +117,9 @@ const useWebVitals = ({
       numberOfLogicalProcessors,
       deviceMemory,
     });
-    getCLS(updateWebVitals);
+    getCLS(updateWebVitals, true); // Setting 'true' will report all CLS changes
     getFID(updateWebVitals);
-    getLCP(updateWebVitals);
+    getLCP(updateWebVitals, true); // Setting 'true' will report all LCP changes
     getFCP(updateWebVitals);
     getTTFB(updateWebVitals);
   }, []);


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**

- Sends the extra `true` param for the `getCLS()` and `getLCP()` functions to ensure we update the values on all events fired.

- Calls the `getCLS()` function one more time just before sending the beacon to ensure we have the most up to date value.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
