### PR TITLE
Fix psammead-radio-schedules package-lock.json

### DIFF
--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.1.12 | [PR#xx](https://github.com/bbc/psammead/pull/xx) Fix package-lock.json issue causing npm install error |
+| 5.1.12 | [PR#4255](https://github.com/bbc/psammead/pull/4255) Fix package-lock.json issue causing npm install error |
 | 5.1.11 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 5.1.10 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 5.1.9 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-live-label |

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.12 | [PR#xx](https://github.com/bbc/psammead/pull/xx) Fix package-lock.json issue causing npm install error |
 | 5.1.11 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 5.1.10 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
 | 5.1.9 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-grid, @bbc/psammead-live-label |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,11 +1,13 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/gel-foundations": {
-      "version": "6.0.0"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-6.0.0.tgz",
+      "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-assets": {
       "version": "3.1.2",
@@ -13,7 +15,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-detokeniser": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-detokeniser/-/psammead-detokeniser-1.0.0.tgz",
+      "integrity": "sha512-xhGwisJtIy+6aCaQtCSr+YcfiqYlCyhri2+4I7AUDPHRv4PSU3Jz1gHBo/6UMOpjustv5BJV4DIzgFQmUfT5yw=="
     },
     "@bbc/psammead-grid": {
       "version": "3.0.10",
@@ -40,9 +44,9 @@
           "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
         },
         "@bbc/psammead-styles": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.1.tgz",
-          "integrity": "sha512-QGgLxJNpOPVAa9XHrCaY8NkU3JDcF65+RO438ZB8v0kZMDJeJvdmF/waZt98POtV/ky2CULhPu5YF4bQi0Omiw=="
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+          "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
         },
         "@bbc/psammead-visually-hidden-text": {
           "version": "2.0.1",
@@ -57,9 +61,9 @@
       "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
     },
     "@bbc/psammead-timestamp": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-4.0.8.tgz",
-      "integrity": "sha512-aF7g2M4NSMbmqK+fEA8t/EITkPBg12BwTnYkXFcINcdFByG6WFKwT5dH2i47jG/TT5HYEiNSWe4AEyYPXOgrhg==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-4.0.9.tgz",
+      "integrity": "sha512-KshCRXeCBshQl9AYR97iJEjU+EMxMHE7ddcakGCUi7lpk28ONbLVm2fJcbJJP8yVNN8o5G/Ved88K/gRLKeNVQ==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-styles": "^7.0.3"
@@ -76,44 +80,9 @@
       },
       "dependencies": {
         "@bbc/gel-foundations": {
-          "version": "6.0.0"
-        },
-        "@bbc/psammead-locales": {
-          "requires": {
-            "jalaali-js": "1.1.0",
-            "moment": "^2.24.0"
-          },
-          "dependencies": {
-            "jalaali-js": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.1.0.tgz",
-              "integrity": "sha512-eznOFGRtHb0ttHkHf8pVYPVfKJdbOqutTwcQYACbv91Q2NiYgnM5Z6+NN/8FMAhuMDAXAmeAG9+UBzqVKdA4cg=="
-            },
-            "moment": {
-              "version": "2.24.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-              "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-            }
-          }
-        },
-        "@bbc/psammead-timestamp": {
-          "version": "4.0.6",
-          "requires": {
-            "@bbc/gel-foundations": "^6.0.0",
-            "@bbc/psammead-styles": "^7.0.1"
-          },
-          "dependencies": {
-            "@bbc/gel-foundations": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-6.0.0.tgz",
-              "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
-            },
-            "@bbc/psammead-styles": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.1.tgz",
-              "integrity": "sha512-QGgLxJNpOPVAa9XHrCaY8NkU3JDcF65+RO438ZB8v0kZMDJeJvdmF/waZt98POtV/ky2CULhPu5YF4bQi0Omiw=="
-            }
-          }
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-6.0.0.tgz",
+          "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
         },
         "moment": {
           "version": "2.29.1",
@@ -127,369 +96,6 @@
           "requires": {
             "moment": ">= 2.9.0"
           }
-        }
-      }
-    },
-    "@emotion/styled": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-      "requires": {
-        "@emotion/styled-base": "^10.0.27",
-        "babel-plugin-emotion": "^10.0.27"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-          "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
-          "requires": {
-            "@babel/types": "^7.12.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.12",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-        },
-        "@emotion/is-prop-valid": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-          "requires": {
-            "@emotion/memoize": "0.7.4"
-          }
-        },
-        "@emotion/memoize": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-        },
-        "@emotion/serialize": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-          "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-          "requires": {
-            "@emotion/hash": "0.8.0",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/unitless": "0.7.5",
-            "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
-          }
-        },
-        "@emotion/styled-base": {
-          "version": "10.0.31",
-          "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-          "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/is-prop-valid": "0.8.8",
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/utils": "0.11.3"
-          }
-        },
-        "@emotion/unitless": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-        },
-        "@emotion/utils": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-        },
-        "@types/parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "babel-plugin-emotion": {
-          "version": "10.0.33",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
-          "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.8.0",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/serialize": "^0.11.16",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "babel-plugin-macros": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-          "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-          "requires": {
-            "@babel/runtime": "^7.7.2",
-            "cosmiconfig": "^6.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-          "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-        },
-        "callsites": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "convert-source-map": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        },
-        "csstype": {
-          "version": "2.6.14",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
-        },
-        "error-ex": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "find-root": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-          "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "import-fresh": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
-        "is-core-module": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-          "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        },
-        "json-parse-even-better-errors": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
-        },
-        "lines-and-columns": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-          "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        },
-        "parent-module": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-          "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-          "requires": {
-            "callsites": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        },
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        },
-        "yaml": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-          "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
         }
       }
     }

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
**Overall change:** 

Running against psammead-styles, Talos was failing with the below error:
```
Error: Command failed: npm install
npm ERR! Cannot read property 'match' of undefined
```

After extensive searching, it was found that this error lay within `psammead-radio-schedule`. I think this was caused by the recent removal of Emotion v10 from root Psammead - psammead-radio-schedule's package-lock still made reference to v10, which was no longer in any dependency.

**Code changes:**

- Delete psammead-radio-schedule's package-lock
- Re-run npm install

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
