### PR TITLE
Setup github users before pushing talos PR

### DIFF
--- a/.github/workflows/psammead-publish.yml
+++ b/.github/workflows/psammead-publish.yml
@@ -30,6 +30,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Run Talos
-        run: node scripts/talos/cli
+        run: |
+          git config --global user.name "simorgh-bbc"
+          git config --global user.email "DENewsSimorghDev@bbc.co.uk"
+          node scripts/talos/cli
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.50 | [PR#4180](https://github.com/bbc/psammead/pull/4180) Setup GitHub user for pushing Talos branch
 | 4.0.49 | [PR#4180](https://github.com/bbc/psammead/pull/4180) Cleanup after Jenkins migration
 | 4.0.48 | [PR#4178](https://github.com/bbc/psammead/pull/4178) Bump psammead-caption dependencies |
 | 4.0.47 | [PR#4175](https://github.com/bbc/psammead/pull/4175) Talos - Bump Dependencies - @bbc/psammead-episode-list |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.49",
+  "version": "4.0.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.49",
+  "version": "4.0.50",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Set the github global user details to be able to push the Talos branches

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
