### PR TITLE
Remove wrapping div from Brand's skip-link

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,13 +3,14 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.0.15 | [PR#????](https://github.com/bbc/psammead/pull/????) Revert [PR#3986](https://github.com/bbc/psammead/pull/3986). |
 | 7.0.14 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.13 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.12 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.11 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 7.0.10 | [PR#4030](https://github.com/bbc/psammead/pull/4030) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.9 | [PR#4029](https://github.com/bbc/psammead/pull/4029) Talos - Bump Dependencies - @bbc/psammead-styles |
-| 7.0.8 | [PR#3945](https://github.com/bbc/psammead/pull/xxxx) Moves skip link content onto a new line with no css |
+| 7.0.8 | [PR#3986](https://github.com/bbc/psammead/pull/3986) Moves skip link content onto a new line with no css |
 | 7.0.7 | [PR#3945](https://github.com/bbc/psammead/pull/3945) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.6 | [PR#3944](https://github.com/bbc/psammead/pull/3944) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.5 | [PR#3933](https://github.com/bbc/psammead/pull/3933) Talos - Bump Dependencies - @bbc/psammead-script-link |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 7.0.15 | [PR#????](https://github.com/bbc/psammead/pull/????) Revert [PR#3986](https://github.com/bbc/psammead/pull/3986). |
+| 7.0.15 | [PR#4110](https://github.com/bbc/psammead/pull/4110) Revert [PR#3986](https://github.com/bbc/psammead/pull/3986). |
 | 7.0.14 | [PR#4073](https://github.com/bbc/psammead/pull/4073) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.13 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.12 | [PR#4053](https://github.com/bbc/psammead/pull/4053) Talos - Bump Dependencies - @bbc/psammead-script-link |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -233,7 +233,7 @@ const Brand = props => {
         ) : (
           <StyledBrand {...props} />
         )}
-        {skipLink && <div>{skipLink}</div>}
+        {skipLink}
         {scriptLink && <div>{scriptLink}</div>}
       </SvgWrapper>
     </Banner>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8511.

**Overall change:**

Adding a wrapping `div` to SkipLink appears to affect how it's positioned when it's hidden. After investigation, we think this causes the regression seen in the issue above. This PR reverts the small change made in #3986 27 days ago.

**Code changes:**
- Remove wrapping `div` from Brand's skip-link.
- Amends an invalid changelog entry.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~~Automated jest tests added (for new features) or updated (for existing features)~~
- [ ] ~~This PR requires manual testing~~
