### PR TITLE
Fix grid styles

### DIFF
--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.4 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Add missing semicolon |
 | 3.0.3 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.2 | [PR#3925](https://github.com/bbc/psammead/pull/3925) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.1 | [PR#3891](https://github.com/bbc/psammead/pull/3894) Update snapshots. |

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.0.4 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Add missing semicolon |
+| 3.0.4 | [PR#3992](https://github.com/bbc/psammead/pull/3992) Add missing semicolon |
 | 3.0.3 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.2 | [PR#3925](https://github.com/bbc/psammead/pull/3925) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.1 | [PR#3891](https://github.com/bbc/psammead/pull/3894) Update snapshots. |

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -943,7 +943,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (max-width:14.9375rem) {
   .emotion-2 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -951,7 +952,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .emotion-2 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -959,7 +961,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-2 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -967,7 +970,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .emotion-2 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -975,7 +979,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .emotion-2 {
     width: calc(75%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -983,7 +988,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:80rem) {
   .emotion-2 {
     width: calc(60%);
-    margin-left: 20% display:inline-block;
+    margin-left: 20%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1165,7 +1171,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (max-width:14.9375rem) {
   .emotion-6 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1173,7 +1180,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .emotion-6 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1181,7 +1189,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-6 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1189,7 +1198,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .emotion-6 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1197,7 +1207,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .emotion-6 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1205,7 +1216,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:80rem) {
   .emotion-6 {
     width: calc(100% - 33.333333333333336%);
-    margin-left: 33.333333333333336% display:inline-block;
+    margin-left: 33.333333333333336%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1279,7 +1291,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (max-width:14.9375rem) {
   .emotion-10 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1287,7 +1300,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .emotion-10 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1295,7 +1309,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-10 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1303,7 +1318,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .emotion-10 {
     width: calc(83.33333333333333%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1311,7 +1327,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .emotion-10 {
     width: calc(83.33333333333333%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1319,7 +1336,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:80rem) {
   .emotion-10 {
     width: calc(83.33333333333333%);
-    margin-left: 33.333333333333336% display:inline-block;
+    margin-left: 33.333333333333336%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1393,7 +1411,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (max-width:14.9375rem) {
   .emotion-18 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1401,7 +1420,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:15rem) and (max-width:24.9375rem) {
   .emotion-18 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1409,7 +1429,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-18 {
     width: calc(100% - 0%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1417,7 +1438,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
   .emotion-18 {
     width: calc(83.33333333333333%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1425,7 +1447,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .emotion-18 {
     width: calc(62.5%);
-    margin-left: 0% display:inline-block;
+    margin-left: 0%;
+    display: inline-block;
     vertical-align: top;
   }
 }
@@ -1433,7 +1456,8 @@ exports[`Grid component should render Grid with Grid items including nested non-
 @media (min-width:80rem) {
   .emotion-18 {
     width: calc(50%);
-    margin-left: 20% display:inline-block;
+    margin-left: 20%;
+    display: inline-block;
     vertical-align: top;
   }
 }

--- a/packages/components/psammead-grid/src/index.jsx
+++ b/packages/components/psammead-grid/src/index.jsx
@@ -186,7 +186,7 @@ const childrenFallback = (
       ? `margin-${dir === 'ltr' ? 'left' : 'right'}: ${startOffsetPercentage(
           parentColumnsGroup,
           gridStartOffsetGroup,
-        )}`
+        )};`
       : ``
   }
   display: inline-block;

--- a/packages/utilities/web-vitals/src/index.test.js
+++ b/packages/utilities/web-vitals/src/index.test.js
@@ -72,11 +72,9 @@ describe('useWebVitals', () => {
       mockSendBeacon();
       renderHook(() => useWebVitals({ enabled }));
 
-      const updateWebVitals = jest.fn()
-
-      expect(webVitals.getCLS).toHaveBeenCalledWith(updateWebVitals, true);
+      expect(webVitals.getCLS).toHaveBeenCalled();
       expect(webVitals.getFID).toHaveBeenCalled();
-      expect(webVitals.getLCP).toHaveBeenCalledWith(updateWebVitals, true);
+      expect(webVitals.getLCP).toHaveBeenCalled();
       expect(webVitals.getFCP).toHaveBeenCalled();
       expect(webVitals.getTTFB).toHaveBeenCalled();
 

--- a/packages/utilities/web-vitals/src/index.test.js
+++ b/packages/utilities/web-vitals/src/index.test.js
@@ -72,9 +72,11 @@ describe('useWebVitals', () => {
       mockSendBeacon();
       renderHook(() => useWebVitals({ enabled }));
 
-      expect(webVitals.getCLS).toHaveBeenCalled();
+      const updateWebVitals = jest.fn()
+
+      expect(webVitals.getCLS).toHaveBeenCalledWith(updateWebVitals, true);
       expect(webVitals.getFID).toHaveBeenCalled();
-      expect(webVitals.getLCP).toHaveBeenCalled();
+      expect(webVitals.getLCP).toHaveBeenCalledWith(updateWebVitals, true);
       expect(webVitals.getFCP).toHaveBeenCalled();
       expect(webVitals.getTTFB).toHaveBeenCalled();
 


### PR DESCRIPTION
Resolves N/A

**Overall change:**

Fixes a bug spotted by @mgurgel where we were missing a semicolon on our main grid component. This resulted in seeing `margin-left:0% display` note the missing semicolon after the `0%`

**Code changes:**
- Adds missing semicolon to grid component
- Updates snapshots

---

- [X] I have assigned myself to this PR and the corresponding issues
- [N/A] Automated jest tests added (for new features) or updated (for existing features)
- [N/A] This PR requires manual testing
