### PR TITLE
Talos - Bump @bbc/psammead-episode-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.38 | [PR#4147](https://github.com/bbc/psammead/pull/4147) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.37 | [PR#4128](https://github.com/bbc/psammead/pull/4128) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.37 | [PR#4114](https://github.com/bbc/psammead/pull/4114) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.36 | [PR#4121](https://github.com/bbc/psammead/pull/4121) Talos - Bump Dependencies - @bbc/psammead-episode-list |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.37",
+  "version": "4.0.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1547,9 +1547,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.19.tgz",
-      "integrity": "sha512-w7rmHhUvSRU7HsDS/f7sXgOGgWUwODUvDP1Kavx/CEg8+Wv0t2RFaFFLioiMRJ3qejwuU8uK7uDbL0Rc0It0ww==",
+      "version": "0.1.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.21.tgz",
+      "integrity": "sha512-LzWxuwZ9FuQ/T3A3zcxc33+G5X7nJ+ZHqUFwGbCPTtdy9fLSqZkV0o/qhbbxlU8KYNEvL9fu9oek0sAyBlKXDQ==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.37",
+  "version": "4.0.38",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -70,7 +70,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.7",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.19",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.21",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-episode-list  0.1.0-alpha.19  →  0.1.0-alpha.21

| Version | Description |
|---------|-------------|
| 0.1.0-alpha.21 | [PR#4129](https://github.com/bbc/psammead/pull/4129) Refactor Episode List HoC implementations |
| 0.1.0-alpha.20 | [PR#4125](https://github.com/bbc/psammead/pull/4125) Use CSS border for episode duration separator |
</details>

