### PR TITLE
Remove ARGS declaration from manual Talos PR workflow

### DIFF
--- a/.github/workflows/psammead-manual-talos.yml
+++ b/.github/workflows/psammead-manual-talos.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       psammeadPackages:
-        description: 'Comma separated list of Psammead packages to bump'
+        description: 'Comma seperated list of packages to have talos bump. e.g. "@bbc/psammead-styles,@bbc/psammead-brand"'
         required: true
         default: ''
 

--- a/.github/workflows/psammead-manual-talos.yml
+++ b/.github/workflows/psammead-manual-talos.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       psammeadPackages:
-        description: 'Comma seperated list of packages to have talos bump. e.g. "@bbc/psammead-styles,@bbc/psammead-brand"'
+        description: 'Comma separated list of packages to have talos bump. e.g. "@bbc/psammead-styles,@bbc/psammead-brand"'
         required: true
         default: ''
 

--- a/.github/workflows/psammead-manual-talos.yml
+++ b/.github/workflows/psammead-manual-talos.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       psammeadPackages:
-        description: 'Comma separated list of packages to have talos bump. e.g. "@bbc/psammead-styles,@bbc/psammead-brand"'
+        description: 'Comma separated list of Psammead packages to have talos bump. e.g. "@bbc/psammead-styles,@bbc/psammead-brand"'
         required: true
         default: ''
 

--- a/.github/workflows/psammead-manual-talos.yml
+++ b/.github/workflows/psammead-manual-talos.yml
@@ -1,4 +1,4 @@
-name: Psammead CD - Manual Talos
+name: Manual Talos - ${{ github.event.inputs.psammeadPackages }}
 
 on:
   workflow_dispatch:
@@ -28,6 +28,6 @@ jobs:
         run: |
           git config --global user.name "simorgh-bbc"
           git config --global user.email "DENewsSimorghDev@bbc.co.uk"
-          node scripts/talos/cli ARGS='${{ github.event.inputs.psammeadPackages }}'
+          node scripts/talos/cli '${{ github.event.inputs.psammeadPackages }}'
         env:
           GITHUB_TOKEN: '${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.71 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Remove ARGS assignment from within manual talos script call |
+| 4.0.71 | [PR#4249](https://github.com/bbc/psammead/pull/4249) Remove ARGS assignment from within manual talos script call |
 | 4.0.70 | [PR#4247](https://github.com/bbc/psammead/pull/4247) Fixing the manual talos run.... hopefully |
 | 4.0.69 | [PR#4246](https://github.com/bbc/psammead/pull/4246) Add action to manually run talos |
 | 4.0.68 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.70 | [PR4247](https://github.com/bbc/psammead/pull/4247) Fixing the manual talos run.... hopefully |
-| 4.0.69 | [PR4246](https://github.com/bbc/psammead/pull/4246) Add action to manually run talos |
+| 4.0.71 | [PR#xxx](https://github.com/bbc/psammead/pull/xxx) Remove ARGS assignment from within manual talos script call |
+| 4.0.70 | [PR#4247](https://github.com/bbc/psammead/pull/4247) Fixing the manual talos run.... hopefully |
+| 4.0.69 | [PR#4246](https://github.com/bbc/psammead/pull/4246) Add action to manually run talos |
 | 4.0.68 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.67 | [PR#4229](https://github.com/bbc/psammead/pull/4229) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.66 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.70",
+  "version": "4.0.71",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.70",
+  "version": "4.0.71",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Resolves no-issue

**Overall change:**
- Remove ARGS assignment within manual talos script
- Improve example to include `@bbc/...`
- Pass input packages to workflow name

---

- [x] I have assigned myself to this PR and the corresponding issues
