### PR TITLE
Update version of all psammead-timestamp to 4.0.11

### DIFF
--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.11 | [PR#xx](https://github.com/bbc/psammead/pull/xx) Unify package.json, package-lock & changelog versions to prevent Talos borking |
 | 4.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.0.11 | [PR#xx](https://github.com/bbc/psammead/pull/xx) Unify package.json, package-lock & changelog versions to prevent Talos borking |
+| 4.0.11 | [PR#4254](https://github.com/bbc/psammead/pull/4254) Unify package.json, package-lock & changelog versions to prevent Talos borking |
 | 4.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.9",
+  "version": "4.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.9",
+  "version": "4.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
**Overall change:** 
- There was a mismatch between `psammead-timestamp`'s changelog (4.0.9) and its package/package-lock (4.0.10). 
- This causes Talos to bork when it hits the package.
- This PR brings them all to 4.0.11

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
