### PR TITLE
Add github actions for CI 

### DIFF
--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -1,12 +1,6 @@
 name: Change Scanner
 
 on:
-  create:
-    branches:
-      - '**'
-  pull_request:
-    branches:
-      - '**'
   push:
     branches-ignore:
       - latest
@@ -24,6 +18,6 @@ jobs:
 
       - name: Install Node Modules
         run: npm run ci:packages
-        
+
       - name: Scan for Changes
         run: npm run changeScanner

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Install Node Modules
         run: npm run ci:packages
 
-      - name: Scan for Changes
+      - name: Change Scanner
         run: npm run changeScanner

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -1,0 +1,20 @@
+name: Change Scanner
+
+on:
+  push:
+    branches:
+      - !latest
+
+jobs:
+  build:
+    name: Change Scanner
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Scan for Changes
+        run: npm run changeScanner

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -22,5 +22,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install Node Modules
+        run: npm run ci:packages
+        
       - name: Scan for Changes
         run: npm run changeScanner

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -1,9 +1,15 @@
 name: Change Scanner
 
 on:
-  push:
+  create:
     branches:
-      - !latest
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches-ignore:
+      - latest
 
 jobs:
   build:

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -1,4 +1,4 @@
-name: Change Scanner
+name: Psammead CI - Change Scanner
 
 on:
   push:

--- a/.github/workflows/psammead-chromatic.yml
+++ b/.github/workflows/psammead-chromatic.yml
@@ -1,0 +1,34 @@
+name: Simorgh CI - Licences, Dependencies, Lint, Chromatic UI, NPM Audit
+on:
+  create:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    env:
+      CI: true
+      CHROMATIC_APP_CODE: ${{ secrets.CHROMATIC_APP_CODE }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Node Modules
+        run: npm ci:packages
+
+      - name: Chromatic UI Tests
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}
+        run: npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive --project-token "$CHROMATIC_APP_CODE"

--- a/.github/workflows/psammead-chromatic.yml
+++ b/.github/workflows/psammead-chromatic.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install Node Modules
-        run: npm ci:packages
+        run: npm run ci:packages
 
       - name: Chromatic UI Tests
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}

--- a/.github/workflows/psammead-chromatic.yml
+++ b/.github/workflows/psammead-chromatic.yml
@@ -1,4 +1,4 @@
-name: Simorgh CI - Licences, Dependencies, Lint, Chromatic UI, NPM Audit
+name: Psammead CI - Chromatic UI
 on:
   create:
     branches:

--- a/.github/workflows/psammead-deploy-storybook.yml
+++ b/.github/workflows/psammead-deploy-storybook.yml
@@ -1,0 +1,32 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - latest
+
+jobs:
+  deploy-storybook:
+    name: Deploy Storybook to GitHub pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install and Build
+        run: |
+          npm run ci:packages
+          npm run build:storybook
+          git config --global user.name "simorgh-bbc"
+          git config --global user.email "DENewsSimorghDev@bbc.co.uk"
+
+      - name: Deploy Storybook
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
+          BRANCH: gh-pages
+          FOLDER: storybook_dist
+          CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/psammead-deploy-storybook.yml
+++ b/.github/workflows/psammead-deploy-storybook.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install and Build
+      - name: Install Node Modules and Build
         run: |
           npm run ci:packages
           npm run build:storybook

--- a/.github/workflows/psammead-unit-tests.yml
+++ b/.github/workflows/psammead-unit-tests.yml
@@ -1,4 +1,5 @@
 name: Psammead CI - Unit Tests & Code Coverage
+
 on:
   create:
     branches:
@@ -9,6 +10,7 @@ on:
   push:
     branches:
       - latest
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/psammead-unit-tests.yml
+++ b/.github/workflows/psammead-unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
 
