### PR TITLE
Recent tv episodes link & dateTime storybook fixture updates

### DIFF
--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.21 | [PR#4152](https://github.com/bbc/psammead/pull/4152) Update fixture to reflect new a11y-compliant HTML markup |
 | 0.1.0-alpha.21 | [PR#4129](https://github.com/bbc/psammead/pull/4129) Refactor Episode List HoC implementations |
 | 0.1.0-alpha.20 | [PR#4125](https://github.com/bbc/psammead/pull/4125) Use CSS border for episode duration separator |
 | 0.1.0-alpha.19 | [PR#4126](https://github.com/bbc/psammead/pull/4126) Improve handling of text-resize |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -240,11 +240,12 @@ export const renderVideoEpisodes = ({
                 locale: episode.locale,
               })}
             />
-            <VisuallyHiddenText>Video, </VisuallyHiddenText>
             <EpisodeList.Link href={episode.url}>
+              <VisuallyHiddenText>Video, </VisuallyHiddenText>
               <EpisodeList.Title className="episode-list__title--hover episode-list__title--visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
+              <VisuallyHiddenText>, </VisuallyHiddenText>
               <EpisodeList.Description className="episode-list__description--hover episode-list__description--visited">
                 {episode.episodeTitle || episode.date}
               </EpisodeList.Description>
@@ -258,11 +259,11 @@ export const renderVideoEpisodes = ({
               </VisuallyHiddenText>
             </EpisodeList.Link>
             {episode.episodeTitle && (
-              <span role="text">
+              <div>
                 <EpisodeList.Metadata as="time">
                   {episode.date}
                 </EpisodeList.Metadata>
-              </span>
+              </div>
             )}
           </EpisodeList.Episode>
         ))}

--- a/packages/components/psammead-episode-list/src/fixtures.jsx
+++ b/packages/components/psammead-episode-list/src/fixtures.jsx
@@ -24,6 +24,7 @@ export const exampleEpisodes = [
     url: 'https://www.bbc.com/blahasda',
     brandTitle: 'Magazine de la Culture',
     date: '4 Avril 2020',
+    dateTime: '2020-04-04',
     duration: 'PT3M',
     durationLabel: 'Durée',
     time: '14:00',
@@ -35,6 +36,7 @@ export const exampleEpisodes = [
     brandTitle: 'Le Journal',
     episodeTitle: "Le premier rendez-vous d'information de la soirée.",
     date: '20 octobre 2020',
+    dateTime: '2020-10-20',
     duration: 'PT1H30M',
     durationLabel: 'Durée',
     time: '14:00',
@@ -46,6 +48,7 @@ export const exampleEpisodes = [
     brandTitle: 'Afrique Avenir',
     episodeTitle: 'Tout savoir sur les jeunes entrepreneurs africains.',
     date: '21 octobre 2020',
+    dateTime: '2020-10-21',
     duration: 'PT59M',
     durationLabel: 'Durée',
     time: '14:00',
@@ -260,7 +263,7 @@ export const renderVideoEpisodes = ({
             </EpisodeList.Link>
             {episode.episodeTitle && (
               <div>
-                <EpisodeList.Metadata as="time">
+                <EpisodeList.Metadata as="time" dateTime={episode.dateTime}>
                   {episode.date}
                 </EpisodeList.Metadata>
               </div>


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/4149

**Overall change:**
- A range of changes were required to the Storybook Fixture for the TV Episodes List, to bring it up to date with the markup in Simorgh.
- This is caused by the way this compound component is built - we need to maintain changes to the way it is composed both in Simorgh, on the page itself, and in the Psammead Storybook.

**Code changes**
- The changes required are detailed in the issue here https://github.com/bbc/psammead/issues/4149
- One change: the use of a `div` rather than a `span` to wrap the timestamp, and removal of the `role=test` attr, have also been carried forward in Simorgh:  https://github.com/bbc/simorgh/pull/8602

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
