### PR TITLE
Radio Schedule Padding

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.6 | [PR#3991](https://github.com/bbc/psammead/pull/3991) Remove L/R Padding below 600px|
 | 5.0.5 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-live-label |
 | 5.0.4 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.3 | [PR#3936](https://github.com/bbc/psammead/pull/3936) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-radio-schedule/src/__snapshots__/index.test.jsx.snap
@@ -94,6 +94,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 }
 
+@media (max-width:37.5rem) {
+  .emotion-161 {
+    padding: 0;
+  }
+}
+
 .emotion-41 {
   position: relative;
   padding-bottom: 1rem;
@@ -1318,6 +1324,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
       grid-column-gap: 1rem;
     }
 }
+}
+
+@media (max-width:37.5rem) {
+  .emotion-159 {
+    padding: 0;
+  }
 }
 
 .emotion-39 {

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { grid } from '@bbc/psammead-styles/detection';
 import Grid from '@bbc/psammead-grid';
@@ -16,6 +17,9 @@ const StartTimeWrapper = styled.div`
 const StyledGrid = styled(Grid)`
   padding: 0;
   margin: 0;
+  @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    padding: 0;
+  }
 `;
 
 // Using flex-box on browsers that do not support grid will break grid fallback defined in psammead-grid


### PR DESCRIPTION
Resolves #3963

**Overall change:** L/R Padding Removed from radio schedule below 600px

**Code changes:**

-Media Query added to styledgrid to override styles from root grid component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
