### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.67 | [PR#4229](https://github.com/bbc/psammead/pull/4229) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.66 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.65 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |
 | 4.0.64 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.66",
+  "version": "4.0.67",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1874,9 +1874,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.9.tgz",
-      "integrity": "sha512-877tPqtJFusQQb5A85encKD6cMXtlAT9A3R9v/7Kp27NioCxDX9xNlcaM6dZsesg23g8bQMdfjONL0Zb5z9eWw==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.10.tgz",
+      "integrity": "sha512-BYckdjNf2/pnv0WUdvPSqWAynfyogTjGsx39sWCH6bhsdZy1wdtLnXMShPeRhGPGJKnsG8d5uFWPODxAXNuRxA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
@@ -1885,7 +1885,7 @@
         "@bbc/psammead-grid": "^3.0.10",
         "@bbc/psammead-live-label": "^2.0.8",
         "@bbc/psammead-styles": "^7.0.3",
-        "@bbc/psammead-timestamp-container": "^5.0.16"
+        "@bbc/psammead-timestamp-container": "^5.0.17"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.66",
+  "version": "4.0.67",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^9.0.1",
     "@bbc/psammead-paragraph": "^4.0.7",
     "@bbc/psammead-play-button": "^3.0.9",
-    "@bbc/psammead-radio-schedule": "5.1.9",
+    "@bbc/psammead-radio-schedule": "5.1.10",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.8",
     "@bbc/psammead-section-label": "^7.0.8",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.1.9  →  5.1.10

| Version | Description |
|---------|-------------|
| 5.1.10 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
</details>

