### PR TITLE
I'm a Talos - Bump @bbc/psammead, @bbc/gel-foundations, @bbc/moment-timezone-include...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.30 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 4.0.29 | [PR#4085](https://github.com/bbc/psammead/pull/4085) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.28 | [PR#4084](https://github.com/bbc/psammead/pull/4084) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.27 | [PR#4077](https://github.com/bbc/psammead/pull/4077) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.29",
+  "version": "4.0.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1430,9 +1430,9 @@
       "dev": true
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw==",
       "dev": true
     },
     "@bbc/psammead-brand": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.29",
+  "version": "4.0.30",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -58,7 +58,7 @@
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/moment-timezone-include": "^1.1.4",
     "@bbc/psammead-amp-geo": "^1.2.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-brand": "^7.0.14",
     "@bbc/psammead-bulleted-list": "^3.0.5",
     "@bbc/psammead-bulletin": "^5.0.13",

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.14 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 5.0.13 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-live-label, @bbc/psammead-story-promo |
 | 5.0.12 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.11 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-live-label, @bbc/psammead-story-promo |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-live-label": {
       "version": "2.0.6",

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-bulletin/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-live-label": "^2.0.6",
     "@bbc/psammead-story-promo": "^8.0.7",
     "@bbc/psammead-styles": "^7.0.1",

--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version        | Description                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 3.0.7 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 3.0.6 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.5 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 3.0.4 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-embed-error/package-lock.json
+++ b/packages/components/psammead-embed-error/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-styles": {
       "version": "7.0.1",

--- a/packages/components/psammead-embed-error/package.json
+++ b/packages/components/psammead-embed-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-styles": "^7.0.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.13 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 0.1.0-alpha.12 | [PR#4080](https://github.com/bbc/psammead/pull/4080) Add data-e2e values for recent-episode |
 | 0.1.0-alpha.11 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-section-label |
 | 0.1.0-alpha.10 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-image-placeholder": {
       "version": "3.0.6",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-episode-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-image-placeholder": "^3.0.6",
     "@bbc/psammead-styles": "^7.0.1"
   },

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.7 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 3.0.6 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.5 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.4 | [PR#4010](https://github.com/bbc/psammead/pull/4010) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-styles": {
       "version": "7.0.1",

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-styles": "^7.0.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.7 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 6.0.6 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.5 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 6.0.4 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-styles": {
       "version": "7.0.1",

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-styles": "^7.0.1",
-    "@bbc/psammead-assets": "^3.1.0"
+    "@bbc/psammead-assets": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.0.12 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 5.0.11 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-play-button |
 | 5.0.10 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-play-button |
 | 5.0.9 | [PR#4030](https://github.com/bbc/psammead/pull/4030) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-play-button |

--- a/packages/components/psammead-media-player/package-lock.json
+++ b/packages/components/psammead-media-player/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-image": {
       "version": "2.0.0",

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-image-placeholder": "^3.0.6",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-image": "^2.0.0",
     "@bbc/psammead-play-button": "^3.0.6"
   }

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 8.0.8 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 8.0.7 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 8.0.6 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 8.0.5 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-styles": {
       "version": "7.0.1",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-styles": "^7.0.1",
     "@bbc/psammead-visually-hidden-text": "^2.0.1"
   },

--- a/packages/components/psammead-play-button/CHANGELOG.md
+++ b/packages/components/psammead-play-button/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------------- | ----------- |
+| 3.0.7 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 3.0.6 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.5 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 3.0.4 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-play-button/package-lock.json
+++ b/packages/components/psammead-play-button/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-styles": {
       "version": "7.0.1",

--- a/packages/components/psammead-play-button/package.json
+++ b/packages/components/psammead-play-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Provides a play button, with optional duration, for playable media.",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-styles": "^7.0.1",
-    "@bbc/psammead-assets": "^3.1.0"
+    "@bbc/psammead-assets": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.5 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 0.1.0-alpha.4 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.3 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 0.1.0-alpha.2 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-image-placeholder, @bbc/psammead-styles, @bbc/psammead-visually-hidden-text |

--- a/packages/components/psammead-podcast-promo/package-lock.json
+++ b/packages/components/psammead-podcast-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-image-placeholder": {
       "version": "3.0.6",

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-podcast-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-image-placeholder": "^3.0.6",
     "@bbc/psammead-styles": "^7.0.1"
   },

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.1 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 5.1.0 | [PR#4075](https://github.com/bbc/psammead/pull/4075) Update RadioSchedules to be able to use client side routing |
 | 5.0.16 | [PR#4074](https://github.com/bbc/psammead/pull/4074) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 5.0.15 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-live-label |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.0.tgz",
-      "integrity": "sha512-C546ocXZdafe09aTJu/aWTEjRtGM4kdvapvj4YwG0Csk7HPze7scSO4R2ySUieTGW/Vhm86U7cQGOd8iVvVNxQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.1.tgz",
+      "integrity": "sha512-Ove54mrrbhAuGdxDV3Nwakl/ecLyRTg612yi28HkfJcImIeNhVnFHGH4YfDrMIRPgzwV7pEnzTSc5Nn52vVCXw=="
     },
     "@bbc/psammead-detokeniser": {
       "version": "1.0.0",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-radio-schedule/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-assets": "^3.1.0",
+    "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-live-label": "^2.0.6",
     "@bbc/psammead-styles": "^7.0.1",
     "@bbc/psammead-timestamp-container": "^5.0.13",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-bulletin

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-embed-error

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-episode-list

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-image-placeholder

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-media-indicator

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-media-player

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-navigation

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-play-button

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>


@bbc/psammead-podcast-promo

<details>
<summary>Details</summary>
@bbc/psammead-assets  ^3.1.0  →  ^3.1.1

| Version | Description |
|---------|-------------|
| 3.1.1 | [PR#3939](https://github.com/bbc/psammead/pull/3939) Reduce ChromaticQA tests. Use chromatic instead of storybook-chromatic, as it has been deprecated |
</details>

