### PR TITLE
[Alpha] Update Episode List to support Videos and Dark Mode

### DIFF
--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.3 | [PR#3979](https://github.com/bbc/psammead/pull/3979) Updating media icon styling |
+| 0.1.0-alpha.3 | [PR#3979](https://github.com/bbc/psammead/pull/3979) Implement episode image component and dark mode support |
 | 0.1.0-alpha.2 | [PR#3962](https://github.com/bbc/psammead/pull/3962) Updating media icon styling |
 | 0.1.0-alpha.1 | [PR#3837](https://github.com/bbc/psammead/pull/3837) Initial creation of package. |

--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,5 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.3 | [PR#3979](https://github.com/bbc/psammead/pull/3979) Updating media icon styling |
 | 0.1.0-alpha.2 | [PR#3962](https://github.com/bbc/psammead/pull/3962) Updating media icon styling |
 | 0.1.0-alpha.1 | [PR#3837](https://github.com/bbc/psammead/pull/3837) Initial creation of package. |

--- a/packages/components/psammead-episode-list/README.md
+++ b/packages/components/psammead-episode-list/README.md
@@ -32,6 +32,8 @@ The base `EpisodeList` component is responsible for mangaging the internal spaci
 
 The `EpisodeList.Link` component is responsible for the click, focus and hover handling of individual episodes. It's child is intended to be an `EpisodeList.Episode` component. By default, it is a styled `<a>` element, however, this can be overridden by the `as` prop, which would be useful for things like client side routing.
 
+Child elements with a class name containing `--visited` will receive `::visited` styling, which currently will change the `color` to one with reduced contrast.
+
 ```jsx
 <EpisodeList.Link as={Link} to={episode.url}>
 ```
@@ -39,6 +41,8 @@ The `EpisodeList.Link` component is responsible for the click, focus and hover h
 ### Components: `EpisodeList.Episode`
 
 The `EpisodeList.Episode` component is responsible for rendering the play icon, and a collection of child elements that describe the episode.
+
+Child elements with a class name containing `--hover` will receive `::hover` styling, which currently will apply a `text-decoration` of `underline`.
 
 ### Components: `EpisodeList.Image`
 

--- a/packages/components/psammead-episode-list/README.md
+++ b/packages/components/psammead-episode-list/README.md
@@ -38,6 +38,14 @@ The `EpisodeList.Link` component is responsible for the click, focus and hover h
 
 The `EpisodeList.Episode` component is responsible for rendering the play icon, and a collection of child elements that describe the episode.
 
+### Components: `EpisodeList.Image`
+
+The `EpisodeList.Image` component displays an image to the left (in LTR locales) or right (in RTL locales) of the episode card. If not provided, the card will use a play icon instead.
+
+If provided, the `EpisodeList.Image` must be the first child of the `EpisodeList.Episode` component
+
+`EpisodeList.Image` accepts a `duration` prop which, if provided, will be placed on the bottom of the image. Any additional props this component receives will be passed through to the underlying `<img>` element. At bare minimum, a `src` or `srcset` should be provided. `alt` is set to an empty string if not provided
+
 ### Components: `EpisodeList.Title`
 
 The `EpisodeList.Title` component is responsible for styling text to be presented as the title of an individual episode. This component is intended to be a child of `EpisodeList.Episode`

--- a/packages/components/psammead-episode-list/README.md
+++ b/packages/components/psammead-episode-list/README.md
@@ -24,7 +24,9 @@ This is an alpha component and currently not production ready
 
 The base `EpisodeList` component is responsible for mangaging the internal spacing of its children, and the rendering of dividers. Its children are intended to be one or more `EpisodeList.Link` or `EpisodeList.Episode` components.
 
-`EpisodeList.Episode` accepts the standard Psammead `script`, `service` and `dir` properties to implement localised styling.
+`EpisodeList` accepts the standard Psammead `script`, `service` and `dir` properties to implement localised styling.
+
+`EpisodeList` also accepts a boolean `darkMode` prop. When set to true, child components will implement dark-mode styling.
 
 ### Components: `EpisodeList.Link`
 
@@ -40,11 +42,13 @@ The `EpisodeList.Episode` component is responsible for rendering the play icon, 
 
 ### Components: `EpisodeList.Image`
 
-The `EpisodeList.Image` component displays an image to the left (in LTR locales) or right (in RTL locales) of the episode card. If not provided, the card will use a play icon instead.
+The `EpisodeList.Image` component displays an image to the left (in LTR locales) or right (in RTL locales) of the episode card.
 
 If provided, the `EpisodeList.Image` must be the first child of the `EpisodeList.Episode` component
 
 `EpisodeList.Image` accepts a `duration` prop which, if provided, will be placed on the bottom of the image. Any additional props this component receives will be passed through to the underlying `<img>` element. At bare minimum, a `src` or `srcset` should be provided. `alt` is set to an empty string if not provided
+
+If an episode does not have an `EpisodeList.Image` child component, the episode card will use a play icon instead. Note: this fallback play icon does not currently support `darkMode` styling. If using `darkMode`, it is recommended that each episode has a `EpisodeList.Image` child.
 
 ### Components: `EpisodeList.Title`
 

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -14,6 +14,30 @@
       "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.14.2.tgz",
       "integrity": "sha512-YWl8pWsytpqGOL1DJpq4wBbF7Tt7/Z2oJzr+g0fK9nXVV+CRa+X30EPH1smaDKpxeNfEE1TjqJHX+ZHfO9Qu+g=="
     },
+    "@bbc/psammead-section-label": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-7.0.3.tgz",
+      "integrity": "sha512-ER/cymj25xm3294R19uyleSDceYzohV9Eg7tn3sv7DEDJR/PNXB9qHKBu+ynY39ARL05mu878OfWBd4SiSKV8g==",
+      "dev": true,
+      "requires": {
+        "@bbc/gel-foundations": "^5.0.1",
+        "@bbc/psammead-styles": "^6.1.0"
+      },
+      "dependencies": {
+        "@bbc/gel-foundations": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-5.0.1.tgz",
+          "integrity": "sha512-NN4+0UiAvbFE/cxXH80Tq9R7BB+y25U70L6/03JhyGI8zPd2pj90G9MJPIKDoUNHMKwiIqbivM51dR5rlh7RBQ==",
+          "dev": true
+        },
+        "@bbc/psammead-styles": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-6.1.0.tgz",
+          "integrity": "sha512-dUTyreN7OZh7RhGiL7yoEP/W6no5E6AHcMCB449d2bPeNZqZkwdwxN0u0JQTykYMZwP4q5/YGY5YNgpq0CQVIg==",
+          "dev": true
+        }
+      }
+    },
     "@bbc/psammead-styles": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.5.1.tgz",
@@ -22,7 +46,8 @@
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-2.0.1.tgz",
-      "integrity": "sha512-n9SBNfxEqBz87UHxsW4321X47AETauejPGaMCIntqiEjL9IwUTExMe8fPGHbJZdT1QCXRhs5qkGDx1UfmZfxzw=="
+      "integrity": "sha512-n9SBNfxEqBz87UHxsW4321X47AETauejPGaMCIntqiEjL9IwUTExMe8fPGHbJZdT1QCXRhs5qkGDx1UfmZfxzw==",
+      "dev": true
     }
   }
 }

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -14,6 +14,15 @@
       "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.0.1.tgz",
       "integrity": "sha512-vsrOzJRRRjy9ep9DGg+fRKp5mouVZX1+2Ujh42PwAFvdKL45Hyl5Y6T0SnVWnIyssGgzPJRzuiTpJqtKUtKG7A=="
     },
