### PR TITLE
enable style overrides in timestamp

### DIFF
--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.6 | [PR#4109](https://github.com/bbc/psammead/pull/4109) enable time element style overrides |
 | 4.0.5 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.4 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.3 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -34,6 +34,7 @@ const Timestamp = ({
   padding,
   service,
   darkMode,
+  className,
 }) => (
   <StyledTimestamp
     dateTime={datetime}
@@ -42,6 +43,7 @@ const Timestamp = ({
     padding={padding}
     service={service}
     darkMode={darkMode}
+    className={className}
   >
     {children}
   </StyledTimestamp>
@@ -51,6 +53,7 @@ Timestamp.defaultProps = {
   typographyFunc: getBrevier,
   padding: true,
   darkMode: false,
+  className: '',
 };
 
 Timestamp.propTypes = {
@@ -61,6 +64,7 @@ Timestamp.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   darkMode: bool,
+  className: string,
 };
 
 export default Timestamp;

--- a/packages/components/psammead-timestamp/src/index.jsx
+++ b/packages/components/psammead-timestamp/src/index.jsx
@@ -53,7 +53,7 @@ Timestamp.defaultProps = {
   typographyFunc: getBrevier,
   padding: true,
   darkMode: false,
-  className: '',
+  className: null,
 };
 
 Timestamp.propTypes = {

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.14 | [PR#4109](https://github.com/bbc/psammead/pull/4109) enable time element style overrides |
 | 5.0.13 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-timestamp |
 | 5.0.12 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-timestamp |
 | 5.0.11 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/containers/psammead-timestamp-container/package-lock.json
+++ b/packages/containers/psammead-timestamp-container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/containers/psammead-timestamp-container/src/index.jsx
+++ b/packages/containers/psammead-timestamp-container/src/index.jsx
@@ -21,6 +21,7 @@ const TimestampContainer = ({
   locale,
   service,
   altCalendar,
+  className,
 }) => {
   let altDateTime;
   if (!isValidDateTime(new Date(timestamp))) {
@@ -56,6 +57,7 @@ const TimestampContainer = ({
       padding={padding}
       script={script}
       service={service}
+      className={className}
     >
       {timestampText}
     </Timestamp>
@@ -74,6 +76,7 @@ TimestampContainer.propTypes = {
   script: shape(scriptPropType).isRequired,
   locale: string,
   service: string.isRequired,
+  className: string,
   altCalendar: shape({
     formatDate: func.isRequired,
   }),
@@ -88,6 +91,7 @@ TimestampContainer.defaultProps = {
   suffix: null,
   locale: 'en-gb',
   altCalendar: null,
+  className: '',
 };
 
 export default TimestampContainer;

--- a/packages/containers/psammead-timestamp-container/src/index.jsx
+++ b/packages/containers/psammead-timestamp-container/src/index.jsx
@@ -91,7 +91,7 @@ TimestampContainer.defaultProps = {
   suffix: null,
   locale: 'en-gb',
   altCalendar: null,
-  className: '',
+  className: null,
 };
 
 export default TimestampContainer;


### PR DESCRIPTION
**Overall change:**
Enables style overrides on the time element.

**Code changes:**

- adds `className` prop to timestamp container and timestamp component so that consumers can override styles.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
