### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.22 | [PR#4055](https://github.com/bbc/psammead/pull/4055) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.21 | [PR#4054](https://github.com/bbc/psammead/pull/4054) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.20 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |
 | 4.0.19 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1711,9 +1711,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.12.tgz",
-      "integrity": "sha512-l63dzFGNH5U7MVW5rPLhPzJ/wo0398zhU+JCEkUn03JtmRiIhzVbBa3hE2pxIhRg3VQMWS522Y46ndm+Oocm5A==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.13.tgz",
+      "integrity": "sha512-OOnvC9VqG2xYfkite3TeDBScCY+waqmTWygLirIY512RPNF6JjTejHWmLFenKUfkZBfkhXtNCd/mHSW7+Ca3CA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
@@ -1721,7 +1721,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^2.0.5",
         "@bbc/psammead-styles": "^7.0.0",
-        "@bbc/psammead-timestamp-container": "^5.0.11"
+        "@bbc/psammead-timestamp-container": "^5.0.12"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^8.0.6",
     "@bbc/psammead-paragraph": "^4.0.4",
     "@bbc/psammead-play-button": "^3.0.5",
-    "@bbc/psammead-radio-schedule": "5.0.12",
+    "@bbc/psammead-radio-schedule": "5.0.13",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.5",
     "@bbc/psammead-section-label": "^7.0.5",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.0.12  →  5.0.13

| Version | Description |
|---------|-------------|
| 5.0.13 | [PR#4054](https://github.com/bbc/psammead/pull/4054) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