+    "@bbc/psammead-image-placeholder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.0.3.tgz",
+      "integrity": "sha512-tr06IV1vbfD3snz/kevMZ2uOLJyHU1G8BnLBvBoD9I+9LZZl4/2S5tHTGOReibY8ejwDnf5pPsKArr9J2oYv3g==",
+      "requires": {
+        "@bbc/psammead-assets": "^3.0.1",
+        "@bbc/psammead-styles": "^6.1.0"
+      }
+    },
     "@bbc/psammead-section-label": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-7.0.3.tgz",

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.3.0.tgz",
-      "integrity": "sha512-KyEDfA8ibVK6ZKhBABa+RLEkCNq7ixHxmJyz4pQwA+cqsqyW2F49CCZ6dNsHJ65HCfHa2k55rzvwnQAP21IP2Q=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-5.0.1.tgz",
+      "integrity": "sha512-NN4+0UiAvbFE/cxXH80Tq9R7BB+y25U70L6/03JhyGI8zPd2pj90G9MJPIKDoUNHMKwiIqbivM51dR5rlh7RBQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.14.2.tgz",
-      "integrity": "sha512-YWl8pWsytpqGOL1DJpq4wBbF7Tt7/Z2oJzr+g0fK9nXVV+CRa+X30EPH1smaDKpxeNfEE1TjqJHX+ZHfO9Qu+g=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.0.1.tgz",
+      "integrity": "sha512-vsrOzJRRRjy9ep9DGg+fRKp5mouVZX1+2Ujh42PwAFvdKL45Hyl5Y6T0SnVWnIyssGgzPJRzuiTpJqtKUtKG7A=="
     },
     "@bbc/psammead-section-label": {
       "version": "7.0.3",
@@ -39,9 +39,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-4.5.1.tgz",
-      "integrity": "sha512-b4vSC0HMBR/13ZF4wGNZZmuLfKpF2Uuclebamwgn5pw0T+6zKceODaz5cMsLH9Kf82fQ+VijTUeuWkMlwhe6vQ=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-6.1.0.tgz",
+      "integrity": "sha512-dUTyreN7OZh7RhGiL7yoEP/W6no5E6AHcMCB449d2bPeNZqZkwdwxN0u0JQTykYMZwP4q5/YGY5YNgpq0CQVIg=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-episode-list/README.md",
   "dependencies": {
-    "@bbc/gel-foundations": "^4.3.0",
-    "@bbc/psammead-assets": "^2.14.2",
-    "@bbc/psammead-styles": "^4.5.1"
+    "@bbc/gel-foundations": "^5.0.1",
+    "@bbc/psammead-assets": "^3.0.1",
+    "@bbc/psammead-styles": "^6.1.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -21,13 +21,16 @@
   "dependencies": {
     "@bbc/gel-foundations": "^4.3.0",
     "@bbc/psammead-assets": "^2.14.2",
-    "@bbc/psammead-styles": "^4.5.1",
-    "@bbc/psammead-visually-hidden-text": "^2.0.0"
+    "@bbc/psammead-styles": "^4.5.1"
   },
   "peerDependencies": {
     "react": "^16.12.0",
     "prop-types": "^15.7.2",
     "@emotion/styled": "^10.0.27"
+  },
+  "devDependencies": {
+    "@bbc/psammead-visually-hidden-text": "^2.0.0",
+    "@bbc/psammead-section-label": "^7.0.3"
   },
   "keywords": [
     "bbc",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^5.0.1",
     "@bbc/psammead-assets": "^3.0.1",
+    "@bbc/psammead-image-placeholder": "^3.0.3",
     "@bbc/psammead-styles": "^6.1.0"
   },
   "peerDependencies": {

--- a/packages/components/psammead-episode-list/src/Description.jsx
+++ b/packages/components/psammead-episode-list/src/Description.jsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import { getLongPrimer } from '@bbc/gel-foundations/typography';
-import { C_EBON } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
 
 const Description = styled.span`
   ${({ script }) => getLongPrimer(script)};
   ${({ service }) => getSansRegular(service)}
-  color: ${C_EBON};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_EBON)};
   display: block;
   margin: ${GEL_SPACING_HLF} 0;
 `;

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -15,7 +15,7 @@ import Image from './Image';
 const Wrapper = styled.div`
   position: relative;
   &:hover {
-    .underlined_hover {
+    [class*='--hover'] {
       text-decoration: underline;
     }
     .rounded-play-button__outer-circle,

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { arrayOf, element, string } from 'prop-types';
+import { node, string } from 'prop-types';
 import {
   GEL_SPACING_DBL,
   GEL_SPACING_QUIN,
@@ -11,11 +11,24 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 import tail from 'ramda/src/tail';
 import pathOr from 'ramda/src/pathOr';
+import { C_POSTBOX, C_WHITE } from '@bbc/psammead-styles/colours';
 import MediaIndicator from './MediaIndicator';
 import Image from './Image';
 
 const Wrapper = styled.div`
   position: relative;
+  &:hover {
+    .underlined_hover {
+      text-decoration: underline;
+    }
+    .rounded-play-button__outer-circle,
+    .rounded-play-button__inner-circle {
+      fill: ${C_POSTBOX};
+    }
+    .rounded-play-button__triangle {
+      fill: ${C_WHITE};
+    }
+  }
 `;
 
 const TextWrapper = styled.div`
@@ -53,12 +66,8 @@ const Episode = ({ children, dir }) => {
 };
 
 Episode.propTypes = {
-  children: arrayOf(element),
+  children: node.isRequired,
   dir: string.isRequired,
-};
-
-Episode.defaultProps = {
-  children: [],
 };
 
 export default Episode;

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -13,7 +13,7 @@ import Image from './Image';
 const Wrapper = styled.div`
   display: inline-block;
   max-width: calc(
-    100% - ${({ sideBarWidth }) => sideBarWidth}px - ${GEL_SPACING_DBL}
+    100% - ${({ narrow }) => (narrow ? 230 : 50)}px - ${GEL_SPACING_DBL}
   );
   vertical-align: top;
 `;
@@ -27,7 +27,7 @@ const Episode = ({ children, dir }) => {
       ) : (
         <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
       )}
-      <Wrapper sideBarWidth={firstChildIsImage ? 230 : 50}>
+      <Wrapper narrow={firstChildIsImage}>
         {firstChildIsImage ? tail(children) : children}
       </Wrapper>
     </>

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -2,19 +2,32 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { arrayOf, element, string } from 'prop-types';
 import { GEL_SPACING_QUIN } from '@bbc/gel-foundations/spacings';
+import tail from 'ramda/src/tail';
+import is from 'ramda/src/is';
+import isEmpty from 'ramda/src/isEmpty';
+import pathOr from 'ramda/src/pathOr';
 import MediaIndicator from './MediaIndicator';
+import Image from './Image';
 
 const Wrapper = styled.div`
   display: inline-block;
   max-width: calc(100% - 64px);
+  vertical-align: top;
 `;
 
-const Episode = ({ children, dir }) => (
-  <>
-    <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
-    <Wrapper>{children}</Wrapper>
-  </>
-);
+const Episode = ({ children, dir }) => {
+  const firstChildIsImage = pathOr({}, '0', children).type === Image;
+  return (
+    <>
+      {firstChildIsImage ? (
+        children[0]
+      ) : (
+        <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
+      )}
+      <Wrapper>{firstChildIsImage ? tail(children) : children}</Wrapper>
+    </>
+  );
+};
 
 Episode.propTypes = {
   children: arrayOf(element),

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 import { arrayOf, element, string } from 'prop-types';
 import { GEL_SPACING_QUIN } from '@bbc/gel-foundations/spacings';
 import tail from 'ramda/src/tail';
-import is from 'ramda/src/is';
-import isEmpty from 'ramda/src/isEmpty';
 import pathOr from 'ramda/src/pathOr';
 import MediaIndicator from './MediaIndicator';
 import Image from './Image';

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -5,6 +5,10 @@ import {
   GEL_SPACING_DBL,
   GEL_SPACING_QUIN,
 } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 import tail from 'ramda/src/tail';
 import pathOr from 'ramda/src/pathOr';
 import MediaIndicator from './MediaIndicator';
@@ -13,9 +17,19 @@ import Image from './Image';
 const Wrapper = styled.div`
   display: inline-block;
   max-width: calc(
-    100% - ${({ narrow }) => (narrow ? 230 : 50)}px - ${GEL_SPACING_DBL}
+    100% - ${({ narrow }) => (narrow ? 70 : 50)}px - ${GEL_SPACING_DBL}
   );
   vertical-align: top;
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    max-width: calc(
+      100% - ${({ narrow }) => (narrow ? 120 : 50)}px - ${GEL_SPACING_DBL}
+    );
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    max-width: calc(
+      100% - ${({ narrow }) => (narrow ? 230 : 50)}px - ${GEL_SPACING_DBL}
+    );
+  }
 `;
 
 const Episode = ({ children, dir }) => {

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -15,6 +15,10 @@ import MediaIndicator from './MediaIndicator';
 import Image from './Image';
 
 const Wrapper = styled.div`
+  position: relative;
+`;
+
+const TextWrapper = styled.div`
   display: inline-block;
   max-width: calc(
     100% - ${({ narrow }) => (narrow ? 70 : 50)}px - ${GEL_SPACING_DBL}
@@ -35,16 +39,16 @@ const Wrapper = styled.div`
 const Episode = ({ children, dir }) => {
   const firstChildIsImage = pathOr({}, '0', children).type === Image;
   return (
-    <>
+    <Wrapper>
       {firstChildIsImage ? (
         children[0]
       ) : (
         <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
       )}
-      <Wrapper narrow={firstChildIsImage}>
+      <TextWrapper narrow={firstChildIsImage}>
         {firstChildIsImage ? tail(children) : children}
-      </Wrapper>
-    </>
+      </TextWrapper>
+    </Wrapper>
   );
 };
 

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { node, string } from 'prop-types';
-import {
-  GEL_SPACING_DBL,
-  GEL_SPACING_QUIN,
-} from '@bbc/gel-foundations/spacings';
+import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
@@ -53,11 +50,7 @@ const Episode = ({ children, dir }) => {
   const firstChildIsImage = pathOr({}, '0', children).type === Image;
   return (
     <Wrapper>
-      {firstChildIsImage ? (
-        children[0]
-      ) : (
-        <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
-      )}
+      {firstChildIsImage ? children[0] : <MediaIndicator size={40} dir={dir} />}
       <TextWrapper narrow={firstChildIsImage}>
         {firstChildIsImage ? tail(children) : children}
       </TextWrapper>

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { arrayOf, element, string } from 'prop-types';
-import { GEL_SPACING_QUIN } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_SPACING_DBL,
+  GEL_SPACING_QUIN,
+} from '@bbc/gel-foundations/spacings';
 import tail from 'ramda/src/tail';
 import pathOr from 'ramda/src/pathOr';
 import MediaIndicator from './MediaIndicator';
@@ -9,7 +12,9 @@ import Image from './Image';
 
 const Wrapper = styled.div`
   display: inline-block;
-  max-width: calc(100% - 64px);
+  max-width: calc(
+    100% - ${({ sideBarWidth }) => sideBarWidth}px - ${GEL_SPACING_DBL}
+  );
   vertical-align: top;
 `;
 
@@ -22,7 +27,9 @@ const Episode = ({ children, dir }) => {
       ) : (
         <MediaIndicator size={GEL_SPACING_QUIN} dir={dir} />
       )}
-      <Wrapper>{firstChildIsImage ? tail(children) : children}</Wrapper>
+      <Wrapper sideBarWidth={firstChildIsImage ? 230 : 50}>
+        {firstChildIsImage ? tail(children) : children}
+      </Wrapper>
     </>
   );
 };

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -16,7 +16,7 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 
-import { withEpisodeLocality } from './helpers';
+import { withEpisodeContext } from './helpers';
 
 const Wrapper = styled.div`
   display: inline-block;
@@ -34,7 +34,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const PlayWrapper = withEpisodeLocality(styled.div`
+const PlayWrapper = withEpisodeContext(styled.div`
   background-color: ${C_EBON};
   padding: ${GEL_SPACING_HLF};
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
@@ -54,7 +54,7 @@ const PlayWrapper = withEpisodeLocality(styled.div`
   }
 `);
 
-const DurationWrapper = withEpisodeLocality(styled.label`
+const DurationWrapper = withEpisodeContext(styled.label`
   ${({ script }) => getMinion(script)};
   ${({ service }) => getSansRegular(service)}
   color: ${C_WHITE};

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -21,7 +21,6 @@ import { withEpisodeContext } from './helpers';
 const Wrapper = styled.div`
   display: inline-block;
   position: relative;
-  line-height: 0;
   margin: 0 ${GEL_SPACING} 0 0;
   :dir(rtl) {
     margin: 0 0 0 ${GEL_SPACING};

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -84,7 +84,7 @@ const EpisodeImage = props => {
   return (
     <Wrapper>
       <StyledImage alt={alt} {...selectImgProps(props)} />
-      <PlayWrapper>
+      <PlayWrapper aria-hidden="true">
         {mediaIcons.video}
         {duration && <DurationWrapper>{duration}</DurationWrapper>}
       </PlayWrapper>

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { string } from 'prop-types';
+import omit from 'ramda/src/omit';
+import styled from '@emotion/styled';
+import { mediaIcons } from '@bbc/psammead-assets/svgs';
+import { getMinion } from '@bbc/gel-foundations/typography';
+import { C_EBON } from '@bbc/psammead-styles/colours';
+import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+
+import { withEpisodeLocality } from './helpers';
+
+const Wrapper = styled.div`
+  display: inline-block;
+  position: relative;
+  line-height: 0;
+  margin-right: 16px;
+`;
+
+// This component only uses a subset of its props
+const usedProps = ['alt', 'duration'];
+
+// others are passed down to the underyling <img> element
+const selectImgProps = omit(usedProps);
+
+const DurationBox = withEpisodeLocality(styled.div`
+  ${({ script }) => getMinion(script)};
+  ${({ service }) => getSansRegular(service)}
+  background-color: ${C_EBON};
+  padding: 8px;
+  color: white;
+  line-height: 1;
+  position: absolute;
+  bottom: 0;
+  svg {
+    margin: 0 4px 2px 0;
+    height: 10px;
+    width: 12px;
+    fill: white;
+  }
+`);
+
+const StyledImage = styled.img`
+  width: 230px;
+`;
+
+const EpisodeImage = props => {
+  const { duration, alt } = props;
+  return (
+    <Wrapper>
+      <StyledImage alt={alt} {...selectImgProps(props)} />
+      <DurationBox>
+        {mediaIcons.video}
+        {duration}
+      </DurationBox>
+    </Wrapper>
+  );
+};
+
+EpisodeImage.propTypes = {
+  alt: string,
+  duration: 'string',
+};
+
+EpisodeImage.defaultProps = {
+  alt: '',
+  duration: '',
+};
+
+export default EpisodeImage;

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -78,7 +78,7 @@ const EpisodeImage = props => {
   const { duration, alt } = props;
 
   // This component only uses a subset of its props
-  // the remaining props are passed down to the underyling <img> element
+  // the remaining props are passed down to the underlying <img> element
   const selectImgProps = omit(['alt', 'duration']);
 
   return (

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -45,7 +45,7 @@ const PlayWrapper = withEpisodeContext(styled.div`
     margin: 0 0 2px 0;
     height: 10px;
     width: 12px;
-    fill: white;
+    color: white;
   }
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -4,8 +4,13 @@ import omit from 'ramda/src/omit';
 import styled from '@emotion/styled';
 import { mediaIcons } from '@bbc/psammead-assets/svgs';
 import { getMinion } from '@bbc/gel-foundations/typography';
-import { C_EBON } from '@bbc/psammead-styles/colours';
+import { C_EBON, C_WHITE } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+import {
+  GEL_SPACING_HLF,
+  GEL_SPACING,
+  GEL_SPACING_DBL,
+} from '@bbc/gel-foundations/spacings';
 
 import { withEpisodeLocality } from './helpers';
 
@@ -13,7 +18,7 @@ const Wrapper = styled.div`
   display: inline-block;
   position: relative;
   line-height: 0;
-  margin-right: 16px;
+  margin-right: ${GEL_SPACING_DBL};
 `;
 
 // This component only uses a subset of its props
@@ -22,21 +27,24 @@ const usedProps = ['alt', 'duration'];
 // others are passed down to the underyling <img> element
 const selectImgProps = omit(usedProps);
 
-const DurationBox = withEpisodeLocality(styled.div`
-  ${({ script }) => getMinion(script)};
-  ${({ service }) => getSansRegular(service)}
+const PlayWrapper = withEpisodeLocality(styled.div`
   background-color: ${C_EBON};
-  padding: 8px;
-  color: white;
-  line-height: 1;
+  padding: ${GEL_SPACING};
   position: absolute;
   bottom: 0;
   svg {
-    margin: 0 4px 2px 0;
+    margin: 0 0 2px 0;
     height: 10px;
     width: 12px;
     fill: white;
   }
+`);
+
+const DurationWrapper = withEpisodeLocality(styled.label`
+  ${({ script }) => getMinion(script)};
+  ${({ service }) => getSansRegular(service)}
+  color: ${C_WHITE};
+  padding-left: ${GEL_SPACING_HLF};
 `);
 
 const StyledImage = styled.img`
@@ -48,10 +56,10 @@ const EpisodeImage = props => {
   return (
     <Wrapper>
       <StyledImage alt={alt} {...selectImgProps(props)} />
-      <DurationBox>
+      <PlayWrapper>
         {mediaIcons.video}
-        {duration}
-      </DurationBox>
+        {duration && <DurationWrapper>{duration}</DurationWrapper>}
+      </PlayWrapper>
     </Wrapper>
   );
 };

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -16,17 +16,24 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 
+import ImagePlaceholder from '@bbc/psammead-image-placeholder';
+
 import { withEpisodeContext } from './helpers';
 
 const Wrapper = styled.div`
   display: inline-block;
   position: relative;
+  width: 70px;
   margin: 0 ${GEL_SPACING} 0 0;
   :dir(rtl) {
     margin: 0 0 0 ${GEL_SPACING};
   }
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    width: 120px;
+  }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     margin: 0 ${GEL_SPACING_DBL} 0 0;
+    width: 230px;
     :dir(rtl) {
       margin: 0 0 0 ${GEL_SPACING_DBL};
     }
@@ -64,13 +71,7 @@ const DurationWrapper = withEpisodeContext(styled.span`
 `);
 
 const StyledImage = styled.img`
-  width: 70px;
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    width: 120px;
-  }
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    width: 230px;
-  }
+  width: 100%;
 `;
 
 const EpisodeImage = props => {
@@ -82,7 +83,10 @@ const EpisodeImage = props => {
 
   return (
     <Wrapper>
-      <StyledImage alt={alt} {...selectImgProps(props)} />
+      <ImagePlaceholder ratio={56.25}>
+        <StyledImage alt={alt} {...selectImgProps(props)} />
+      </ImagePlaceholder>
+
       <PlayWrapper aria-hidden="true">
         {mediaIcons.video}
         {duration && <DurationWrapper>{duration}</DurationWrapper>}

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -11,6 +11,10 @@ import {
   GEL_SPACING,
   GEL_SPACING_DBL,
 } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 
 import { withEpisodeLocality } from './helpers';
 
@@ -18,25 +22,29 @@ const Wrapper = styled.div`
   display: inline-block;
   position: relative;
   line-height: 0;
-  margin-right: ${GEL_SPACING_DBL};
+  margin-right: ${GEL_SPACING};
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    margin-right: ${GEL_SPACING_DBL};
+  }
 `;
-
-// This component only uses a subset of its props
-const usedProps = ['alt', 'duration'];
-
-// others are passed down to the underyling <img> element
-const selectImgProps = omit(usedProps);
 
 const PlayWrapper = withEpisodeLocality(styled.div`
   background-color: ${C_EBON};
-  padding: ${GEL_SPACING};
-  position: absolute;
-  bottom: 0;
+  padding: ${GEL_SPACING_HLF};
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    padding: ${GEL_SPACING};
+  }
+
   svg {
     margin: 0 0 2px 0;
     height: 10px;
     width: 12px;
     fill: white;
+  }
+
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    position: absolute;
+    bottom: 0;
   }
 `);
 
@@ -48,11 +56,22 @@ const DurationWrapper = withEpisodeLocality(styled.label`
 `);
 
 const StyledImage = styled.img`
-  width: 230px;
+  width: 70px;
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    width: 120px;
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    width: 230px;
+  }
 `;
 
 const EpisodeImage = props => {
   const { duration, alt } = props;
+
+  // This component only uses a subset of its props
+  // the remaining props are passed down to the underyling <img> element
+  const selectImgProps = omit(['alt', 'duration']);
+
   return (
     <Wrapper>
       <StyledImage alt={alt} {...selectImgProps(props)} />
@@ -66,7 +85,7 @@ const EpisodeImage = props => {
 
 EpisodeImage.propTypes = {
   alt: string,
-  duration: 'string',
+  duration: string,
 };
 
 EpisodeImage.defaultProps = {

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -54,7 +54,7 @@ const PlayWrapper = withEpisodeContext(styled.div`
   }
 `);
 
-const DurationWrapper = withEpisodeContext(styled.label`
+const DurationWrapper = withEpisodeContext(styled.span`
   ${({ script }) => getMinion(script)};
   ${({ service }) => getSansRegular(service)}
   color: ${C_WHITE};

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -42,10 +42,10 @@ const PlayWrapper = withEpisodeContext(styled.div`
   }
 
   svg {
-    margin: 0 0 2px 0;
-    height: 10px;
-    width: 12px;
-    color: white;
+    margin: 0 0 1px 0;
+    height: 0.6rem;
+    width: 0.7rem;
+    color: ${C_WHITE};
   }
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -58,7 +58,10 @@ const DurationWrapper = withEpisodeContext(styled.label`
   ${({ script }) => getMinion(script)};
   ${({ service }) => getSansRegular(service)}
   color: ${C_WHITE};
-  padding-left: ${GEL_SPACING_HLF};
+  padding: 0 0 0 ${GEL_SPACING_HLF};
+  :dir(rtl) {
+    padding: 0 ${GEL_SPACING_HLF} 0 0;
+  }
 `);
 
 const StyledImage = styled.img`

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -22,9 +22,15 @@ const Wrapper = styled.div`
   display: inline-block;
   position: relative;
   line-height: 0;
-  margin-right: ${GEL_SPACING};
+  margin: 0 ${GEL_SPACING} 0 0;
+  :dir(rtl) {
+    margin: 0 0 0 ${GEL_SPACING};
+  }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    margin-right: ${GEL_SPACING_DBL};
+    margin: 0 ${GEL_SPACING_DBL} 0 0;
+    :dir(rtl) {
+      margin: 0 0 0 ${GEL_SPACING_DBL};
+    }
   }
 `;
 

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -3,6 +3,7 @@ import { C_METAL, C_POSTBOX, C_WHITE } from '@bbc/psammead-styles/colours';
 
 const Link = styled.a`
   display: block;
+  line-height: 0;
   .rounded-play-button__outer-circle,
   .rounded-play-button__inner-circle,
   .rounded-play-button__triangle {

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -1,5 +1,10 @@
 import styled from '@emotion/styled';
-import { C_METAL, C_POSTBOX, C_WHITE } from '@bbc/psammead-styles/colours';
+import {
+  C_METAL,
+  C_POSTBOX,
+  C_WHITE,
+  C_PEBBLE,
+} from '@bbc/psammead-styles/colours';
 
 const Link = styled.a`
   display: block;
@@ -24,7 +29,7 @@ const Link = styled.a`
   }
   &:visited {
     span {
-      color: ${C_METAL};
+      color: ${({ darkMode }) => (darkMode ? C_PEBBLE : C_METAL)};
     }
   }
 `;

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -7,7 +7,15 @@ import {
 } from '@bbc/psammead-styles/colours';
 
 const Link = styled.a`
-  display: block;
+  :before {
+    position: absolute;
+    inset: 0;
+    content: '';
+    white-space: nowrap;
+    overflow: hidden;
+    z-index: 1;
+  }
+  display: inline;
   line-height: 0;
   .rounded-play-button__outer-circle,
   .rounded-play-button__inner-circle,

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -9,13 +9,11 @@ import {
 const Link = styled.a`
   :before {
     position: absolute;
-    inset: 0;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
     content: '';
-    white-space: nowrap;
     overflow: hidden;
     z-index: 1;
   }

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -10,6 +10,10 @@ const Link = styled.a`
   :before {
     position: absolute;
     inset: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
     content: '';
     white-space: nowrap;
     overflow: hidden;
@@ -17,6 +21,7 @@ const Link = styled.a`
   }
   display: inline;
   line-height: 0;
+  text-decoration: none;
   .rounded-play-button__outer-circle,
   .rounded-play-button__inner-circle,
   .rounded-play-button__triangle {

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -39,7 +39,7 @@ const Link = styled.a`
     }
   }
   &:visited {
-    .fade_visited {
+    [class*='--visited'] {
       color: ${({ darkMode }) => (darkMode ? C_STONE : C_METAL)};
     }
   }

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -3,7 +3,7 @@ import {
   C_METAL,
   C_POSTBOX,
   C_WHITE,
-  C_PEBBLE,
+  C_STONE,
 } from '@bbc/psammead-styles/colours';
 
 const Link = styled.a`
@@ -28,8 +28,8 @@ const Link = styled.a`
     }
   }
   &:visited {
-    span {
-      color: ${({ darkMode }) => (darkMode ? C_PEBBLE : C_METAL)};
+    .fade_visited {
+      color: ${({ darkMode }) => (darkMode ? C_STONE : C_METAL)};
     }
   }
 `;

--- a/packages/components/psammead-episode-list/src/MediaIndicator.jsx
+++ b/packages/components/psammead-episode-list/src/MediaIndicator.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { string } from 'prop-types';
+import { string, number } from 'prop-types';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { C_WHITE } from '@bbc/psammead-styles/colours';
 import {
@@ -46,7 +46,7 @@ const MediaIndicator = ({ size, dir }) => (
 );
 
 MediaIndicator.propTypes = {
-  size: string.isRequired,
+  size: number.isRequired,
   dir: string.isRequired,
 };
 

--- a/packages/components/psammead-episode-list/src/Metadata.jsx
+++ b/packages/components/psammead-episode-list/src/Metadata.jsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import { getBrevier } from '@bbc/gel-foundations/typography';
-import { C_METAL } from '@bbc/psammead-styles/colours';
+import { C_METAL, C_PEBBLE } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 const Metadata = styled.span`
   ${({ script }) => getBrevier(script)};
   ${({ service }) => getSansRegular(service)}
   display: block;
-  color: ${C_METAL};
+  color: ${({ darkMode }) => (darkMode ? C_PEBBLE : C_METAL)};
 `;
 
 export default Metadata;

--- a/packages/components/psammead-episode-list/src/Metadata.jsx
+++ b/packages/components/psammead-episode-list/src/Metadata.jsx
@@ -6,7 +6,6 @@ import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 const Metadata = styled.span`
   ${({ script }) => getBrevier(script)};
   ${({ service }) => getSansRegular(service)}
-  display: block;
   color: ${({ darkMode }) => (darkMode ? C_PEBBLE : C_METAL)};
 `;
 

--- a/packages/components/psammead-episode-list/src/Title.jsx
+++ b/packages/components/psammead-episode-list/src/Title.jsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
-import { C_EBON } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
 import { getPica } from '@bbc/gel-foundations/typography';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 const Title = styled.span`
   ${({ script }) => getPica(script)};
   ${({ service }) => getSansRegular(service)}
-  color: ${C_EBON};
+  color: ${({ darkMode }) => (darkMode ? C_WHITE : C_EBON)};
   display: block;
   font-weight: 700;
 `;

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/aria-role */
 /* eslint-disable react/prop-types */
 // This provides fixture data and helper functions that are useful to both storybook and unit tests
 import React from 'react';
@@ -20,7 +21,7 @@ import EpisodeList from '.';
 export const exampleEpisodes = [
   {
     id: '1',
-    url: 'https://www.bbc.com',
+    url: 'https://www.bbc.com/blahasda',
     brandTitle: 'Magazine de la Culture',
     date: '4 Avril 2020',
     duration: 'PT3M',
@@ -99,7 +100,7 @@ const StyledSpan = styled.span`
   padding-right: 8px;
 `;
 
-const Spacer = styled.div`
+const Spacer = styled.aside`
   background: ${({ darkMode }) => (darkMode ? C_MIDNIGHT_BLACK : 'unset')};
   position: absolute;
   top: 0;
@@ -129,7 +130,8 @@ const SurroundingComponents = ({
   dir,
   darkMode,
 }) => (
-  <Spacer darkMode={darkMode}>
+  // eslint-disable-next-line jsx-a11y/aria-role
+  <Spacer darkMode={darkMode} role="complimentary">
     <StyledSectionLabel
       script={script}
       service={service}
@@ -160,45 +162,42 @@ export const renderEpisodes = ({
     >
       <EpisodeList script={script} service={service} dir={dir}>
         {episodes.map(episode => (
-          <EpisodeList.Link key={episode.id} href={episode.url}>
-            <EpisodeList.Episode>
-              {/* eslint-disable-next-line jsx-a11y/aria-role */}
-              <span role="text">
-                <VisuallyHiddenText>Audio, </VisuallyHiddenText>
-                <EpisodeList.Title className="underlined_hover fade_visited">
-                  {episode.brandTitle}
-                </EpisodeList.Title>
-                <VisuallyHiddenText>, </VisuallyHiddenText>
-                <EpisodeList.Description className="underlined_hover fade_visited">
-                  {episode.episodeTitle || `${episode.date}, ${episode.time}`}
-                </EpisodeList.Description>
-                <VisuallyHiddenText>, </VisuallyHiddenText>
-                <VisuallyHiddenText>
+          <EpisodeList.Episode>
+            <EpisodeList.Link key={episode.id} href={episode.url}>
+              <VisuallyHiddenText>Audio, </VisuallyHiddenText>
+              <EpisodeList.Title className="underlined_hover fade_visited">
+                {episode.brandTitle}
+              </EpisodeList.Title>
+              <VisuallyHiddenText>, </VisuallyHiddenText>
+              <EpisodeList.Description className="underlined_hover fade_visited">
+                {episode.episodeTitle || `${episode.date}, ${episode.time}`}
+              </EpisodeList.Description>
+              <VisuallyHiddenText>, </VisuallyHiddenText>
+              <VisuallyHiddenText>
+                {` ${episode.durationLabel} ${formatDuration({
+                  duration: episode.duration,
+                  format: episode.duration.includes('H') ? 'h,mm,ss' : 'mm,ss',
+                  locale: episode.locale,
+                })} `}
+              </VisuallyHiddenText>
+              <EpisodeList.Metadata>
+                <span aria-hidden="true">
                   {` ${episode.durationLabel} ${formatDuration({
                     duration: episode.duration,
-                    format: episode.duration.includes('H')
-                      ? 'h,mm,ss'
-                      : 'mm,ss',
                     locale: episode.locale,
-                  })} `}
-                </VisuallyHiddenText>
-                <EpisodeList.Metadata>
-                  <span aria-hidden="true">
-                    {` ${episode.durationLabel} ${formatDuration({
-                      duration: episode.duration,
-                      locale: episode.locale,
-                    })}`}
+                  })}`}
+                </span>
+              </EpisodeList.Metadata>
+              <EpisodeList.Metadata>
+                {episode.episodeTitle && (
+                  <span aria-hidden>
+                    {' '}
+                    <StyledSpan>|</StyledSpan> {episode.date}
                   </span>
-                  {episode.episodeTitle && (
-                    <span aria-hidden>
-                      {' '}
-                      <StyledSpan>|</StyledSpan> {episode.date}
-                    </span>
-                  )}
-                </EpisodeList.Metadata>
-              </span>
-            </EpisodeList.Episode>
-          </EpisodeList.Link>
+                )}
+              </EpisodeList.Metadata>
+            </EpisodeList.Link>
+          </EpisodeList.Episode>
         ))}
       </EpisodeList>
     </Wrapper>
@@ -227,27 +226,40 @@ export const renderVideoEpisodes = ({
         darkMode={darkMode}
       >
         {episodes.map(episode => (
-          <EpisodeList.Link key={episode.id} href={episode.url}>
-            <EpisodeList.Episode>
-              <EpisodeList.Image
-                src={episode.image}
-                alt={episode.altText}
-                duration={formatDuration({
-                  duration: episode.duration,
-                  locale: episode.locale,
-                })}
-              />
+          <EpisodeList.Episode>
+            <EpisodeList.Image
+              src={episode.image}
+              alt={episode.altText}
+              duration={formatDuration({
+                duration: episode.duration,
+                locale: episode.locale,
+              })}
+            />
+            <VisuallyHiddenText>Video, </VisuallyHiddenText>
+            <EpisodeList.Link key={episode.id} href={episode.url}>
               <EpisodeList.Title className="underlined_hover fade_visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
               <EpisodeList.Description className="underlined_hover fade_visited">
                 {episode.episodeTitle || episode.date}
               </EpisodeList.Description>
-              {episode.episodeTitle && (
-                <EpisodeList.Metadata>{episode.date}</EpisodeList.Metadata>
-              )}
-            </EpisodeList.Episode>
-          </EpisodeList.Link>
+              <VisuallyHiddenText>, </VisuallyHiddenText>
+              <VisuallyHiddenText>
+                {` ${episode.durationLabel} ${formatDuration({
+                  duration: episode.duration,
+                  format: episode.duration.includes('H') ? 'h,mm,ss' : 'mm,ss',
+                  locale: episode.locale,
+                })} `}
+              </VisuallyHiddenText>
+            </EpisodeList.Link>
+            {episode.episodeTitle && (
+              <span role="text">
+                <EpisodeList.Metadata as="time">
+                  {episode.date}
+                </EpisodeList.Metadata>
+              </span>
+            )}
+          </EpisodeList.Episode>
         ))}
       </EpisodeList>
     </Wrapper>

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -49,11 +49,6 @@ const rtlEpisode = {
   locale: 'ar',
 };
 
-const StyledSpan = styled.span`
-  padding-left: 8px;
-  padding-right: 8px;
-`;
-
 export const rtlEpisodes = [
   {
     id: '1',
@@ -71,6 +66,23 @@ export const rtlEpisodes = [
     ...rtlEpisode,
   },
 ];
+
+export const exampleVideoEpisodes = exampleEpisodes.map(episode => ({
+  ...episode,
+  image: 'https://ichef.bbci.co.uk/images/ic/768x432/p08b22y1.png',
+  altText: 'BBC News Afrique',
+}));
+
+export const exampleRtlVideoEpisodes = rtlEpisodes.map(episode => ({
+  ...episode,
+  image: 'https://ichef.bbci.co.uk/images/ic/768x432/p08b22y1.png',
+  altText: 'BBC News Afrique',
+}));
+
+const StyledSpan = styled.span`
+  padding-left: 8px;
+  padding-right: 8px;
+`;
 
 export const renderEpisodes = (episodes, script, service, dir) => (
   <EpisodeList script={script} service={service} dir={dir}>
@@ -110,6 +122,34 @@ export const renderEpisodes = (episodes, script, service, dir) => (
               )}
             </EpisodeList.Metadata>
           </span>
+        </EpisodeList.Episode>
+      </EpisodeList.Link>
+    ))}
+  </EpisodeList>
+);
+
+export const renderVideoEpisodes = (episodes, script, service, dir) => (
+  <EpisodeList script={script} service={service} dir={dir}>
+    {episodes.map(episode => (
+      <EpisodeList.Link key={episode.id} href={episode.url}>
+        <EpisodeList.Episode>
+          <EpisodeList.Image
+            src={episode.image}
+            alt={episode.altText}
+            duration={formatDuration({
+              duration: episode.duration,
+              locale: episode.locale,
+            })}
+          />
+          <EpisodeList.Title className="underlined_hover">
+            {episode.brandTitle}
+          </EpisodeList.Title>
+          <EpisodeList.Description className="underlined_hover">
+            {episode.episodeTitle || episode.date}
+          </EpisodeList.Description>
+          {episode.episodeTitle && (
+            <EpisodeList.Metadata>{episode.date}</EpisodeList.Metadata>
+          )}
         </EpisodeList.Episode>
       </EpisodeList.Link>
     ))}

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -119,6 +119,8 @@ const StyledSectionLabel = styled(SectionLabel)`
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     margin-bottom: ${GEL_SPACING_TRPL};
   }
+
+  /* TODO: this is a temporary workaround until SectionLabel package is updated to support dark mode */
   ${({ darkMode }) =>
     darkMode &&
     `[class*='Title'] {

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -1,8 +1,20 @@
+/* eslint-disable react/prop-types */
 // This provides fixture data and helper functions that are useful to both storybook and unit tests
 import React from 'react';
 import styled from '@emotion/styled';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { formatDuration } from '@bbc/psammead-timestamp-container/utilities';
+import SectionLabel from '@bbc/psammead-section-label';
+import { C_MIDNIGHT_BLACK } from '@bbc/psammead-styles/colours';
+import {
+  GEL_SPACING,
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+} from '@bbc/gel-foundations/spacings';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 import EpisodeList from '.';
 
 export const exampleEpisodes = [
@@ -84,74 +96,157 @@ const StyledSpan = styled.span`
   padding-right: 8px;
 `;
 
-export const renderEpisodes = (episodes, script, service, dir) => (
-  <EpisodeList script={script} service={service} dir={dir}>
-    {episodes.map(episode => (
-      <EpisodeList.Link key={episode.id} href={episode.url}>
-        <EpisodeList.Episode>
-          {/* eslint-disable-next-line jsx-a11y/aria-role */}
-          <span role="text">
-            <VisuallyHiddenText>Audio, </VisuallyHiddenText>
-            <EpisodeList.Title className="underlined_hover">
-              {episode.brandTitle}
-            </EpisodeList.Title>
-            <VisuallyHiddenText>, </VisuallyHiddenText>
-            <EpisodeList.Description className="underlined_hover">
-              {episode.episodeTitle || `${episode.date}, ${episode.time}`}
-            </EpisodeList.Description>
-            <VisuallyHiddenText>, </VisuallyHiddenText>
-            <VisuallyHiddenText>
-              {` ${episode.durationLabel} ${formatDuration({
-                duration: episode.duration,
-                format: episode.duration.includes('H') ? 'h,mm,ss' : 'mm,ss',
-                locale: episode.locale,
-              })} `}
-            </VisuallyHiddenText>
-            <EpisodeList.Metadata>
-              <span aria-hidden="true">
-                {` ${episode.durationLabel} ${formatDuration({
-                  duration: episode.duration,
-                  locale: episode.locale,
-                })}`}
-              </span>
-              {episode.episodeTitle && (
-                <span aria-hidden>
-                  {' '}
-                  <StyledSpan>|</StyledSpan> {episode.date}
-                </span>
-              )}
-            </EpisodeList.Metadata>
-          </span>
-        </EpisodeList.Episode>
-      </EpisodeList.Link>
-    ))}
-  </EpisodeList>
+const Spacer = styled.div`
+  background: ${({ darkMode }) => (darkMode ? C_MIDNIGHT_BLACK : 'unset')};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  padding: 0 ${GEL_SPACING};
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    padding: 0 ${GEL_SPACING_DBL};
+  }
+`;
+const StyledSectionLabel = styled(SectionLabel)`
+  margin-bottom: 0;
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    margin-bottom: ${GEL_SPACING_DBL};
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    margin-bottom: ${GEL_SPACING_TRPL};
+  }
+  ${({ darkMode }) =>
+    darkMode &&
+    `[class*='Title'] {
+    background: ${C_MIDNIGHT_BLACK};
+    color: white;
+  }`}
+`;
+
+const SurroundingComponents = ({
+  children,
+  script,
+  service,
+  dir,
+  darkMode,
+}) => (
+  <Spacer darkMode={darkMode}>
+    <StyledSectionLabel
+      script={script}
+      service={service}
+      dir={dir}
+      darkMode={darkMode}
+    >
+      Recent Episodes
+    </StyledSectionLabel>
+    {children}
+  </Spacer>
 );
 
-export const renderVideoEpisodes = (episodes, script, service, dir) => (
-  <EpisodeList script={script} service={service} dir={dir}>
-    {episodes.map(episode => (
-      <EpisodeList.Link key={episode.id} href={episode.url}>
-        <EpisodeList.Episode>
-          <EpisodeList.Image
-            src={episode.image}
-            alt={episode.altText}
-            duration={formatDuration({
-              duration: episode.duration,
-              locale: episode.locale,
-            })}
-          />
-          <EpisodeList.Title className="underlined_hover">
-            {episode.brandTitle}
-          </EpisodeList.Title>
-          <EpisodeList.Description className="underlined_hover">
-            {episode.episodeTitle || episode.date}
-          </EpisodeList.Description>
-          {episode.episodeTitle && (
-            <EpisodeList.Metadata>{episode.date}</EpisodeList.Metadata>
-          )}
-        </EpisodeList.Episode>
-      </EpisodeList.Link>
-    ))}
-  </EpisodeList>
-);
+export const renderEpisodes = ({
+  episodes,
+  script,
+  service,
+  dir,
+  withSurroundingComponents,
+  darkMode,
+}) => {
+  const Wrapper = withSurroundingComponents
+    ? SurroundingComponents
+    : React.Fragment;
+  return (
+    <Wrapper script={script} service={service} dir={dir} darkMode={darkMode}>
+      <EpisodeList script={script} service={service} dir={dir}>
+        {episodes.map(episode => (
+          <EpisodeList.Link key={episode.id} href={episode.url}>
+            <EpisodeList.Episode>
+              {/* eslint-disable-next-line jsx-a11y/aria-role */}
+              <span role="text">
+                <VisuallyHiddenText>Audio, </VisuallyHiddenText>
+                <EpisodeList.Title className="underlined_hover">
+                  {episode.brandTitle}
+                </EpisodeList.Title>
+                <VisuallyHiddenText>, </VisuallyHiddenText>
+                <EpisodeList.Description className="underlined_hover">
+                  {episode.episodeTitle || `${episode.date}, ${episode.time}`}
+                </EpisodeList.Description>
+                <VisuallyHiddenText>, </VisuallyHiddenText>
+                <VisuallyHiddenText>
+                  {` ${episode.durationLabel} ${formatDuration({
+                    duration: episode.duration,
+                    format: episode.duration.includes('H')
+                      ? 'h,mm,ss'
+                      : 'mm,ss',
+                    locale: episode.locale,
+                  })} `}
+                </VisuallyHiddenText>
+                <EpisodeList.Metadata>
+                  <span aria-hidden="true">
+                    {` ${episode.durationLabel} ${formatDuration({
+                      duration: episode.duration,
+                      locale: episode.locale,
+                    })}`}
+                  </span>
+                  {episode.episodeTitle && (
+                    <span aria-hidden>
+                      {' '}
+                      <StyledSpan>|</StyledSpan> {episode.date}
+                    </span>
+                  )}
+                </EpisodeList.Metadata>
+              </span>
+            </EpisodeList.Episode>
+          </EpisodeList.Link>
+        ))}
+      </EpisodeList>
+    </Wrapper>
+  );
+};
+
+export const renderVideoEpisodes = ({
+  episodes,
+  script,
+  service,
+  dir,
+  withSurroundingComponents,
+  darkMode,
+}) => {
+  const Wrapper = withSurroundingComponents
+    ? SurroundingComponents
+    : React.Fragment;
+  return (
+    <Wrapper script={script} service={service} dir={dir} darkMode={darkMode}>
+      <EpisodeList
+        script={script}
+        service={service}
+        dir={dir}
+        darkMode={darkMode}
+      >
+        {episodes.map(episode => (
+          <EpisodeList.Link key={episode.id} href={episode.url}>
+            <EpisodeList.Episode>
+              <EpisodeList.Image
+                src={episode.image}
+                alt={episode.altText}
+                duration={formatDuration({
+                  duration: episode.duration,
+                  locale: episode.locale,
+                })}
+              />
+              <EpisodeList.Title className="underlined_hover">
+                {episode.brandTitle}
+              </EpisodeList.Title>
+              <EpisodeList.Description className="underlined_hover">
+                {episode.episodeTitle || episode.date}
+              </EpisodeList.Description>
+              {episode.episodeTitle && (
+                <EpisodeList.Metadata>{episode.date}</EpisodeList.Metadata>
+              )}
+            </EpisodeList.Episode>
+          </EpisodeList.Link>
+        ))}
+      </EpisodeList>
+    </Wrapper>
+  );
+};

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -191,10 +191,10 @@ export const renderEpisodes = ({
             </EpisodeList.Link>
             <EpisodeList.Metadata>
               {episode.episodeTitle && (
-                <span aria-hidden>
+                <>
                   {' '}
-                  <StyledSpan>|</StyledSpan> {episode.date}
-                </span>
+                  <StyledSpan aria-hidden>|</StyledSpan> {episode.date}
+                </>
               )}
             </EpisodeList.Metadata>
           </EpisodeList.Episode>

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -30,7 +30,7 @@ export const exampleEpisodes = [
   },
   {
     id: '2',
-    url: 'https://www.bbc.com',
+    url: 'https://www.bbc.com/1',
     brandTitle: 'Le Journal',
     episodeTitle: "Le premier rendez-vous d'information de la soirée.",
     date: '20 octobre 2020',
@@ -41,7 +41,7 @@ export const exampleEpisodes = [
   },
   {
     id: '3',
-    url: 'https://www.bbc.com/blah',
+    url: 'https://www.bbc.com/2',
     brandTitle: 'Afrique Avenir',
     episodeTitle: 'Tout savoir sur les jeunes entrepreneurs africains.',
     date: '21 octobre 2020',
@@ -55,7 +55,6 @@ export const exampleEpisodes = [
 const rtlEpisode = {
   brandTitle: 'یونیورسٹی کی اندھیری',
   date: 'بی بی سی اردو ڈاٹ کام، کرا',
-  duration: 'PT3H29M',
   durationLabel: 'المدة',
   time: 'ریشان',
   locale: 'ar',
@@ -65,16 +64,20 @@ export const rtlEpisodes = [
   {
     id: '1',
     url: 'https://www.bbc.com',
+    duration: 'PT3M',
+    episodeTitle: 'بی بی سی ا یونیورسٹی ردو',
     ...rtlEpisode,
   },
   {
     id: '2',
-    url: 'https://www.bbc.com',
+    url: 'https://www.bbc.com/a',
+    duration: 'PT1H30M',
     ...rtlEpisode,
   },
   {
     id: '3',
-    url: 'https://www.bbc.com/blah',
+    url: 'https://www.bbc.com/b',
+    duration: 'PT59M',
     ...rtlEpisode,
   },
 ];
@@ -164,11 +167,11 @@ export const renderEpisodes = ({
               {/* eslint-disable-next-line jsx-a11y/aria-role */}
               <span role="text">
                 <VisuallyHiddenText>Audio, </VisuallyHiddenText>
-                <EpisodeList.Title className="underlined_hover">
+                <EpisodeList.Title className="underlined_hover fade_visited">
                   {episode.brandTitle}
                 </EpisodeList.Title>
                 <VisuallyHiddenText>, </VisuallyHiddenText>
-                <EpisodeList.Description className="underlined_hover">
+                <EpisodeList.Description className="underlined_hover fade_visited">
                   {episode.episodeTitle || `${episode.date}, ${episode.time}`}
                 </EpisodeList.Description>
                 <VisuallyHiddenText>, </VisuallyHiddenText>
@@ -234,10 +237,10 @@ export const renderVideoEpisodes = ({
                   locale: episode.locale,
                 })}
               />
-              <EpisodeList.Title className="underlined_hover">
+              <EpisodeList.Title className="underlined_hover fade_visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
-              <EpisodeList.Description className="underlined_hover">
+              <EpisodeList.Description className="underlined_hover fade_visited">
                 {episode.episodeTitle || episode.date}
               </EpisodeList.Description>
               {episode.episodeTitle && (

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { formatDuration } from '@bbc/psammead-timestamp-container/utilities';
 import SectionLabel from '@bbc/psammead-section-label';
-import { C_MIDNIGHT_BLACK } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_MIDNIGHT_BLACK } from '@bbc/psammead-styles/colours';
 import {
   GEL_SPACING,
   GEL_SPACING_DBL,
@@ -119,14 +119,7 @@ const StyledSectionLabel = styled(SectionLabel)`
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     margin-bottom: ${GEL_SPACING_TRPL};
   }
-
-  /* TODO: this is a temporary workaround until SectionLabel package is updated to support dark mode */
-  ${({ darkMode }) =>
-    darkMode &&
-    `[class*='Title'] {
-    background: ${C_MIDNIGHT_BLACK};
-    color: white;
-  }`}
+  ${({ darkMode }) => darkMode && `color: ${C_WHITE}`}
 `;
 
 const SurroundingComponents = ({
@@ -142,6 +135,7 @@ const SurroundingComponents = ({
       service={service}
       dir={dir}
       darkMode={darkMode}
+      {...(darkMode ? { backgroundColor: C_MIDNIGHT_BLACK } : {})}
     >
       Recent Episodes
     </StyledSectionLabel>

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -165,11 +165,11 @@ export const renderEpisodes = ({
           <EpisodeList.Episode key={episode.id}>
             <EpisodeList.Link href={episode.url}>
               <VisuallyHiddenText>Audio, </VisuallyHiddenText>
-              <EpisodeList.Title className="underlined_hover fade_visited">
+              <EpisodeList.Title className="episode-list__title--hover episode-list__title--visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
               <VisuallyHiddenText>, </VisuallyHiddenText>
-              <EpisodeList.Description className="underlined_hover fade_visited">
+              <EpisodeList.Description className="episode-list__description--hover episode-list__description--visited">
                 {episode.episodeTitle || `${episode.date}, ${episode.time}`}
               </EpisodeList.Description>
               <VisuallyHiddenText>, </VisuallyHiddenText>
@@ -237,10 +237,10 @@ export const renderVideoEpisodes = ({
             />
             <VisuallyHiddenText>Video, </VisuallyHiddenText>
             <EpisodeList.Link href={episode.url}>
-              <EpisodeList.Title className="underlined_hover fade_visited">
+              <EpisodeList.Title className="episode-list__title--hover episode-list__title--visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
-              <EpisodeList.Description className="underlined_hover fade_visited">
+              <EpisodeList.Description className="episode-list__description--hover episode-list__description--visited">
                 {episode.episodeTitle || episode.date}
               </EpisodeList.Description>
               <VisuallyHiddenText>, </VisuallyHiddenText>

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -162,8 +162,8 @@ export const renderEpisodes = ({
     >
       <EpisodeList script={script} service={service} dir={dir}>
         {episodes.map(episode => (
-          <EpisodeList.Episode>
-            <EpisodeList.Link key={episode.id} href={episode.url}>
+          <EpisodeList.Episode key={episode.id}>
+            <EpisodeList.Link href={episode.url}>
               <VisuallyHiddenText>Audio, </VisuallyHiddenText>
               <EpisodeList.Title className="underlined_hover fade_visited">
                 {episode.brandTitle}
@@ -226,7 +226,7 @@ export const renderVideoEpisodes = ({
         darkMode={darkMode}
       >
         {episodes.map(episode => (
-          <EpisodeList.Episode>
+          <EpisodeList.Episode key={episode.id}>
             <EpisodeList.Image
               src={episode.image}
               alt={episode.altText}
@@ -236,7 +236,7 @@ export const renderVideoEpisodes = ({
               })}
             />
             <VisuallyHiddenText>Video, </VisuallyHiddenText>
-            <EpisodeList.Link key={episode.id} href={episode.url}>
+            <EpisodeList.Link href={episode.url}>
               <EpisodeList.Title className="underlined_hover fade_visited">
                 {episode.brandTitle}
               </EpisodeList.Title>

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -158,10 +158,10 @@ export const renderEpisodes = ({
   darkMode,
 }) => {
   const Wrapper = withSurroundingComponents
-    ? SurroundingComponents
-    : React.Fragment;
+    ? () => <SurroundingComponents {...{ script, service, dir, darkMode }} />
+    : 'div';
   return (
-    <Wrapper script={script} service={service} dir={dir} darkMode={darkMode}>
+    <Wrapper>
       <EpisodeList script={script} service={service} dir={dir}>
         {episodes.map(episode => (
           <EpisodeList.Link key={episode.id} href={episode.url}>
@@ -218,10 +218,10 @@ export const renderVideoEpisodes = ({
   darkMode,
 }) => {
   const Wrapper = withSurroundingComponents
-    ? SurroundingComponents
-    : React.Fragment;
+    ? () => <SurroundingComponents {...{ script, service, dir, darkMode }} />
+    : 'div';
   return (
-    <Wrapper script={script} service={service} dir={dir} darkMode={darkMode}>
+    <Wrapper>
       <EpisodeList
         script={script}
         service={service}

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -158,10 +158,12 @@ export const renderEpisodes = ({
   darkMode,
 }) => {
   const Wrapper = withSurroundingComponents
-    ? () => <SurroundingComponents {...{ script, service, dir, darkMode }} />
-    : 'div';
+    ? SurroundingComponents
+    : React.Fragment;
   return (
-    <Wrapper>
+    <Wrapper
+      {...(withSurroundingComponents ? { script, service, dir, darkMode } : {})}
+    >
       <EpisodeList script={script} service={service} dir={dir}>
         {episodes.map(episode => (
           <EpisodeList.Link key={episode.id} href={episode.url}>
@@ -218,10 +220,12 @@ export const renderVideoEpisodes = ({
   darkMode,
 }) => {
   const Wrapper = withSurroundingComponents
-    ? () => <SurroundingComponents {...{ script, service, dir, darkMode }} />
-    : 'div';
+    ? SurroundingComponents
+    : React.Fragment;
   return (
-    <Wrapper>
+    <Wrapper
+      {...(withSurroundingComponents ? { script, service, dir, darkMode } : {})}
+    >
       <EpisodeList
         script={script}
         service={service}

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -188,15 +188,15 @@ export const renderEpisodes = ({
                   })}`}
                 </span>
               </EpisodeList.Metadata>
-              <EpisodeList.Metadata>
-                {episode.episodeTitle && (
-                  <span aria-hidden>
-                    {' '}
-                    <StyledSpan>|</StyledSpan> {episode.date}
-                  </span>
-                )}
-              </EpisodeList.Metadata>
             </EpisodeList.Link>
+            <EpisodeList.Metadata>
+              {episode.episodeTitle && (
+                <span aria-hidden>
+                  {' '}
+                  <StyledSpan>|</StyledSpan> {episode.date}
+                </span>
+              )}
+            </EpisodeList.Metadata>
           </EpisodeList.Episode>
         ))}
       </EpisodeList>

--- a/packages/components/psammead-episode-list/src/helpers.jsx
+++ b/packages/components/psammead-episode-list/src/helpers.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 // Used to make service, script and dir passed to <EpisodeList> available to children
-export const LocalityContext = React.createContext({});
-export const withEpisodeLocality = Component => props => (
-  <LocalityContext.Consumer>
-    {locality => <Component {...locality} {...props} />}
-  </LocalityContext.Consumer>
+export const EpisodeContext = React.createContext({});
+export const withEpisodeContext = Component => props => (
+  <EpisodeContext.Consumer>
+    {context => <Component {...context} {...props} />}
+  </EpisodeContext.Consumer>
 );

--- a/packages/components/psammead-episode-list/src/helpers.jsx
+++ b/packages/components/psammead-episode-list/src/helpers.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+// Used to make service, script and dir passed to <EpisodeList> available to children
+export const LocalityContext = React.createContext({});
+export const withEpisodeLocality = Component => props => (
+  <LocalityContext.Consumer>
+    {locality => <Component {...locality} {...props} />}
+  </LocalityContext.Consumer>
+);

--- a/packages/components/psammead-episode-list/src/helpers.jsx
+++ b/packages/components/psammead-episode-list/src/helpers.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-// Used to make service, script and dir passed to <EpisodeList> available to children
+// Used to make props passed to <EpisodeList> available to children
 export const EpisodeContext = React.createContext({});
 export const withEpisodeContext = Component => props => (
   <EpisodeContext.Consumer>

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -20,27 +20,15 @@ const StyledEpisodeList = styled.ul`
 const StyledEpisodeListItem = styled.li`
   padding: ${GEL_SPACING_DBL} 0;
   &:first-child {
-    padding-top: ${GEL_SPACING_DBL};
+    padding-top: 0;
   }
   &:last-child {
-    padding-bottom: ${GEL_SPACING_DBL};
+    padding-bottom: 0;
   }
   &:not(:last-child) {
     border-bottom: 1px ${C_CLOUD_LIGHT} solid;
   }
 `;
-
-const StyledSingleEpisode = styled.div`
-  padding: ${GEL_SPACING_DBL} 0;
-`;
-
-// Used to make service, script and dir passed to <EpisodeList> available to children
-const LocalityContext = React.createContext({});
-const withEpisodeLocality = Component => props => (
-  <LocalityContext.Consumer>
-    {locality => <Component {...locality} {...props} />}
-  </LocalityContext.Consumer>
-);
 
 const EpisodeList = ({ children, script, service, dir }) => {
   if (!children.length) return null;
@@ -58,7 +46,7 @@ const EpisodeList = ({ children, script, service, dir }) => {
           ))}
         </StyledEpisodeList>
       ) : (
-        <StyledSingleEpisode>{children}</StyledSingleEpisode>
+        { children }
       )}
     </LocalityContext.Provider>
   );

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -12,6 +12,7 @@ import Title from './Title';
 import Description from './Description';
 import Metadata from './Metadata';
 import Image from './Image';
+import MediaIndicator from './MediaIndicator';
 
 const StyledEpisodeList = styled.ul`
   list-style: none;
@@ -21,6 +22,7 @@ const StyledEpisodeList = styled.ul`
 
 const StyledEpisodeListItem = styled.li`
   padding: ${GEL_SPACING_DBL} 0;
+  line-height: 0;
   &:first-child {
     padding-top: 0;
   }
@@ -73,6 +75,7 @@ EpisodeList.Episode = withEpisodeContext(Episode);
 EpisodeList.Link = withEpisodeContext(Link);
 EpisodeList.Title = withEpisodeContext(Title);
 EpisodeList.Image = Image;
+EpisodeList.MediaIndicator = MediaIndicator;
 EpisodeList.Description = withEpisodeContext(Description);
 EpisodeList.Metadata = withEpisodeContext(Metadata);
 

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -11,6 +11,7 @@ import Link from './Link';
 import Title from './Title';
 import Description from './Description';
 import Metadata from './Metadata';
+import Image from './Image';
 
 const StyledEpisodeList = styled.ul`
   list-style: none;
@@ -69,6 +70,7 @@ EpisodeList.defaultProps = {
 EpisodeList.Episode = withEpisodeLocality(Episode);
 EpisodeList.Link = Link;
 EpisodeList.Title = withEpisodeLocality(Title);
+EpisodeList.Image = Image;
 EpisodeList.Description = withEpisodeLocality(Description);
 EpisodeList.Metadata = withEpisodeLocality(Metadata);
 

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -5,7 +5,7 @@ import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { string, shape, arrayOf, oneOf, element, bool } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
-import { LocalityContext, withEpisodeLocality } from './helpers';
+import { EpisodeContext, withEpisodeContext } from './helpers';
 import Episode from './Episode';
 import Link from './Link';
 import Title from './Title';
@@ -38,7 +38,7 @@ const EpisodeList = ({ children, script, service, dir, darkMode }) => {
   const hasMultipleChildren = children.length > 1;
 
   return (
-    <LocalityContext.Provider value={{ script, service, dir, darkMode }}>
+    <EpisodeContext.Provider value={{ script, service, dir, darkMode }}>
       {hasMultipleChildren ? (
         <StyledEpisodeList role="list">
           {children.map(child => (
@@ -50,7 +50,7 @@ const EpisodeList = ({ children, script, service, dir, darkMode }) => {
       ) : (
         children
       )}
-    </LocalityContext.Provider>
+    </EpisodeContext.Provider>
   );
 };
 
@@ -69,11 +69,11 @@ EpisodeList.defaultProps = {
 };
 
 // This module also has a range of supplemental components to provide consumers with some compositational control
-EpisodeList.Episode = withEpisodeLocality(Episode);
-EpisodeList.Link = withEpisodeLocality(Link);
-EpisodeList.Title = withEpisodeLocality(Title);
+EpisodeList.Episode = withEpisodeContext(Episode);
+EpisodeList.Link = withEpisodeContext(Link);
+EpisodeList.Title = withEpisodeContext(Title);
 EpisodeList.Image = Image;
-EpisodeList.Description = withEpisodeLocality(Description);
-EpisodeList.Metadata = withEpisodeLocality(Metadata);
+EpisodeList.Description = withEpisodeContext(Description);
+EpisodeList.Metadata = withEpisodeContext(Metadata);
 
 export default EpisodeList;

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -70,7 +70,6 @@ EpisodeList.defaultProps = {
   darkMode: false,
 };
 
-// This module also has a range of supplemental components to provide consumers with some compositational control
 EpisodeList.Episode = withEpisodeContext(Episode);
 EpisodeList.Link = withEpisodeContext(Link);
 EpisodeList.Title = withEpisodeContext(Title);

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { C_CLOUD_LIGHT } from '@bbc/psammead-styles/colours';
 import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
-import { string, shape, arrayOf, oneOf, element } from 'prop-types';
+import { string, shape, arrayOf, oneOf, element, bool } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
 import { LocalityContext, withEpisodeLocality } from './helpers';
@@ -32,13 +32,13 @@ const StyledEpisodeListItem = styled.li`
   }
 `;
 
-const EpisodeList = ({ children, script, service, dir }) => {
+const EpisodeList = ({ children, script, service, dir, darkMode }) => {
   if (!children.length) return null;
 
   const hasMultipleChildren = children.length > 1;
 
   return (
-    <LocalityContext.Provider value={{ script, service, dir }}>
+    <LocalityContext.Provider value={{ script, service, dir, darkMode }}>
       {hasMultipleChildren ? (
         <StyledEpisodeList role="list">
           {children.map(child => (
@@ -48,7 +48,7 @@ const EpisodeList = ({ children, script, service, dir }) => {
           ))}
         </StyledEpisodeList>
       ) : (
-        { children }
+        children
       )}
     </LocalityContext.Provider>
   );
@@ -59,16 +59,18 @@ EpisodeList.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   dir: oneOf(['ltr', 'rtl']),
+  darkMode: bool,
 };
 
 EpisodeList.defaultProps = {
   children: [],
   dir: 'ltr',
+  darkMode: false,
 };
 
 // This module also has a range of supplemental components to provide consumers with some compositational control
 EpisodeList.Episode = withEpisodeLocality(Episode);
-EpisodeList.Link = Link;
+EpisodeList.Link = withEpisodeLocality(Link);
 EpisodeList.Title = withEpisodeLocality(Title);
 EpisodeList.Image = Image;
 EpisodeList.Description = withEpisodeLocality(Description);

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -5,6 +5,7 @@ import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { string, shape, arrayOf, oneOf, element } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
+import { LocalityContext, withEpisodeLocality } from './helpers';
 import Episode from './Episode';
 import Link from './Link';
 import Title from './Title';

--- a/packages/components/psammead-episode-list/src/index.stories.jsx
+++ b/packages/components/psammead-episode-list/src/index.stories.jsx
@@ -1,19 +1,6 @@
-import React from 'react';
-import styled from '@emotion/styled';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
-import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
-import SectionLabel from '@bbc/psammead-section-label';
-import {
-  GEL_SPACING_HLF,
-  GEL_SPACING,
-  GEL_SPACING_DBL,
-  GEL_SPACING_TRPL,
-} from '@bbc/gel-foundations/spacings';
-import {
-  GEL_GROUP_2_SCREEN_WIDTH_MIN,
-  GEL_GROUP_3_SCREEN_WIDTH_MIN,
-} from '@bbc/gel-foundations/breakpoints';
+import { withServicesKnob, themes } from '@bbc/psammead-storybook-helpers';
 
 import {
   renderEpisodes,
@@ -28,71 +15,71 @@ storiesOf('Components/EpisodeList', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
   .add('default', ({ script, service, dir }) =>
-    renderEpisodes(
-      dir === 'rtl' ? rtlEpisodes : exampleEpisodes,
+    renderEpisodes({
+      episodes: dir === 'rtl' ? rtlEpisodes : exampleEpisodes,
       script,
       service,
       dir,
-    ),
+    }),
   )
   .add('with single episode', ({ script, service, dir }) =>
-    renderEpisodes(
-      dir === 'rtl' ? [rtlEpisodes[0]] : [exampleEpisodes[0]],
+    renderEpisodes({
+      episodes: dir === 'rtl' ? [rtlEpisodes[0]] : [exampleEpisodes[0]],
       script,
       service,
       dir,
-    ),
+    }),
   )
   .add('with no episodes', ({ script, service, dir }) =>
-    renderEpisodes([], script, service, dir),
+    renderEpisodes({ episodes: [], script, service, dir }),
   )
   .add('with video episodes', ({ script, service, dir }) =>
-    renderVideoEpisodes(
-      dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
+    renderVideoEpisodes({
+      episodes: dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
       script,
       service,
       dir,
-    ),
+    }),
   )
   .add('with single video episode', ({ script, service, dir }) =>
-    renderVideoEpisodes(
-      dir === 'rtl' ? [exampleRtlVideoEpisodes[0]] : [exampleVideoEpisodes[0]],
+    renderVideoEpisodes({
+      episodes:
+        dir === 'rtl'
+          ? [exampleRtlVideoEpisodes[0]]
+          : [exampleVideoEpisodes[0]],
       script,
       service,
       dir,
-    ),
+    }),
   )
   .add('with no video episodes', ({ script, service, dir }) =>
-    renderVideoEpisodes([], script, service, dir),
+    renderVideoEpisodes({ episodes: [], script, service, dir }),
   )
   .add('with surrounding components', ({ script, service, dir }) => {
-    const Spacer = styled.div`
-      margin: 0 ${GEL_SPACING};
-      @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-        margin: 0 ${GEL_SPACING_DBL};
-      }
-    `;
-    const StyledSectionLabel = styled(SectionLabel)`
-      margin-bottom: 0;
-      @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-        margin-bottom: ${GEL_SPACING_DBL};
-      }
-      @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-        margin-bottom: ${GEL_SPACING_TRPL};
-      }
-    `;
-
-    return (
-      <Spacer>
-        <StyledSectionLabel script={script} service={service} dir={dir}>
-          Recent Episodes
-        </StyledSectionLabel>
-        {renderVideoEpisodes(
+    return renderVideoEpisodes({
+      episodes: dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
+      script,
+      service,
+      dir,
+      withSurroundingComponents: true,
+    });
+  })
+  .add(
+    'with surrounding components (dark)',
+    ({ script, service, dir }) => {
+      return renderVideoEpisodes({
+        episodes:
           dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
-          script,
-          service,
-          dir,
-        )}
-      </Spacer>
-    );
-  });
+        script,
+        service,
+        dir,
+        withSurroundingComponents: true,
+        darkMode: true,
+      });
+    },
+    {
+      options: {
+        theme: themes.dark,
+      },
+    },
+  );

--- a/packages/components/psammead-episode-list/src/index.stories.jsx
+++ b/packages/components/psammead-episode-list/src/index.stories.jsx
@@ -2,7 +2,14 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 
-import { renderEpisodes, exampleEpisodes, rtlEpisodes } from './fixtures';
+import {
+  renderEpisodes,
+  renderVideoEpisodes,
+  exampleEpisodes,
+  rtlEpisodes,
+  exampleVideoEpisodes,
+  exampleRtlVideoEpisodes,
+} from './fixtures';
 
 storiesOf('Components/EpisodeList', module)
   .addDecorator(withKnobs)
@@ -25,4 +32,23 @@ storiesOf('Components/EpisodeList', module)
   )
   .add('with no episodes', ({ script, service, dir }) =>
     renderEpisodes([], script, service, dir),
+  )
+  .add('with video episodes', ({ script, service, dir }) =>
+    renderVideoEpisodes(
+      dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
+      script,
+      service,
+      dir,
+    ),
+  )
+  .add('with single video episode', ({ script, service, dir }) =>
+    renderVideoEpisodes(
+      dir === 'rtl' ? [exampleRtlVideoEpisodes[0]] : [exampleVideoEpisodes[0]],
+      script,
+      service,
+      dir,
+    ),
+  )
+  .add('with no video episodes', ({ script, service, dir }) =>
+    renderVideoEpisodes([], script, service, dir),
   );

--- a/packages/components/psammead-episode-list/src/index.stories.jsx
+++ b/packages/components/psammead-episode-list/src/index.stories.jsx
@@ -1,6 +1,19 @@
+import React from 'react';
+import styled from '@emotion/styled';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import SectionLabel from '@bbc/psammead-section-label';
+import {
+  GEL_SPACING_HLF,
+  GEL_SPACING,
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+} from '@bbc/gel-foundations/spacings';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 
 import {
   renderEpisodes,
@@ -51,4 +64,35 @@ storiesOf('Components/EpisodeList', module)
   )
   .add('with no video episodes', ({ script, service, dir }) =>
     renderVideoEpisodes([], script, service, dir),
-  );
+  )
+  .add('with surrounding components', ({ script, service, dir }) => {
+    const Spacer = styled.div`
+      margin: 0 ${GEL_SPACING};
+      @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+        margin: 0 ${GEL_SPACING_DBL};
+      }
+    `;
+    const StyledSectionLabel = styled(SectionLabel)`
+      margin-bottom: 0;
+      @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+        margin-bottom: ${GEL_SPACING_DBL};
+      }
+      @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+        margin-bottom: ${GEL_SPACING_TRPL};
+      }
+    `;
+
+    return (
+      <Spacer>
+        <StyledSectionLabel script={script} service={service} dir={dir}>
+          Recent Episodes
+        </StyledSectionLabel>
+        {renderVideoEpisodes(
+          dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
+          script,
+          service,
+          dir,
+        )}
+      </Spacer>
+    );
+  });

--- a/packages/components/psammead-episode-list/src/index.stories.jsx
+++ b/packages/components/psammead-episode-list/src/index.stories.jsx
@@ -14,7 +14,7 @@ import {
 storiesOf('Components/EpisodeList', module)
   .addDecorator(withKnobs)
   .addDecorator(withServicesKnob())
-  .add('default', ({ script, service, dir }) =>
+  .add('audio', ({ script, service, dir }) =>
     renderEpisodes({
       episodes: dir === 'rtl' ? rtlEpisodes : exampleEpisodes,
       script,
@@ -22,7 +22,7 @@ storiesOf('Components/EpisodeList', module)
       dir,
     }),
   )
-  .add('with single episode', ({ script, service, dir }) =>
+  .add('audio - single episode', ({ script, service, dir }) =>
     renderEpisodes({
       episodes: dir === 'rtl' ? [rtlEpisodes[0]] : [exampleEpisodes[0]],
       script,
@@ -30,10 +30,16 @@ storiesOf('Components/EpisodeList', module)
       dir,
     }),
   )
-  .add('with no episodes', ({ script, service, dir }) =>
-    renderEpisodes({ episodes: [], script, service, dir }),
-  )
-  .add('with video episodes', ({ script, service, dir }) =>
+  .add('audio - with surrounding components', ({ script, service, dir }) => {
+    return renderEpisodes({
+      episodes: dir === 'rtl' ? rtlEpisodes : exampleEpisodes,
+      script,
+      service,
+      dir,
+      withSurroundingComponents: true,
+    });
+  })
+  .add('video', ({ script, service, dir }) =>
     renderVideoEpisodes({
       episodes: dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
       script,
@@ -41,7 +47,7 @@ storiesOf('Components/EpisodeList', module)
       dir,
     }),
   )
-  .add('with single video episode', ({ script, service, dir }) =>
+  .add('video - single episode', ({ script, service, dir }) =>
     renderVideoEpisodes({
       episodes:
         dir === 'rtl'
@@ -52,10 +58,7 @@ storiesOf('Components/EpisodeList', module)
       dir,
     }),
   )
-  .add('with no video episodes', ({ script, service, dir }) =>
-    renderVideoEpisodes({ episodes: [], script, service, dir }),
-  )
-  .add('with surrounding components', ({ script, service, dir }) => {
+  .add('video - with surrounding components', ({ script, service, dir }) => {
     return renderVideoEpisodes({
       episodes: dir === 'rtl' ? exampleRtlVideoEpisodes : exampleVideoEpisodes,
       script,
@@ -65,7 +68,7 @@ storiesOf('Components/EpisodeList', module)
     });
   })
   .add(
-    'with surrounding components (dark)',
+    'video - with surrounding components (dark)',
     ({ script, service, dir }) => {
       return renderVideoEpisodes({
         episodes:

--- a/packages/components/psammead-episode-list/src/index.test.jsx
+++ b/packages/components/psammead-episode-list/src/index.test.jsx
@@ -3,7 +3,12 @@ import { render } from '@testing-library/react';
 import * as scripts from '@bbc/gel-foundations/scripts';
 import '@testing-library/jest-dom/extend-expect';
 
-import { renderEpisodes, exampleEpisodes } from './fixtures';
+import {
+  renderEpisodes,
+  renderVideoEpisodes,
+  exampleEpisodes,
+  exampleVideoEpisodes,
+} from './fixtures';
 
 describe('Episode List ', () => {
   it('should render the list', () => {
@@ -140,5 +145,23 @@ describe('Episode List ', () => {
 
     expect(queryByRole('list')).not.toBeInTheDocument();
     expect(queryByRole('listitem')).not.toBeInTheDocument();
+  });
+
+  it('should correctly handle images', () => {
+    const { container } = render(
+      renderVideoEpisodes({
+        episodes: [exampleVideoEpisodes[0]],
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
+    );
+
+    expect(
+      container.querySelector(`img[src='${exampleVideoEpisodes[0].image}']`),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(`img[alt='${exampleVideoEpisodes[0].altText}']`),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/components/psammead-episode-list/src/index.test.jsx
+++ b/packages/components/psammead-episode-list/src/index.test.jsx
@@ -70,10 +70,9 @@ describe('Episode List ', () => {
       }),
     );
 
-    expect(getByText('Le Journal').closest('a')).toHaveAttribute(
-      'href',
-      'https://www.bbc.com',
-    );
+    expect(
+      getByText(exampleEpisodes[0].brandTitle).closest('a'),
+    ).toHaveAttribute('href', exampleEpisodes[0].url);
   });
 
   it('should render the media indicator', () => {

--- a/packages/components/psammead-episode-list/src/index.test.jsx
+++ b/packages/components/psammead-episode-list/src/index.test.jsx
@@ -8,7 +8,12 @@ import { renderEpisodes, exampleEpisodes } from './fixtures';
 describe('Episode List ', () => {
   it('should render the list', () => {
     const { getByRole } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getByRole('list')).toBeInTheDocument();
@@ -16,7 +21,12 @@ describe('Episode List ', () => {
 
   it('should render the list item', () => {
     const { getAllByRole } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getAllByRole('listitem')[0]).toBeInTheDocument();
@@ -24,7 +34,12 @@ describe('Episode List ', () => {
 
   it('should render the brand title', () => {
     const { getByText } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getByText('Le Journal')).toBeInTheDocument();
@@ -32,7 +47,12 @@ describe('Episode List ', () => {
 
   it('should render the episode title', () => {
     const { getByText } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(
@@ -42,7 +62,12 @@ describe('Episode List ', () => {
 
   it('should render the link', () => {
     const { getByText } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getByText('Le Journal').closest('a')).toHaveAttribute(
@@ -53,7 +78,12 @@ describe('Episode List ', () => {
 
   it('should render the media indicator', () => {
     const { container } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
     const svgs = container.querySelectorAll('svg');
 
@@ -62,7 +92,12 @@ describe('Episode List ', () => {
 
   it('should render the duration', () => {
     const { getAllByText } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getAllByText('Durée 59:00')[0]).toBeInTheDocument();
@@ -70,7 +105,12 @@ describe('Episode List ', () => {
 
   it('should render the date', () => {
     const { getAllByText } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getAllByText('4 Avril 2020, 14:00')[0]);
@@ -78,7 +118,12 @@ describe('Episode List ', () => {
 
   it('should render the correct number of episodes', () => {
     const { getAllByRole } = render(
-      renderEpisodes(exampleEpisodes, scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: exampleEpisodes,
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(getAllByRole('listitem').length).toEqual(3);
@@ -86,7 +131,12 @@ describe('Episode List ', () => {
 
   it('should not render a list when there is only one episode', () => {
     const { queryByRole } = render(
-      renderEpisodes([exampleEpisodes[0]], scripts.latin, 'news', 'ltr'),
+      renderEpisodes({
+        episodes: [exampleEpisodes[0]],
+        script: scripts.latin,
+        service: 'news',
+        dir: 'ltr',
+      }),
     );
 
     expect(queryByRole('list')).not.toBeInTheDocument();


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/8304

**Overall change:**
Update the Psammead Episode List Component to support images and dark mode

**Code changes:**

- Remove external padding/margins/line heights
- Add a new `EpisodeList.Image` component
- Update the `EpisodeList.Episode` component to render differently if passed an `EpisodeList.Image`
- Add a `darkMode` prop
- Update the audio example fixture to better implement a11y criteria

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
