### PR TITLE
Use correct BBC Reith Qalam fontPathMap prefix for Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -78,13 +78,14 @@ export const parameters = {
 };
 
 const fontPathMap = [
-  { prefix: 'F_REITH', path: 'fonts/Reith/' },
-  { prefix: 'F_REITH_QALAM', path: 'fonts/ReithQalam/' },
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
   { prefix: 'F_LATHA', path: 'fonts/Latha/' },
-  { prefix: 'F_MALLANNA', path: 'fonts/Mallanna/' },
-  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/NotoSansEthiopic/' },
+  { prefix: 'F_MALLANNA', path: 'fonts/Latha/' },
+  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/Latha/' },
   { prefix: 'F_PADAUK', path: 'fonts/Padauk/' },
+  { prefix: 'F_REITH_QALAM', path: 'fonts/ReithQalam/' },
+  { prefix: 'F_REITH_SANS', path: 'fonts/Reith/' },
+  { prefix: 'F_REITH_SERIF', path: 'fonts/Reith/' },
   { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
 ];
 
@@ -93,7 +94,7 @@ addDecorator(story => (
     <GlobalStyles
       fonts={Object.values(fontFaces).map(fontFace => {
         const fontMap =
-          fontPathMap.find(map => fontFace.name.includes(map.prefix)) ||
+          fontPathMap.find(map => fontFace.name.startsWith(map.prefix)) ||
           fontPathMap[0];
         return fontFace(fontMap.path);
       })}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -79,13 +79,13 @@ export const parameters = {
 
 const fontPathMap = [
   { prefix: 'F_REITH', path: 'fonts/Reith/' },
+  { prefix: 'F_REITH_QALAM', path: 'fonts/ReithQalam/' },
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
   { prefix: 'F_LATHA', path: 'fonts/Latha/' },
   { prefix: 'F_MALLANNA', path: 'fonts/Mallanna/' },
   { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/NotoSansEthiopic/' },
   { prefix: 'F_PADAUK', path: 'fonts/Padauk/' },
   { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
-  { prefix: 'F_QALAM', path: 'fonts/ReithQalam/' },
 ];
 
 addDecorator(story => (

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -80,8 +80,8 @@ export const parameters = {
 const fontPathMap = [
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
   { prefix: 'F_LATHA', path: 'fonts/Latha/' },
-  { prefix: 'F_MALLANNA', path: 'fonts/Latha/' },
-  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/Latha/' },
+  { prefix: 'F_MALLANNA', path: 'fonts/Mallanna/' },
+  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/NotoSansEthiopic/' },
   { prefix: 'F_PADAUK', path: 'fonts/Padauk/' },
   { prefix: 'F_REITH_QALAM', path: 'fonts/ReithQalam/' },
   { prefix: 'F_REITH_SANS', path: 'fonts/Reith/' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.23 | [PR#4056](https://github.com/bbc/psammead/pull/4056) Use correct BBC Reith Qalam fontPathMap prefix for Storybook. |
 | 4.0.22 | [PR#4055](https://github.com/bbc/psammead/pull/4055) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.21 | [PR#4054](https://github.com/bbc/psammead/pull/4054) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.20 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-figure, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-storybook-helpers, @bbc/psammead-timestamp, @bbc/psammead-timestamp-container, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
No issue.

**Overall change:** 

I noticed we were using an incorrect BBC Reith Qalam fontPathMap prefix for Storybook. This PR uses the correct prefix and resolves a bug whereby the `REITH` prefix erroneously matches `REITH_QALAM`.

**Code changes:**


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~~Automated jest tests added (for new features) or updated (for existing features)~~
- [ ] ~~This PR requires manual testing~~
