### PR TITLE
fix firefox not allowing fullscreen

### DIFF
--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.0.6 | [PR#3990](https://github.com/bbc/psammead/pull/3990) fix fullscreen bug in firefox < v77 |
 | 5.0.5 | [PR#3977](https://github.com/bbc/psammead/pull/3977) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 5.0.4 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-play-button |
 | 5.0.3 | [PR#3927](https://github.com/bbc/psammead/pull/3927) Remove styled-components 'referencing other components' comment |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Canonical/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`Media Player: Canonical should render an iframe 1`] = `
 
 <div>
   <iframe
-    allow="autoplay; fullscreen"
+    allow="autoplay"
     allowfullscreen=""
     class="emotion-0 emotion-1"
     scrolling="no"

--- a/packages/components/psammead-media-player/src/Canonical/index.jsx
+++ b/packages/components/psammead-media-player/src/Canonical/index.jsx
@@ -79,7 +79,7 @@ const Canonical = ({
       <StyledIframe
         src={src}
         title={title}
-        allow="autoplay; fullscreen"
+        allow="autoplay"
         scrolling="no"
         gesture="media"
         allowFullScreen

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -675,7 +675,7 @@ exports[`Media Player: Canonical Entry renders an iframe when showPlaceholder is
     class="emotion-2 emotion-3"
   >
     <iframe
-      allow="autoplay; fullscreen"
+      allow="autoplay"
       allowfullscreen=""
       class="emotion-0 emotion-1"
       scrolling="no"
@@ -715,7 +715,7 @@ exports[`Media Player: Canonical Entry renders the audio skin 1`] = `
     class="emotion-2 emotion-3"
   >
     <iframe
-      allow="autoplay; fullscreen"
+      allow="autoplay"
       allowfullscreen=""
       class="emotion-0 emotion-1"
       scrolling="no"
@@ -1002,7 +1002,7 @@ exports[`Media Player: Canonical Entry shows a loading image before the player i
     class="emotion-6 emotion-7"
   >
     <iframe
-      allow="autoplay; fullscreen"
+      allow="autoplay"
       allowfullscreen=""
       class="emotion-0 emotion-1"
       scrolling="no"


### PR DESCRIPTION
**Overall change:**
Fixes media player not being able to go into full screen mode in Firefox < 77.

**Code changes:**

- Removes `fullscreen` from `allow` attribute on iframe because if `allow="fullscreen"` and `allowfullscreen` are both present on an iframe element, then the more restrictive `allowlist` of `allow="fullscreen"` will be used which didn't work in FF.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
