### PR TITLE
Recent Episodes play icon padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4137,7 +4137,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "4.2.1",
+        "dot-prop": "^4.2.0",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -4169,7 +4169,13 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -11163,11 +11169,25 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "4.2.1"
+        "dot-prop": "^5.1.0"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "is-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+              "dev": true
+            }
+          }
         },
         "is-obj": {
           "version": "2.0.0",
@@ -11212,7 +11232,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.1",
+        "dot-prop": "^4.1.0",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -11220,7 +11240,13 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "env-paths": {
           "version": "1.0.0",
@@ -11330,7 +11356,7 @@
       "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.1",
+        "dot-prop": "^4.2.1",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -11339,7 +11365,13 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         },
         "make-dir": {
           "version": "1.3.0",
@@ -24446,12 +24478,18 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.15.1",
         "lowlight": "1.12.1",
-        "prismjs": "1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -24720,11 +24758,17 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -25978,11 +26022,17 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "4.2.1"
+        "dot-prop": "^4.1.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1"
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4137,7 +4137,7 @@
         "@lerna/validation-error": "3.13.0",
         "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
-        "dot-prop": "^4.2.0",
+        "dot-prop": "4.2.1",
         "glob-parent": "^5.0.0",
         "globby": "^9.2.0",
         "load-json-file": "^5.3.0",
@@ -4169,13 +4169,7 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "4.2.1"
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -11169,25 +11163,11 @@
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
+        "dot-prop": "4.2.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "is-obj": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-              "dev": true
-            }
-          }
+          "version": "4.2.1"
         },
         "is-obj": {
           "version": "2.0.0",
@@ -11232,7 +11212,7 @@
       "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop": "4.2.1",
         "env-paths": "^1.0.0",
         "make-dir": "^1.0.0",
         "pkg-up": "^2.0.0",
@@ -11240,13 +11220,7 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "4.2.1"
         },
         "env-paths": {
           "version": "1.0.0",
@@ -11356,7 +11330,7 @@
       "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.2.1",
+        "dot-prop": "4.2.1",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -11365,13 +11339,7 @@
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "4.2.1"
         },
         "make-dir": {
           "version": "1.3.0",
@@ -24478,18 +24446,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.15.1",
         "lowlight": "1.12.1",
-        "prismjs": "^1.8.4",
+        "prismjs": "1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -24758,17 +24720,11 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "1.21.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -26022,17 +25978,11 @@
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
-        "dot-prop": "^4.1.1"
+        "dot-prop": "4.2.1"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
+          "version": "4.2.1"
         }
       }
     },

--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,4 +3,5 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.2 | [PR#3962](https://github.com/bbc/psammead/pull/3962) Updating media icon styling |
 | 0.1.0-alpha.1 | [PR#3837](https://github.com/bbc/psammead/pull/3837) Initial creation of package. |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "requires": true,
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
       "version": "4.3.0",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "",
+  "version": "0.1.0-alpha.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { arrayOf, element } from 'prop-types';
+import { arrayOf, element, string } from 'prop-types';
 import { GEL_SPACING_QUIN } from '@bbc/gel-foundations/spacings';
 import MediaIndicator from './MediaIndicator';
 
@@ -9,15 +9,16 @@ const Wrapper = styled.div`
   max-width: calc(100% - 64px);
 `;
 
-const Episode = ({ children }) => (
+const Episode = ({ children, dir }) => (
   <>
-    <MediaIndicator size={GEL_SPACING_QUIN} />
+    <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
     <Wrapper>{children}</Wrapper>
   </>
 );
 
 Episode.propTypes = {
   children: arrayOf(element),
+  dir: string.isRequired,
 };
 
 Episode.defaultProps = {

--- a/packages/components/psammead-episode-list/src/MediaIndicator.jsx
+++ b/packages/components/psammead-episode-list/src/MediaIndicator.jsx
@@ -3,23 +3,35 @@ import styled from '@emotion/styled';
 import { string } from 'prop-types';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
-import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_GROUP_1_SCREEN_WIDTH_MAX,
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 
 const Wrapper = styled.div`
   display: inline-block;
   width: ${props => props.size};
   height: ${props => props.size};
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    margin-left: ${GEL_SPACING};
+  @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
+    margin-left: ${props => (props.dir === 'ltr' ? 0 : GEL_SPACING_DBL)};
+    margin-right: ${props => (props.dir === 'ltr' ? GEL_SPACING_DBL : 0)};
+    padding-top: ${props => (props.dir === 'ltr' ? 0 : '0.25rem')};
   }
-  margin-right: ${GEL_SPACING_DBL};
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    margin-left: ${props =>
+      props.dir === 'ltr' ? GEL_SPACING : GEL_SPACING_DBL};
+    margin-right: ${props =>
+      props.dir === 'ltr' ? GEL_SPACING_DBL : GEL_SPACING};
+    padding-top: ${props => (props.dir === 'ltr' ? 0 : '0.25rem')};
+  }
   vertical-align: top;
 `;
 
-const MediaIndicator = ({ size }) => (
+const MediaIndicator = ({ size, dir }) => (
   <Wrapper
     aria-hidden="true"
     size={size}
+    dir={dir}
     dangerouslySetInnerHTML={{
       __html: `
       <svg class="rounded-play-button" focusable="false" width=${size} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}">
@@ -35,6 +47,7 @@ const MediaIndicator = ({ size }) => (
 
 MediaIndicator.propTypes = {
   size: string.isRequired,
+  dir: string.isRequired,
 };
 
 export default MediaIndicator;

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -77,7 +77,7 @@ EpisodeList.defaultProps = {
 };
 
 // This module also has a range of supplemental components to provide consumers with some compositational control
-EpisodeList.Episode = Episode;
+EpisodeList.Episode = withEpisodeLocality(Episode);
 EpisodeList.Link = Link;
 EpisodeList.Title = withEpisodeLocality(Title);
 EpisodeList.Description = withEpisodeLocality(Description);

--- a/packages/components/psammead-episode-list/src/index.stories.jsx
+++ b/packages/components/psammead-episode-list/src/index.stories.jsx
@@ -16,7 +16,12 @@ storiesOf('Components/EpisodeList', module)
     ),
   )
   .add('with single episode', ({ script, service, dir }) =>
-    renderEpisodes([exampleEpisodes[0]], script, service, dir),
+    renderEpisodes(
+      dir === 'rtl' ? [rtlEpisodes[0]] : [exampleEpisodes[0]],
+      script,
+      service,
+      dir,
+    ),
   )
   .add('with no episodes', ({ script, service, dir }) =>
     renderEpisodes([], script, service, dir),


### PR DESCRIPTION
Resolves #3828

**Overall change:** The padding on the Recent Episode play icon differs based on rtl/ltr. The designs can be found here: https://app.zeplin.io/project/5d4d77b1fcbfc79bf47e0294/screen/5f2035d795f41b8a78b9ea12

**Code changes:**

LTR small screen: No left padding, no top padding, and 16px right padding
LTR larger screen: 8px left padding, no top padding, and 16px right padding

RTL small screen: No right padding, 4px top padding, and 16px left padding
RTL larger screen: 8px right padding, 4px top padding, and 16px left padding


---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
