### PR TITLE
Hide image in podcast promo below 320px breakpoint

### DIFF
--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.12 | [PR##4214](https://github.com/bbc/psammead/pull/#4214) Hide image below 320px|
 | 0.1.0-alpha.11 | [PR##4214](https://github.com/bbc/psammead/pull/#4214) Design fixes|
 | 0.1.0-alpha.10 | [PR#4197](https://github.com/bbc/psammead/pull/4197) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.9 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-styles |

--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.12 | [PR##4214](https://github.com/bbc/psammead/pull/#4214) Hide image below 320px|
+| 0.1.0-alpha.12 | [PR#4219](https://github.com/bbc/psammead/pull/#4219) Hide image below 320px|
 | 0.1.0-alpha.11 | [PR##4214](https://github.com/bbc/psammead/pull/#4214) Design fixes|
 | 0.1.0-alpha.10 | [PR#4197](https://github.com/bbc/psammead/pull/4197) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.9 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-styles |

--- a/packages/components/psammead-podcast-promo/package-lock.json
+++ b/packages/components/psammead-podcast-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
@@ -143,6 +143,12 @@ exports[`Podcast Promo Card Image should match snapshot 1`] = `
   margin: 0.5rem 0 0 0.5rem;
 }
 
+@media (max-width:20rem) {
+  .emotion-0 {
+    display: none;
+  }
+}
+
 @media (min-width:25rem) {
   .emotion-0 {
     -webkit-flex: 0 0 6.8125rem;
@@ -403,6 +409,12 @@ exports[`Podcast Promo Examples basic example 1`] = `
   -ms-flex: 0 0 5.5rem;
   flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
+}
+
+@media (max-width:20rem) {
+  .emotion-8 {
+    display: none;
+  }
 }
 
 @media (min-width:25rem) {
@@ -768,6 +780,12 @@ exports[`Podcast Promo Examples on-page example 1`] = `
   -ms-flex: 0 0 5.5rem;
   flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
+}
+
+@media (max-width:20rem) {
+  .emotion-14 {
+    display: none;
+  }
 }
 
 @media (min-width:25rem) {

--- a/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
@@ -137,9 +137,6 @@ exports[`Podcast Promo Card Episodes Text should match snapshot 1`] = `
 
 exports[`Podcast Promo Card Image should match snapshot 1`] = `
 .emotion-0 {
-  -webkit-flex: 0 0 5.5rem;
-  -ms-flex: 0 0 5.5rem;
-  flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
   display: none;
 }
@@ -406,9 +403,6 @@ exports[`Podcast Promo Examples basic example 1`] = `
 }
 
 .emotion-8 {
-  -webkit-flex: 0 0 5.5rem;
-  -ms-flex: 0 0 5.5rem;
-  flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
   display: none;
 }
@@ -778,9 +772,6 @@ exports[`Podcast Promo Examples on-page example 1`] = `
 }
 
 .emotion-14 {
-  -webkit-flex: 0 0 5.5rem;
-  -ms-flex: 0 0 5.5rem;
-  flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
   display: none;
 }

--- a/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
@@ -141,11 +141,12 @@ exports[`Podcast Promo Card Image should match snapshot 1`] = `
   -ms-flex: 0 0 5.5rem;
   flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
+  display: none;
 }
 
-@media (max-width:20rem) {
+@media (min-width:20rem) {
   .emotion-0 {
-    display: none;
+    display: unset;
   }
 }
 
@@ -409,11 +410,12 @@ exports[`Podcast Promo Examples basic example 1`] = `
   -ms-flex: 0 0 5.5rem;
   flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
+  display: none;
 }
 
-@media (max-width:20rem) {
+@media (min-width:20rem) {
   .emotion-8 {
-    display: none;
+    display: unset;
   }
 }
 
@@ -780,11 +782,12 @@ exports[`Podcast Promo Examples on-page example 1`] = `
   -ms-flex: 0 0 5.5rem;
   flex: 0 0 5.5rem;
   margin: 0.5rem 0 0 0.5rem;
+  display: none;
 }
 
-@media (max-width:20rem) {
+@media (min-width:20rem) {
   .emotion-14 {
-    display: none;
+    display: unset;
   }
 }
 

--- a/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
+++ b/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
@@ -8,7 +8,6 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 
 const CardImageWrapper = styled.div`
-  flex: 0 0 5.5rem;
   margin: ${GEL_SPACING} 0 0 ${GEL_SPACING};
   display: none;
   @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {

--- a/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
+++ b/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
@@ -4,11 +4,15 @@ import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
+  GEL_GROUP_B_MIN_WIDTH,
 } from '@bbc/gel-foundations/breakpoints';
 
 const CardImageWrapper = styled.div`
   flex: 0 0 5.5rem;
   margin: ${GEL_SPACING} 0 0 ${GEL_SPACING};
+  @media (max-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
+    display: none;
+  }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     flex: 0 0 6.8125rem;
   }

--- a/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
+++ b/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
@@ -10,8 +10,9 @@ import {
 const CardImageWrapper = styled.div`
   flex: 0 0 5.5rem;
   margin: ${GEL_SPACING} 0 0 ${GEL_SPACING};
-  @media (max-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
-    display: none;
+  display: none;
+  @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
+    display: unset;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     flex: 0 0 6.8125rem;


### PR DESCRIPTION


**Overall change:** Hide image in podcast promo below 320px 

**Code changes:**

- Add display: none at breakpoint

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
