### PR TITLE
Adds div for skip link in Brand component

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.0.8 | [PR#3945](https://github.com/bbc/psammead/pull/xxxx) Moves skip link content onto a new line with no css |
 | 7.0.7 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.6 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.5 | [PR#3933](https://github.com/bbc/psammead/pull/3933) Talos - Bump Dependencies - @bbc/psammead-script-link |
@@ -55,7 +56,7 @@
 | 5.1.0-alpha.10 | [PR#2863](https://github.com/bbc/psammead/pull/2863) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 5.1.0-alpha.9 | [PR#2833](https://github.com/bbc/psammead/pull/2833) Wrap `scriptLink` in a div to fix Read&Write issue in chrome |
 | 5.1.0-alpha.8 | [PR#2701](https://github.com/bbc/psammead/pull/2701) Talos - Bump Dependencies - @bbc/psammead-styles |
-| 5.1.0-alpha.7 | [PR#2680](https://github.com/bbc/psammead/pull/2680) Export `SkipLink` from a separated folder and fix its position  | 
+| 5.1.0-alpha.7 | [PR#2680](https://github.com/bbc/psammead/pull/2680) Export `SkipLink` from a separated folder and fix its position  |
 | 5.1.0-alpha.6 | [PR#2697](https://github.com/bbc/psammead/pull/2697) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.1.0-alpha.5 | [PR#2569](https://github.com/bbc/psammead/pull/2569) Reduce height of Brand Component for all breakpoints |
 | 5.1.0-alpha.4 | [PR#2564](https://github.com/bbc/psammead/pull/2564) Add skip to content link |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -133,7 +133,6 @@ exports[`Brand should render correctly with link not provided 1`] = `
         , 
         Service
       </span>
-      <div />
     </div>
   </div>
 </div>
@@ -294,7 +293,6 @@ exports[`Brand should render correctly with link provided 1`] = `
           Service
         </span>
       </a>
-      <div />
     </div>
   </div>
 </div>
@@ -426,7 +424,6 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
       >
         BBC News
       </span>
-      <div />
     </div>
   </div>
 </div>
@@ -560,7 +557,6 @@ exports[`Brand should render correctly with transparent borders 1`] = `
       >
         BBC News
       </span>
-      <div />
     </div>
   </div>
 </div>

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -133,6 +133,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
         , 
         Service
       </span>
+      <div />
     </div>
   </div>
 </div>
@@ -293,6 +294,7 @@ exports[`Brand should render correctly with link provided 1`] = `
           Service
         </span>
       </a>
+      <div />
     </div>
   </div>
 </div>
@@ -424,6 +426,7 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
       >
         BBC News
       </span>
+      <div />
     </div>
   </div>
 </div>
@@ -557,6 +560,7 @@ exports[`Brand should render correctly with transparent borders 1`] = `
       >
         BBC News
       </span>
+      <div />
     </div>
   </div>
 </div>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -233,7 +233,7 @@ const Brand = props => {
         ) : (
           <StyledBrand {...props} />
         )}
-        {skipLink}
+        <div>{skipLink}</div>
         {scriptLink && <div>{scriptLink}</div>}
       </SvgWrapper>
     </Banner>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -233,7 +233,7 @@ const Brand = props => {
         ) : (
           <StyledBrand {...props} />
         )}
-        <div>{skipLink}</div>
+        {skipLink && <div>{skipLink}</div>}
         {scriptLink && <div>{scriptLink}</div>}
       </SvgWrapper>
     </Banner>


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/7151

**Overall change:** Fixes no css spacing for the skip link in the Brand component

**Code changes:**

- Encapsulated the skip link in a div for the brand component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