-      - name: Install Packages
+      - name: Install Node Modules
         run: |
           echo ${GITHUB_REF##*/}
           npm run ci:packages

--- a/.github/workflows/psammead-unit-tests.yml
+++ b/.github/workflows/psammead-unit-tests.yml
@@ -1,0 +1,57 @@
+name: Psammead CI - Unit Tests & Code Coverage
+on:
+  create:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    env:
+      CI: true
+      LOG_LEVEL: 'error'
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      GIT_COMMIT_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # Sets the GIT_BRANCH env variable on a push event which occurs when we merge a PR. ${GITHUB_REF##*/} is the shorthand syntax for getting the short branch name
+      - name: Set GIT_BRANCH Environment Variable For Push Event
+        if: ${{ github.event_name == 'push' }}
+        run: echo "GIT_BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+
+      # Sets the GIT_BRANCH env variable on a pull request event which occurs when we create/update a PR. ${{ github.head_ref }} is the syntax for getting the short branch name
+      - name: Set GIT_BRANCH Environment Variable For Pull Request Event
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+
+      - name: Install Packages
+        run: |
+          echo ${GITHUB_REF##*/}
+          npm run ci:packages
+
+      - name: Setup Code Climate Test Coverage
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter	
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
+      - name: Unit Tests
+        run: npm run test:ci
+
+      - name: Report Code Climate Test Coverage
+        run: ./cc-test-reporter after-build -t lcov --debug --exit-code 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.11 | [PR#4011](https://github.com/bbc/psammead/pull/4011) GitHub Actions for Unit Tests, Chromatic, Deploy Storybook & Change Scanner |
 | 4.0.10 | [PR#4007](https://github.com/bbc/psammead/pull/4007) Talos - Bump Dependencies - @bbc/psammead-storybook-helpers |
 | 4.0.9 | [PR#4000](https://github.com/bbc/psammead/pull/4000) Talos - Bump Dependencies - @bbc/psammead-grid |
 | 4.0.8 | [PR#3989](https://github.com/bbc/psammead/pull/3989) Update package to contain psammead-episode-list |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,10 +34,10 @@ node {
     ]) {
       cleanWs()
 
+      if (env.BRANCH_NAME == 'latest') {
       // git checkout
       checkout scm
 
-      if (env.BRANCH_NAME == 'latest') {
       // get git commit info for notifications
         gitCommitHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
         gitCommitAuthor = sh(returnStdout: true, script: "git log -1 --pretty=%an").trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,10 +52,8 @@ node {
           if (env.BRANCH_NAME == 'latest') {
             if (params.TALOS_PACKAGES == '') {
               stage ('Publish to NPM') {
-                'Publish to NPM': {
-                    withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {
-                      sh 'make publish'
-                    }
+                withCredentials([string(credentialsId: 'npm_bbc-online_read_write', variable: 'NPM_TOKEN')]) {
+                  sh 'make publish'
                 }
               }
             }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ none:
 install:
 	npm run ci:packages;
 
-
 setup-git:
 	git remote set-url origin "https://${GITHUB_TOKEN}@github.com/bbc/psammead.git"
 	git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
@@ -14,9 +13,6 @@ setup-git:
 publish:
 	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 	npm run publish
-
-change-scanner:
-	npm run changeScanner;
 
 talos:
 	node scripts/talos/cli ${ARGS};

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,9 @@
 none:
 	@ echo Please specify a target
 
-code-coverage-before-build:
-	curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter;
-	chmod +x ./cc-test-reporter;
-	./cc-test-reporter before-build;
-
-code-coverage-after-build:
-	./cc-test-reporter after-build -t lcov;
-
 install:
 	npm run ci:packages;
-	npm run build:storybook
 
-test:
-	npm run test:ci;
-
-test-chromatic:
-	npx chromatic test run  --storybook-build-dir=storybook_dist --exit-once-uploaded --no-interactive
-
-deploy-storybook:
-	npm run deploy-storybook
 
 setup-git:
 	git remote set-url origin "https://${GITHUB_TOKEN}@github.com/bbc/psammead.git"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Implement GitHub actions as a replacement for various stages in the Jenkins pipeline
- Run Unit Tests & Collect Code Coverage
- Change Scanner
- Chromatic UI
- Deploy Storybook
- Cleanup of Jenkins file

***TODO:***
- [ ] Chromatic requires a project token (needs to be added to GitHub secrets)
- [ ] NPM Publish - currently via Jenkins on latest branch only
- [ ] Talos - currently via Jenkins on latest branch only

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
