### PR TITLE
Talos - Bump @bbc/psammead-episode-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.36 | [PR#4119](https://github.com/bbc/psammead/pull/4119) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.35 | [PR#4113](https://github.com/bbc/psammead/pull/4113) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 4.0.34 | [PR#4111](https://github.com/bbc/psammead/pull/4111) Talos - Bump Dependencies - @bbc/psammead-brand |
 | 4.0.33 | [PR#4092](https://github.com/bbc/psammead/pull/4092) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1547,9 +1547,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.14.tgz",
-      "integrity": "sha512-jEm5VO3wLeJJt5aWVX7zl/LZCV1esmJpHb4LQ2uY8OrMdGseKUn59uec4hiQHdNciWwQm7P361KRUiREH8LuuA==",
+      "version": "0.1.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.17.tgz",
+      "integrity": "sha512-Q/OpEnQz2vgpMQ3FvxIKzd7fZK8RXWzC81D9h0yNeWO9TdmH7a++2otzG4L/olEe6oimVvo6H00EPRI3Fo5/1Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -70,7 +70,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.7",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.14",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.17",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-episode-list  0.1.0-alpha.14  →  0.1.0-alpha.17

| Version | Description |
|---------|-------------|
| 0.1.0-alpha.17 | [PR#4118](https://github.com/bbc/psammead/pull/4118) remove required dir prop type from media indicator |
| 0.1.0-alpha.16 | [PR#4116](https://github.com/bbc/psammead/pull/4116) fix for error when cloning undefined children |

| 0.1.0-alpha.15 | [PR#4050](https://github.com/bbc/psammead/pull/4050) assisitive tech fixes |
</details>

