### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.27 | [PR#4077](https://github.com/bbc/psammead/pull/4077) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.26 | [PR#4074](https://github.com/bbc/psammead/pull/4074) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.25 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |
 | 4.0.24 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.26",
+  "version": "4.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1711,9 +1711,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.15.tgz",
-      "integrity": "sha512-PGgyOJ3v+JaDGTuvuZw+PfD8Ip+4KRmvwfXsV3WCWRZDnaKsLaINXx4yZp9JZc+ETSE50UCkWL5lg//xDArV8A==",
+      "version": "5.0.16",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.16.tgz",
+      "integrity": "sha512-n4pu7VHRdjuAs3xKUeil3z3B0uqlSslwNUKF+JHQ9p3Ijvz415PlysxtOu92KafVpsCVBIbH0DLM5lU5oORBZw==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
@@ -1721,7 +1721,7 @@
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^2.0.6",
         "@bbc/psammead-styles": "^7.0.1",
-        "@bbc/psammead-timestamp-container": "^5.0.12"
+        "@bbc/psammead-timestamp-container": "^5.0.13"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.26",
+  "version": "4.0.27",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^8.0.7",
     "@bbc/psammead-paragraph": "^4.0.5",
     "@bbc/psammead-play-button": "^3.0.6",
-    "@bbc/psammead-radio-schedule": "5.0.15",
+    "@bbc/psammead-radio-schedule": "5.0.16",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.6",
     "@bbc/psammead-section-label": "^7.0.6",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.0.15  →  5.0.16

| Version | Description |
|---------|-------------|
| 5.0.16 | [PR#4074](https://github.com/bbc/psammead/pull/4074) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

