### PR TITLE
Fix captions margin

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.1 | [PR#4167](https://github.com/bbc/psammead/pull/4167) Fixed margin for gel groups 2 and 3 |
 | 4.1.0 | [PR#4156](https://github.com/bbc/psammead/pull/4156) Captions UX Changes |
 | 4.0.5 | [PR#4072](https://github.com/bbc/psammead/pull/4072) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.4 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -49,7 +49,8 @@ exports[`Caption should render with some offscreen text 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .emotion-2 {
-    margin-left: 0.5rem;
+    width: calc(100% - 1rem);
+    margin-left: 1rem;
     padding-right: 1rem;
     padding-left: 0.5rem;
   }
@@ -150,7 +151,8 @@ exports[`Caption should render with some offscreen text and arabic script typogr
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .emotion-2 {
-    margin-left: 0.5rem;
+    width: calc(100% - 1rem);
+    margin-left: 1rem;
     padding-right: 1rem;
     padding-left: 0.5rem;
   }

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -21,7 +21,8 @@ const rtlStyles = `
   border-right: 1px solid ${C_METAL};
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    margin-right: ${GEL_SPACING};
+    width: calc(100% - ${GEL_MARGIN_ABOVE_400PX});
+    margin-right: ${GEL_MARGIN_ABOVE_400PX};
     padding-right: ${GEL_SPACING};
     padding-left: ${GEL_MARGIN_ABOVE_400PX};
   }
@@ -37,7 +38,8 @@ const ltrStyles = `
   border-left: 1px solid ${C_METAL};
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    margin-left: ${GEL_SPACING};
+    width: calc(100% - ${GEL_MARGIN_ABOVE_400PX});
+    margin-left: ${GEL_MARGIN_ABOVE_400PX};
     padding-right: ${GEL_MARGIN_ABOVE_400PX};
     padding-left: ${GEL_SPACING};
   }


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8631

**Overall change:** _Fixes the margin for the psammead-caption component so that it is inline with text where the viewport belongs to gel groups 2 or 3._

**Code changes:**

- _The `margin-left` or `margin-right` (depending on language direction) is set to `GEL_MARGIN_ABOVE_400PX` for gel groups 2 and 3._
- _The width `calc` calls have been updated so that they consider the updated margins._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
