### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.10 | [PR#4004](https://github.com/bbc/psammead/pull/4004) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.9 | [PR#4000](https://github.com/bbc/psammead/pull/4000) Talos - Bump Dependencies - @bbc/psammead-grid |
 | 4.0.8 | [PR#3989](https://github.com/bbc/psammead/pull/3989) Update package to contain psammead-episode-list |
 | 4.0.7 | [PR#3978](https://github.com/bbc/psammead/pull/3978) Talos - Bump Dependencies - @bbc/psammead-media-player |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1711,15 +1711,15 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.4.tgz",
-      "integrity": "sha512-tXflmi0/xhwNED3/ncLre5FKzYcm2MSKSNqcDWoGIj7Ot4kGJlMgOxewqdOJH9ClwC3VAwc54KIH+RpYwb/oyw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.6.tgz",
+      "integrity": "sha512-5iCoM7ZY7nJVbXlnQWOpc09i/Lk8W34OrHqeJD3B8l4NTVDnEsSbbrH81ZB+Va3n6JDEFgZoW6vxcwlixOTG8g==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
         "@bbc/psammead-assets": "^3.0.1",
         "@bbc/psammead-detokeniser": "^1.0.0",
-        "@bbc/psammead-live-label": "^2.0.2",
+        "@bbc/psammead-live-label": "^2.0.3",
         "@bbc/psammead-styles": "^6.1.0",
         "@bbc/psammead-timestamp-container": "^5.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^8.0.3",
     "@bbc/psammead-paragraph": "^4.0.2",
     "@bbc/psammead-play-button": "^3.0.2",
-    "@bbc/psammead-radio-schedule": "5.0.4",
+    "@bbc/psammead-radio-schedule": "5.0.6",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.3",
     "@bbc/psammead-section-label": "^7.0.3",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.0.4  →  5.0.6

| Version | Description |
|---------|-------------|
| 5.0.6 | [PR#3991](https://github.com/bbc/psammead/pull/3991) Remove L/R Padding below 600px|
| 5.0.5 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-live-label |
</details>

