### PR TITLE
Update RTL wording in buildRTLSubstories helper

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.0.3 | [PR#4006](https://github.com/bbc/psammead/pull/4006) Update RTL wording in buildRTLSubstories helper |
 | 9.0.2 | [PR#3855](https://github.com/bbc/psammead/pull/3855) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 9.0.1 | [PR#3832](https://github.com/bbc/psammead/pull/3832) Bump @bbc/gel-foundations to 5.0.0 for BBC Reith Qalam |
 | 9.0.0 | [PR#3806](https://github.com/bbc/psammead/pull/3806) Support for BBC Reith Qalam |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/buildRTLSubstories.js
+++ b/packages/utilities/psammead-storybook-helpers/src/buildRTLSubstories.js
@@ -10,9 +10,10 @@ const buildRTLSubstory = (kind, name, storyFn) => {
     defaultService: 'arabic',
     services: ['arabic', 'persian', 'urdu', 'pashto'],
   });
-  storiesOf(`${kind}/RTL`, module).add(`RTL - ${name}`, () =>
-    rtlServiceDecorator(storyFn),
-  );
+  storiesOf(
+    `${kind}/Right to left layouts`,
+    module,
+  ).add(`Right to left - ${name}`, () => rtlServiceDecorator(storyFn));
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/utilities/psammead-storybook-helpers/src/buildRTLSubstories.test.js
+++ b/packages/utilities/psammead-storybook-helpers/src/buildRTLSubstories.test.js
@@ -61,11 +61,19 @@ it('should add the withServicesKnob decorator so that the default service and se
 it("should build RTL variants of story kind's full suite of stories", () => {
   buildRTLSubstories('Components/Brand');
 
-  expect(storiesOf.mock.calls[0][0]).toEqual('Components/Brand/RTL');
-  expect(mockAddStory.mock.calls[0][0]).toEqual('RTL - without brand link');
+  expect(storiesOf.mock.calls[0][0]).toEqual(
+    'Components/Brand/Right to left layouts',
+  );
+  expect(mockAddStory.mock.calls[0][0]).toEqual(
+    'Right to left - without brand link',
+  );
 
-  expect(storiesOf.mock.calls[1][0]).toEqual('Components/Brand/RTL');
-  expect(mockAddStory.mock.calls[1][0]).toEqual('RTL - with brand link');
+  expect(storiesOf.mock.calls[1][0]).toEqual(
+    'Components/Brand/Right to left layouts',
+  );
+  expect(mockAddStory.mock.calls[1][0]).toEqual(
+    'Right to left - with brand link',
+  );
 
   expect(mockAddStory.mock.calls[2]).toBeUndefined();
 });
@@ -73,8 +81,12 @@ it("should build RTL variants of story kind's full suite of stories", () => {
 it("should build RTL variants of story kind's specified stories", () => {
   buildRTLSubstories('Components/Brand', { include: ['with brand link'] });
 
-  expect(storiesOf.mock.calls[0][0]).toEqual('Components/Brand/RTL');
-  expect(mockAddStory.mock.calls[0][0]).toEqual('RTL - with brand link');
+  expect(storiesOf.mock.calls[0][0]).toEqual(
+    'Components/Brand/Right to left layouts',
+  );
+  expect(mockAddStory.mock.calls[0][0]).toEqual(
+    'Right to left - with brand link',
+  );
 
   expect(storiesOf.mock.calls[1]).toBeUndefined();
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/2489

A 2nd PR will need to be raised (probably via Talos) to update the rest of Psammead to use the newest helper version.

I carried out a manual local test, changing a package to use 9.0.3 helpers and the change was reflected in Storybook.

**Overall change:**
Rename the Storybook substories folder to Right-to-left layouts or similar so it is clearer.

**Code changes:**

- Update substories folder name for RTL from `RTL` to `Right to left layouts`
- Update RTL component naming structure from `RTL -` to `Right to left -`
- Update tests
- Update changlog

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
