### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.33 | [PR#4092](https://github.com/bbc/psammead/pull/4092) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.32 | [PR#4089](https://github.com/bbc/psammead/pull/4089) Talos - Bump Dependencies - @bbc/psammead-episode-list, @bbc/psammead-media-player |
 | 4.0.31 | [PR#4088](https://github.com/bbc/psammead/pull/4088) Talos - Bump Dependencies - @bbc/psammead-bulletin, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-image-placeholder, @bbc/psammead-media-player, @bbc/psammead-media-indicator, @bbc/psammead-navigation, @bbc/psammead-play-button, @bbc/psammead-radio-schedule |
 | 4.0.30 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.32",
+  "version": "4.0.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1711,9 +1711,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.1.tgz",
-      "integrity": "sha512-SlMrRQv7Hn69GZKq6HKFkc6l2JXNB2l/L8/Ql2Z10xJ58XRgB05jVqzosfqO24h1pFH7Zo8W5e+0klB1ekNR2w==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.2.tgz",
+      "integrity": "sha512-7AzRYHvx2sBx27XMeWwqdXJ9hmrlrVxVyve/mGeeVRuGPrxIyMv887kSP3g3mh5PzkfKA8f92z1XaeA7XtLBAg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.32",
+  "version": "4.0.33",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^8.0.8",
     "@bbc/psammead-paragraph": "^4.0.5",
     "@bbc/psammead-play-button": "^3.0.7",
-    "@bbc/psammead-radio-schedule": "5.1.1",
+    "@bbc/psammead-radio-schedule": "5.1.2",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.6",
     "@bbc/psammead-section-label": "^7.0.6",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.1.1  →  5.1.2

| Version | Description |
|---------|-------------|
| 5.1.2 | [PR#4091](https://github.com/bbc/psammead/pull/4091) Set correct propTypes for radio schedules link component |
</details>

