### PR TITLE
Talos - Bump @bbc/psammead-episode-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.41 | [PR#4155](https://github.com/bbc/psammead/pull/4155) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.40 | [PR#4056](https://github.com/bbc/psammead/pull/4153) Patch init and highlight.js security vuln's |
 | 4.0.39 | [PR#4130](https://github.com/bbc/psammead/pull/4130) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.38 | [PR#4147](https://github.com/bbc/psammead/pull/4147) Talos - Bump Dependencies - @bbc/psammead-episode-list |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.40",
+  "version": "4.0.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1707,9 +1707,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.21.tgz",
-      "integrity": "sha512-LzWxuwZ9FuQ/T3A3zcxc33+G5X7nJ+ZHqUFwGbCPTtdy9fLSqZkV0o/qhbbxlU8KYNEvL9fu9oek0sAyBlKXDQ==",
+      "version": "0.1.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.23.tgz",
+      "integrity": "sha512-AZzP66w/5j49U1efCVXF2v1PpCSW3EGpJw2E3TpcNulBnfi3kSsaB6LNMYd5SCTeyg1NPlzNLt4y3YTPvoZg5Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
@@ -18662,12 +18662,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -22612,6 +22606,14 @@
       "requires": {
         "fault": "^1.0.0",
         "highlight.js": "~10.4.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
+          "dev": true
+        }
       }
     },
     "lru-cache": {
@@ -25557,15 +25559,6 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
-      "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -26638,6 +26631,23 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
+          "dev": true
+        },
+        "prismjs": {
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
+          "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        }
       }
     },
     "react-test-renderer": {
@@ -26906,6 +26916,17 @@
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
         "prismjs": "~1.22.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
+          "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        }
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.40",
+  "version": "4.0.41",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -72,7 +72,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.7",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.21",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.23",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-episode-list  0.1.0-alpha.21  →  0.1.0-alpha.23

| Version | Description |
|---------|-------------|
| 0.1.0-alpha.23 | [PR#4152](https://github.com/bbc/psammead/pull/4152) Update fixture to reflect new a11y-compliant HTML markup |
| 0.1.0-alpha.22 | [PR#4148](https://github.com/bbc/psammead/pull/415) Fix duration wrapper padding|
</details>

