### PR TITLE
filter out undefined children

### DIFF
--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.16 | [PR#4116](https://github.com/bbc/psammead/pull/4116) fix for error when cloning undefined children |
 
 | 0.1.0-alpha.15 | [PR#4045](https://github.com/bbc/psammead/pull/4045) assisitive tech fixes |
 | 0.1.0-alpha.14 | [PR#4088](https://github.com/bbc/psammead/pull/4088) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -34,9 +34,9 @@ const Episode = ({ children, dir }) => {
   return (
     <Wrapper dir={dir} showMediaIndicator={showMediaIndicator}>
       {showMediaIndicator ? (
-        Children.filter(Boolean).map(children, child =>
-          cloneElement(child, { showMediaIndicator }),
-        )
+        Children.toArray(children)
+          .filter(Boolean)
+          .map(child => cloneElement(child, { showMediaIndicator }))
       ) : (
         <>
           {cloneElement(children[0], { dir })}

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -34,7 +34,7 @@ const Episode = ({ children, dir }) => {
   return (
     <Wrapper dir={dir} showMediaIndicator={showMediaIndicator}>
       {showMediaIndicator ? (
-        Children.map(children, child =>
+        Children.filter(Boolean).map(children, child =>
           cloneElement(child, { showMediaIndicator }),
         )
       ) : (

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -202,14 +202,14 @@ export const renderEpisodes = ({
                 </span>
               </EpisodeList.Metadata>
             </EpisodeList.Link>
-            <EpisodeList.Metadata>
-              {episode.episodeTitle && (
+            {episode.episodeTitle && (
+              <EpisodeList.Metadata>
                 <>
                   {' '}
                   <StyledSpan aria-hidden>|</StyledSpan> {episode.date}
                 </>
-              )}
-            </EpisodeList.Metadata>
+              </EpisodeList.Metadata>
+            )}
           </EpisodeList.Episode>
         ))}
       </EpisodeList>


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Fixes the error erroring when trying to clone a child that is undefined when the child is conditionally not rendered.

**Code changes:**

- filters out falsey React children before mapping cloning
---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
