### PR TITLE
remove all use of deprecated waitForDomChange

### DIFF
--- a/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-storybook-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.0.5 | [PR#4191](https://github.com/bbc/psammead/pull/4191) remove use of deprecated waitForDomChange |
 | 9.0.4 | [PR#4052](https://github.com/bbc/psammead/pull/4052) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 9.0.3 | [PR#4006](https://github.com/bbc/psammead/pull/4006) Update RTL wording in buildRTLSubstories helper |
 | 9.0.2 | [PR#3855](https://github.com/bbc/psammead/pull/3855) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/utilities/psammead-storybook-helpers/package-lock.json
+++ b/packages/utilities/psammead-storybook-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-storybook-helpers/package.json
+++ b/packages/utilities/psammead-storybook-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-storybook-helpers",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
@@ -1,4 +1,4 @@
-import { render, waitForDomChange } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import * as knobs from '@storybook/addon-knobs';
 import { latin, arabic, chinese } from '@bbc/gel-foundations/scripts';
 import withServicesKnob from './withServicesKnob';
@@ -37,7 +37,7 @@ it('should correctly set the default html dir attribute', async () => {
   const storyFn = () => {};
   knobs.select = () => 'news';
   render(withServicesKnob()(storyFn));
-  await waitForDomChange();
+  await waitFor();
   const htmlDirAttr = document.querySelector('html').getAttribute('dir');
 
   expect(htmlDirAttr).toEqual('ltr');
@@ -47,7 +47,7 @@ it('should correctly set the chosen service html dir attribute', async () => {
   const mockStoryFn = jest.fn();
   knobs.select = () => 'arabic';
   render(withServicesKnob({ service: 'arabic' })(mockStoryFn));
-  await waitForDomChange();
+  await waitFor();
   const htmlDirAttr = document.querySelector('html').getAttribute('dir');
 
   expect(htmlDirAttr).toEqual('rtl');

--- a/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
+++ b/packages/utilities/psammead-storybook-helpers/src/withServicesKnob.test.jsx
@@ -37,20 +37,22 @@ it('should correctly set the default html dir attribute', async () => {
   const storyFn = () => {};
   knobs.select = () => 'news';
   render(withServicesKnob()(storyFn));
-  await waitFor();
-  const htmlDirAttr = document.querySelector('html').getAttribute('dir');
+  await waitFor(() => {
+    const htmlDirAttr = document.querySelector('html').getAttribute('dir');
 
-  expect(htmlDirAttr).toEqual('ltr');
+    expect(htmlDirAttr).toEqual('ltr');
+  });
 });
 
 it('should correctly set the chosen service html dir attribute', async () => {
   const mockStoryFn = jest.fn();
   knobs.select = () => 'arabic';
   render(withServicesKnob({ service: 'arabic' })(mockStoryFn));
-  await waitFor();
-  const htmlDirAttr = document.querySelector('html').getAttribute('dir');
+  await waitFor(() => {
+    const htmlDirAttr = document.querySelector('html').getAttribute('dir');
 
-  expect(htmlDirAttr).toEqual('rtl');
+    expect(htmlDirAttr).toEqual('rtl');
+  });
 });
 
 it('should pass the correct props to the story function', () => {

--- a/packages/utilities/psammead-test-helpers/CHANGELOG.md
+++ b/packages/utilities/psammead-test-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.2 | [PR#4191](https://github.com/bbc/psammead/pull/4191) remove use of deprecated waitForDomChange |
 | 5.0.1 | [PR#3927](https://github.com/bbc/psammead/pull/3927) Remove reference to styled-components in pacakge description |
 | 5.0.0 | [PR#3869](https://github.com/bbc/psammead/pull/3869) shouldMatchSnapshot simplified to work with Emotion |
 | 4.0.0 | [PR#3636](https://github.com/bbc/psammead/pull/3636) Decouple from jest-styled-components |

--- a/packages/utilities/psammead-test-helpers/package-lock.json
+++ b/packages/utilities/psammead-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utilities/psammead-test-helpers/package.json
+++ b/packages/utilities/psammead-test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-test-helpers",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/utilities/psammead-test-helpers/src/renderWithHelmet.js
+++ b/packages/utilities/psammead-test-helpers/src/renderWithHelmet.js
@@ -1,4 +1,4 @@
-import { render, waitForDomChange } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 export default component => {
   /*
@@ -15,11 +15,11 @@ export default component => {
 
   headElement.innerHTML = ''; // clear out head mutations from previous tests
 
-  return waitForDomChange({
+  return waitFor({
     container: headElement,
     timeout: ARBITRARY_TIMEOUT,
   })
-    .catch(noop) // handle a waitForDomChange timeout
+    .catch(noop) // handle a waitFor timeout
     .then(mutationsList => {
       const headMutationDetected = mutationsList && mutationsList.length;
 


### PR DESCRIPTION
**Overall change:**
Removes use of deprecated `waitForDomChange` which is causing unit tests to fail in React 17 upgrade PR https://github.com/bbc/simorgh/pull/8670

**Code changes:**

- Replaces `waitForDomChange` with `waitFor`
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
