### PR TITLE
Talos - Bump @bbc/psammead-brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.8 | [PR#3988](https://github.com/bbc/psammead/pull/3988) Talos - Bump Dependencies - @bbc/psammead-brand |
 | 4.0.7 | [PR#3978](https://github.com/bbc/psammead/pull/3978) Talos - Bump Dependencies - @bbc/psammead-media-player |
 | 4.0.6 | [PR#3977](https://github.com/bbc/psammead/pull/3977) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 4.0.5 | [PR#3961](https://github.com/bbc/psammead/pull/3961) Update packages README to include an example of `createGlobalStyles` in Simorgh |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1436,9 +1436,9 @@
       "dev": true
     },
     "@bbc/psammead-brand": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-7.0.6.tgz",
-      "integrity": "sha512-8jf9Zh0Vzcb3VpzIKHnH3HEQ+7G/CqoeUtAe03oM6XTVirJPqRX4nAbTxkrifPmc6L4RE00C00Tv+gpBE4wCPA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-7.0.8.tgz",
+      "integrity": "sha512-BhzaolKKEw0E9QbGBBWzQ/O1oVsbHudkfwggLhBed/GqO+MXPWxUiSSDMqi2TZ8ai2F+QlteCCecsy9kJYVmJQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -59,7 +59,7 @@
     "@bbc/moment-timezone-include": "^1.1.4",
     "@bbc/psammead-amp-geo": "^1.2.0",
     "@bbc/psammead-assets": "^3.0.1",
-    "@bbc/psammead-brand": "^7.0.6",
+    "@bbc/psammead-brand": "^7.0.8",
     "@bbc/psammead-bulleted-list": "^3.0.2",
     "@bbc/psammead-bulletin": "^5.0.4",
     "@bbc/psammead-byline": "^3.0.2",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-brand  ^7.0.6  →  ^7.0.8

| Version | Description |
| ------- | ----------- |
| 7.0.8 | [PR#3945](https://github.com/bbc/psammead/pull/xxxx) Moves skip link content onto a new line with no css |
| 7.0.7 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-script-link |
</details>

