### PR TITLE
Fix issue where recent video episodes shows audio icon

### DIFF
--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.20 | [PR#4129](https://github.com/bbc/psammead/pull/4129) Refactor Episode List HoC implementations |
 | 0.1.0-alpha.19 | [PR#4126](https://github.com/bbc/psammead/pull/4126) Improve handling of text-resize |
 | 0.1.0-alpha.18 | [PR#4120](https://github.com/bbc/psammead/pull/4120) change size prop type to string instead of number |
 | 0.1.0-alpha.17 | [PR#4118](https://github.com/bbc/psammead/pull/4118) remove required dir prop type from media indicator |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/src/Description.jsx
+++ b/packages/components/psammead-episode-list/src/Description.jsx
@@ -4,6 +4,8 @@ import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
 
+import { withEpisodeContext } from './helpers';
+
 const Description = styled.span`
   ${({ script }) => getLongPrimer(script)}
   ${({ service }) => getSansRegular(service)}
@@ -13,4 +15,4 @@ const Description = styled.span`
   margin: ${GEL_SPACING_HLF} 0;
 `;
 
-export default Description;
+export default withEpisodeContext(Description);

--- a/packages/components/psammead-episode-list/src/Episode.jsx
+++ b/packages/components/psammead-episode-list/src/Episode.jsx
@@ -9,6 +9,7 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 import pathOr from 'ramda/src/pathOr';
 import Image from './Image';
+import { withEpisodeContext } from './helpers';
 
 const Wrapper = styled.div`
   position: relative;
@@ -52,4 +53,4 @@ Episode.propTypes = {
   dir: string.isRequired,
 };
 
-export default Episode;
+export default withEpisodeContext(Episode);

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -101,4 +101,4 @@ EpisodeImage.defaultProps = {
   duration: '',
 };
 
-export default EpisodeImage;
+export default withEpisodeContext(EpisodeImage);

--- a/packages/components/psammead-episode-list/src/Link.jsx
+++ b/packages/components/psammead-episode-list/src/Link.jsx
@@ -4,6 +4,7 @@ import { node, string, bool } from 'prop-types';
 import styled from '@emotion/styled';
 import { C_METAL, C_POSTBOX, C_STONE } from '@bbc/psammead-styles/colours';
 import MediaIndicator from './MediaIndicator';
+import { withEpisodeContext } from './helpers';
 
 const MediaIndicatorWrapper = styled.div`
   position: absolute;
@@ -73,4 +74,4 @@ Link.defaultProps = {
   showMediaIndicator: false,
 };
 
-export default Link;
+export default withEpisodeContext(Link);

--- a/packages/components/psammead-episode-list/src/Metadata.jsx
+++ b/packages/components/psammead-episode-list/src/Metadata.jsx
@@ -3,10 +3,12 @@ import { getBrevier } from '@bbc/gel-foundations/typography';
 import { C_METAL, C_PEBBLE } from '@bbc/psammead-styles/colours';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
+import { withEpisodeContext } from './helpers';
+
 const Metadata = styled.span`
   ${({ script }) => getBrevier(script)}
   ${({ service }) => getSansRegular(service)}
   color: ${({ darkMode }) => (darkMode ? C_PEBBLE : C_METAL)};
 `;
 
-export default Metadata;
+export default withEpisodeContext(Metadata);

--- a/packages/components/psammead-episode-list/src/Title.jsx
+++ b/packages/components/psammead-episode-list/src/Title.jsx
@@ -3,6 +3,8 @@ import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
 import { getPica } from '@bbc/gel-foundations/typography';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
+import { withEpisodeContext } from './helpers';
+
 const Title = styled.span`
   ${({ script }) => getPica(script)}
   ${({ service }) => getSansRegular(service)}
@@ -12,4 +14,4 @@ const Title = styled.span`
   font-weight: 700;
 `;
 
-export default Title;
+export default withEpisodeContext(Title);

--- a/packages/components/psammead-episode-list/src/index.jsx
+++ b/packages/components/psammead-episode-list/src/index.jsx
@@ -5,7 +5,7 @@ import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { string, shape, arrayOf, oneOf, element, bool } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 
-import { EpisodeContext, withEpisodeContext } from './helpers';
+import { EpisodeContext } from './helpers';
 import Episode from './Episode';
 import Link from './Link';
 import Title from './Title';
@@ -82,12 +82,12 @@ EpisodeList.defaultProps = {
   liProps: {},
 };
 
-EpisodeList.Episode = withEpisodeContext(Episode);
-EpisodeList.Link = withEpisodeContext(Link);
-EpisodeList.Title = withEpisodeContext(Title);
-EpisodeList.Image = withEpisodeContext(Image);
+EpisodeList.Episode = Episode;
+EpisodeList.Link = Link;
+EpisodeList.Title = Title;
+EpisodeList.Image = Image;
 EpisodeList.MediaIndicator = MediaIndicator;
-EpisodeList.Description = withEpisodeContext(Description);
-EpisodeList.Metadata = withEpisodeContext(Metadata);
+EpisodeList.Description = Description;
+EpisodeList.Metadata = Metadata;
 
 export default EpisodeList;


### PR DESCRIPTION
Resolves [No Issue]

**Overall change:** Fix for a bug where the video episode list also includes the media indicators: 
![Screen Shot 2020-12-11 at 12 43 04](https://user-images.githubusercontent.com/8601460/101904905-7e0c0f80-3bae-11eb-915f-76daefbc0794.png)

Caused by the root `Episode` component not recognising it was provided with a child `Image` as Image components are now wrapped with a HoC to provide the `dir` from context

**Code changes:**

- _Update components to export themselves pre-wrapped, rather than wrapping them in the index.js_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
