### PR TITLE
Bumped psammead-caption dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.47 | [PR#4178](https://github.com/bbc/psammead/pull/4178) Bump psammead-caption dependencies |
 | 4.0.46 | [PR#4177](https://github.com/bbc/psammead/pull/4177) Update publish action to include package scope |
 | 4.0.45 | [PR#4176](https://github.com/bbc/psammead/pull/4176) Update Github actions to not cancel workflows on latest branch |
 | 4.0.44 | [PR#4159](https://github.com/bbc/psammead/pull/4172) Add Github Actions for CI/CD |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.46",
+  "version": "4.0.47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1650,9 +1650,9 @@
       }
     },
     "@bbc/psammead-caption": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-caption/-/psammead-caption-4.1.0.tgz",
-      "integrity": "sha512-xJBdytHPImiNSFKSz2noP33EkVbTi11FsI4H1WBWmr5y1onosS8kDFyHM3Clv92+q98X8hZHPY6qkqLbmsDIYg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-caption/-/psammead-caption-4.1.1.tgz",
+      "integrity": "sha512-1ckYmowbSAeoxpqYrYXpEIpmv0X3PEUnzu0c7l5oazAMZsfjcghT0Xj/CHFgu3btw0AwDHtUymeAQxPsQYMRTg==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.46",
+  "version": "4.0.47",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -66,7 +66,7 @@
     "@bbc/psammead-bulletin": "^5.0.14",
     "@bbc/psammead-byline": "^3.0.5",
     "@bbc/psammead-calendars": "^2.0.19",
-    "@bbc/psammead-caption": "^4.1.0",
+    "@bbc/psammead-caption": "^4.1.1",
     "@bbc/psammead-consent-banner": "^4.0.5",
     "@bbc/psammead-content-anchor": "^1.0.0-alpha.1",
     "@bbc/psammead-copyright": "^3.0.5",


### PR DESCRIPTION

**Overall change:** _Bumps the psammead-caption component to 4.1.1 and the psammead component itself to 4.0.47._

I did this manually because when I merged the actual component update earlier today the talos script failed.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
