### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.58 | [PR#4202](https://github.com/bbc/psammead/pull/4202) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.57 | [PR#4198](https://github.com/bbc/psammead/pull/4198) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.56 | [PR#4199](https://github.com/bbc/psammead/pull/4199) Talos - Bump Dependencies - @bbc/psammead-storybook-helpers |
 | 4.0.55 | [PR#4197](https://github.com/bbc/psammead/pull/4197) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-live-label, @bbc/psammead-media-player, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.57",
+  "version": "4.0.58",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1871,9 +1871,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.6.tgz",
-      "integrity": "sha512-X72nRaLDKM0hmL/T6ANfTBhsaL1ehm9OSs8y8uJU3cJEX4mtXcSZiQvB1HJ8OZhQJInA6weaz/ZK1PZaYmTArQ==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.7.tgz",
+      "integrity": "sha512-qMmrZFPg3urqw3z/38LjEgNZoduOP8F2vj7PWnikG7dEqHGYos/50Bx2bl54YnFuBvfWgdVD3k6+3I80FVtr4g==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
@@ -1882,7 +1882,7 @@
         "@bbc/psammead-grid": "^3.0.9",
         "@bbc/psammead-live-label": "^2.0.7",
         "@bbc/psammead-styles": "^7.0.2",
-        "@bbc/psammead-timestamp-container": "^5.0.15"
+        "@bbc/psammead-timestamp-container": "^5.0.16"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.57",
+  "version": "4.0.58",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -88,7 +88,7 @@
     "@bbc/psammead-navigation": "^8.0.9",
     "@bbc/psammead-paragraph": "^4.0.6",
     "@bbc/psammead-play-button": "^3.0.8",
-    "@bbc/psammead-radio-schedule": "5.1.6",
+    "@bbc/psammead-radio-schedule": "5.1.7",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.7",
     "@bbc/psammead-section-label": "^7.0.7",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.1.6  →  5.1.7

| Version | Description |
|---------|-------------|
| 5.1.7 | [PR#4198](https://github.com/bbc/psammead/pull/4198) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

