### PR TITLE
Talos - Bump @bbc/psammead-timestamp-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.35 | [PR#4113](https://github.com/bbc/psammead/pull/4113) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 4.0.34 | [PR#4111](https://github.com/bbc/psammead/pull/4111) Talos - Bump Dependencies - @bbc/psammead-brand |
 | 4.0.33 | [PR#4092](https://github.com/bbc/psammead/pull/4092) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.32 | [PR#4089](https://github.com/bbc/psammead/pull/4089) Talos - Bump Dependencies - @bbc/psammead-episode-list, @bbc/psammead-media-player |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.34",
+  "version": "4.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1835,14 +1835,26 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-5.0.13.tgz",
-      "integrity": "sha512-sorm3fbKOTwFxloMA/KlrjuhDFdT6obPxnlDBwMOrfCKhS8OyU21oyB48v1UdFcfOe4sMcixC2XZPC1Wa/6kwA==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-5.0.15.tgz",
+      "integrity": "sha512-oYHtAXai1u0qLN6mX7BsKhL/OCZm8sJRrtQIeVZvtf7Sqb43jboZc0I8fGf3gAm91SDtMIyia4WN7SKO8aCj0Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
-        "@bbc/psammead-timestamp": "^4.0.5",
+        "@bbc/psammead-timestamp": "^4.0.6",
         "moment-timezone": "^0.5.26"
+      },
+      "dependencies": {
+        "@bbc/psammead-timestamp": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-4.0.6.tgz",
+          "integrity": "sha512-EWYMPj3L2PazRHvEwhfkcmHlZL82IX6qRO/uIi9862K8/biFVIrL2oXlcf18eJ2Fo+lew/OSmvjarpn/u9D+Lg==",
+          "dev": true,
+          "requires": {
+            "@bbc/gel-foundations": "^6.0.0",
+            "@bbc/psammead-styles": "^7.0.1"
+          }
+        }
       }
     },
     "@bbc/psammead-useful-links": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.34",
+  "version": "4.0.35",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -98,7 +98,7 @@
     "@bbc/psammead-styles": "^7.0.1",
     "@bbc/psammead-test-helpers": "^5.0.1",
     "@bbc/psammead-timestamp": "^4.0.5",
-    "@bbc/psammead-timestamp-container": "^5.0.13",
+    "@bbc/psammead-timestamp-container": "^5.0.15",
     "@bbc/psammead-useful-links": "^3.0.6",
     "@bbc/psammead-visually-hidden-text": "^2.0.1",
     "@loadable/babel-plugin": "^5.13.0",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.3 | [PR#4113](https://github.com/bbc/psammead/pull/4113) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 5.1.2 | [PR#4091](https://github.com/bbc/psammead/pull/4091) Set correct propTypes for radio schedules link component |
 | 5.1.1 | [PR#4087](https://github.com/bbc/psammead/pull/4087) Talos - Bump Dependencies - @bbc/psammead-assets |
 | 5.1.0 | [PR#4075](https://github.com/bbc/psammead/pull/4075) Update RadioSchedules to be able to use client side routing |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,21 +35,21 @@
       "integrity": "sha512-QGgLxJNpOPVAa9XHrCaY8NkU3JDcF65+RO438ZB8v0kZMDJeJvdmF/waZt98POtV/ky2CULhPu5YF4bQi0Omiw=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-4.0.5.tgz",
-      "integrity": "sha512-2YCQY4SBSeXWdxY6BZg/Dh9WtwiwCafbdKG3CpofJo2p/hmmNRMKkaX4VsBGytSqxV8A/LtzKXZtfHEI8bPoUw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-4.0.6.tgz",
+      "integrity": "sha512-EWYMPj3L2PazRHvEwhfkcmHlZL82IX6qRO/uIi9862K8/biFVIrL2oXlcf18eJ2Fo+lew/OSmvjarpn/u9D+Lg==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-styles": "^7.0.1"
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-5.0.13.tgz",
-      "integrity": "sha512-sorm3fbKOTwFxloMA/KlrjuhDFdT6obPxnlDBwMOrfCKhS8OyU21oyB48v1UdFcfOe4sMcixC2XZPC1Wa/6kwA==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-5.0.15.tgz",
+      "integrity": "sha512-oYHtAXai1u0qLN6mX7BsKhL/OCZm8sJRrtQIeVZvtf7Sqb43jboZc0I8fGf3gAm91SDtMIyia4WN7SKO8aCj0Q==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
-        "@bbc/psammead-timestamp": "^4.0.5",
+        "@bbc/psammead-timestamp": "^4.0.6",
         "moment-timezone": "^0.5.26"
       }
     },

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^3.1.1",
     "@bbc/psammead-live-label": "^2.0.6",
     "@bbc/psammead-styles": "^7.0.1",
-    "@bbc/psammead-timestamp-container": "^5.0.13",
+    "@bbc/psammead-timestamp-container": "^5.0.15",
     "@bbc/psammead-detokeniser": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^5.0.13  →  ^5.0.15

| Version | Description |
|---------|-------------|
| 5.0.15 | [PR#4112](https://github.com/bbc/psammead/pull/4112) bumps psammead-timestamp |
| 5.0.14 | [PR#4109](https://github.com/bbc/psammead/pull/4109) enable time element style overrides |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-timestamp-container  ^5.0.13  →  ^5.0.15

| Version | Description |
|---------|-------------|
| 5.0.15 | [PR#4112](https://github.com/bbc/psammead/pull/4112) bumps psammead-timestamp |
| 5.0.14 | [PR#4109](https://github.com/bbc/psammead/pull/4109) enable time element style overrides |
</details>

