### PR TITLE
[amp-validation] Expand omit list for episode-list-image

### DIFF
--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.24 | [PR#4154](https://github.com/bbc/psammead/pull/4154) Expand omit list for episode-list-image |
 | 0.1.0-alpha.23 | [PR#4152](https://github.com/bbc/psammead/pull/4152) Update fixture to reflect new a11y-compliant HTML markup |
 | 0.1.0-alpha.22 | [PR#4148](https://github.com/bbc/psammead/pull/415) Fix duration wrapper padding|
 | 0.1.0-alpha.21 | [PR#4129](https://github.com/bbc/psammead/pull/4129) Refactor Episode List HoC implementations |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.23",
+  "version": "0.1.0-alpha.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "0.1.0-alpha.23",
+  "version": "0.1.0-alpha.24",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -74,7 +74,14 @@ const EpisodeImage = props => {
 
   // This component only uses a subset of its props
   // the remaining props are passed down to the underlying <img> element
-  const selectImgProps = omit(['alt', 'duration']);
+  const selectImgProps = omit([
+    'alt',
+    'duration',
+    'classname',
+    'script',
+    'service',
+    'darkmode',
+  ]);
 
   return (
     <Wrapper dir={dir}>

--- a/packages/components/psammead-episode-list/src/Image.jsx
+++ b/packages/components/psammead-episode-list/src/Image.jsx
@@ -77,10 +77,10 @@ const EpisodeImage = props => {
   const selectImgProps = omit([
     'alt',
     'duration',
-    'classname',
+    'className',
     'script',
     'service',
-    'darkmode',
+    'darkMode',
   ]);
 
   return (


### PR DESCRIPTION
Related to: https://github.com/bbc/simorgh/issues/8590

**Overall change:** _Expand the omit list for props to be passed through to the img component_

**Code changes:**

- _Add additional fields to the omit list._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
