### PR TITLE
Set correct propTypes for radio schedules link component

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.2 | [PR#4091](https://github.com/bbc/psammead/pull/4091) Set correct propTypes for radio schedules link component |
 | 5.1.1 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 5.1.0 | [PR#4075](https://github.com/bbc/psammead/pull/4075) Update RadioSchedules to be able to use client side routing |
 | 5.0.16 | [PR#4074](https://github.com/bbc/psammead/pull/4074) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/README.md
+++ b/packages/components/psammead-radio-schedule/README.md
@@ -32,7 +32,7 @@ npm install @bbc/psammead-radio-schedule --save
 | liveLabel | string | yes | N/A | `'LIVE'` |
 | nextLabel | string | yes | N/A | `'NEXT'` |
 | dir | string | no | `"ltr"` | `"rtl"` |
-| linkComponent | node | no | `"a"` | `ReactRouterLink` |
+| linkComponent | elementType &#124; string | no | `"a"` | `ReactRouterLink` |
 | linkComponentAttr | string | no | `"href"` | `"to"` |
 
 ### Usage
@@ -125,7 +125,7 @@ const schedules = [
 | dir | string | no | `"ltr"` | `"rtl"` |
 | timezone | string | no | `'GMT'` | `'Europe/London'` |
 | locale | string | no | `'en-gb'` | `'fa'` |
-| linkComponent | node | no | `"a"` | `ReactRouterLink` |
+| linkComponent | elementType &#124; string | no | `"a"` | `ReactRouterLink` |
 | linkComponentAttr | string | no | `"href"` | `"to"` |
 
 ### Usage

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/ProgramCard/index.jsx
@@ -21,7 +21,14 @@ import {
   getPica,
 } from '@bbc/gel-foundations/typography';
 import { Link } from '@bbc/psammead-story-promo';
-import { oneOf, node, shape, string, number } from 'prop-types';
+import {
+  oneOf,
+  oneOfType,
+  elementType,
+  shape,
+  string,
+  number,
+} from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import LiveLabel from '@bbc/psammead-live-label';
@@ -298,7 +305,7 @@ const programCardPropTypes = {
   startTime: number.isRequired,
   timezone: string,
   locale: string,
-  linkComponent: node,
+  linkComponent: oneOfType([elementType, string]),
   linkComponentAttr: string,
 };
 

--- a/packages/components/psammead-radio-schedule/src/index.jsx
+++ b/packages/components/psammead-radio-schedule/src/index.jsx
@@ -4,7 +4,15 @@ import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { grid } from '@bbc/psammead-styles/detection';
 import Grid from '@bbc/psammead-grid';
-import { arrayOf, node, number, oneOf, shape, string } from 'prop-types';
+import {
+  arrayOf,
+  elementType,
+  number,
+  oneOf,
+  shape,
+  string,
+  oneOfType,
+} from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import ProgramCard from './ProgramCard';
 import StartTime from './StartTime';
@@ -157,7 +165,7 @@ const sharedProps = {
 renderSchedule.propTypes = {
   program: programPropTypes.isRequired,
   ...sharedProps,
-  linkComponent: node,
+  linkComponent: oneOfType([elementType, string]),
   linkComponentAttr: string,
 };
 
@@ -169,7 +177,7 @@ renderSchedule.defaultProps = {
 RadioSchedule.propTypes = {
   schedules: arrayOf(programPropTypes).isRequired,
   ...sharedProps,
-  linkComponent: node,
+  linkComponent: oneOfType([elementType, string]),
   linkComponentAttr: string,
 };
 


### PR DESCRIPTION
**Overall change:** 
The radio schedules currently use the `node` prop type, which is inaccurate. Change the prop type to `oneOfType([elementType, string])` to match the requirements.

**Code changes:**
- Change the prop type from `node` to `oneOfType([elementType, string])`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
