### PR TITLE
Talos - Bump @bbc/psammead-styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.75 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.74 | [PR#4222](https://github.com/bbc/psammead/pull/4222) Talos - Bump Dependencies - @bbc/psammead-test-helpers |
 | 4.0.73 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
 | 4.0.72 | [PR#4250](https://github.com/bbc/psammead/pull/4250) Revert #4249 changes to psammead-manual-talos workflow name |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.74",
+  "version": "4.0.75",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1798,9 +1798,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug==",
       "dev": true
     },
     "@bbc/psammead-test-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.74",
+  "version": "4.0.75",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -95,7 +95,7 @@
     "@bbc/psammead-story-promo": "^8.0.9",
     "@bbc/psammead-story-promo-list": "^6.0.7",
     "@bbc/psammead-storybook-helpers": "^9.0.7",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-test-helpers": "^6.0.0",
     "@bbc/psammead-timestamp": "^4.0.8",
     "@bbc/psammead-timestamp-container": "^5.0.17",

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.0.21 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.20 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 7.0.19 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.18 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-brand/package-lock.json
+++ b/packages/components/psammead-brand/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.20",
+  "version": "7.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,9 +20,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug==",
       "dev": true
     },
     "@bbc/psammead-visually-hidden-text": {

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.20",
+  "version": "7.0.21",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@bbc/psammead-script-link": "^3.0.8",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-bulleted-list/CHANGELOG.md
+++ b/packages/components/psammead-bulleted-list/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                           |
 | ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| 3.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8         | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11                                           |
 | 3.0.7         | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles                 |
 | 3.0.6         | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles                 |

--- a/packages/components/psammead-bulleted-list/package-lock.json
+++ b/packages/components/psammead-bulleted-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-bulleted-list/package.json
+++ b/packages/components/psammead-bulleted-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-bulleted-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.20 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.19 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 5.0.18 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-live-label, @bbc/psammead-story-promo |
 | 5.0.17 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-bulletin/package-lock.json
+++ b/packages/components/psammead-bulletin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.19",
+  "version": "5.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.19",
+  "version": "5.0.20",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^3.1.2",
     "@bbc/psammead-live-label": "^2.0.8",
     "@bbc/psammead-story-promo": "^8.0.9",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-visually-hidden-text": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-byline/CHANGELOG.md
+++ b/packages/components/psammead-byline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8         | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11                                 |
 | 3.0.7         | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles       |
 | 3.0.6         | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles       |

--- a/packages/components/psammead-byline/package-lock.json
+++ b/packages/components/psammead-byline/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-byline",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-byline/package.json
+++ b/packages/components/psammead-byline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-byline",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-byline/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.5 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.1.4 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.1.3 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.1.2 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-caption/package-lock.json
+++ b/packages/components/psammead-caption/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-copyright/package-lock.json
+++ b/packages/components/psammead-copyright/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version        | Description                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 3.0.11 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.10         | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11                                                 |
 | 3.0.9          | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles                       |
 | 3.0.8          | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-styles |

--- a/packages/components/psammead-embed-error/package-lock.json
+++ b/packages/components/psammead-embed-error/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-embed-error/package.json
+++ b/packages/components/psammead-embed-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-assets": "^3.1.2",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 1.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 1.0.7 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-section-label |
 | 1.0.6 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-episode-list/package-lock.json
+++ b/packages/components/psammead-episode-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,9 +34,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-assets": "^3.1.2",
     "@bbc/psammead-image-placeholder": "^3.0.9",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.12 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.11 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.10 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.9 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-grid/package-lock.json
+++ b/packages/components/psammead-grid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-heading-index/package-lock.json
+++ b/packages/components/psammead-heading-index/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-heading-index/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 5.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-headings/package-lock.json
+++ b/packages/components/psammead-headings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.11 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.10 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.9 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-assets, @bbc/psammead-styles |

--- a/packages/components/psammead-image-placeholder/package-lock.json
+++ b/packages/components/psammead-image-placeholder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
     "@bbc/psammead-assets": "^3.1.2",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.8 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.7 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.6 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.5 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-inline-link/package-lock.json
+++ b/packages/components/psammead-inline-link/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "React component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.10 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 2.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 2.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-live-label/package-lock.json
+++ b/packages/components/psammead-live-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-live-label",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-live-label/package.json
+++ b/packages/components/psammead-live-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-live-label",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-social-embed/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-visually-hidden-text": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.11 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.10 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 6.0.9 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.8 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles, @bbc/psammead-assets |

--- a/packages/components/psammead-media-indicator/package-lock.json
+++ b/packages/components/psammead-media-indicator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-assets": "^3.1.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.18 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.17 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 6.0.16 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-grid |
 | 6.0.15 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-most-read/package-lock.json
+++ b/packages/components/psammead-most-read/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "6.0.17",
+  "version": "6.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "6.0.17",
+  "version": "6.0.18",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-grid": "^3.0.10",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.0.3 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 9.0.2 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 9.0.1 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 9.0.0 | [PR#4187](https://github.com/bbc/psammead/pull/4187) Require colours to be passed in as props |

--- a/packages/components/psammead-navigation/package-lock.json
+++ b/packages/components/psammead-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-assets": "^3.1.2",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-visually-hidden-text": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-paragraph/package-lock.json
+++ b/packages/components/psammead-paragraph/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "React component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-play-button/CHANGELOG.md
+++ b/packages/components/psammead-play-button/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------------- | ----------- |
+| 3.0.11 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.10 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.9 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.8 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles, @bbc/psammead-assets |

--- a/packages/components/psammead-play-button/package-lock.json
+++ b/packages/components/psammead-play-button/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-efI7PAXtluhDW9UnOFS3lwv/Q0xyMtPswFEBQvbTe+sRG0p88bdwrXwlieo7ezAr+32qB/SabawZ02uArL7IUQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-play-button/package.json
+++ b/packages/components/psammead-play-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Provides a play button, with optional duration, for playable media.",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-play-button/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-assets": "^3.1.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.16 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 0.1.0-alpha.15 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 0.1.0-alpha.14 | [PR#4227](https://github.com/bbc/psammead/pull/4227) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.13 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-podcast-promo/package-lock.json
+++ b/packages/components/psammead-podcast-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-visually-hidden-text": {
       "version": "2.0.1",

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "^6.0.0",
     "@bbc/psammead-assets": "^3.1.2",
     "@bbc/psammead-image-placeholder": "^3.0.9",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.13 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 5.1.12 | [PR#4255](https://github.com/bbc/psammead/pull/4255) Fix package-lock.json issue causing npm install error |
 | 5.1.11 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 5.1.10 | [PR#4228](https://github.com/bbc/psammead/pull/4228) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |

--- a/packages/components/psammead-radio-schedule/package-lock.json
+++ b/packages/components/psammead-radio-schedule/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -56,9 +56,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     },
     "@bbc/psammead-timestamp": {
       "version": "4.0.9",

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,7 +23,7 @@
     "@bbc/psammead-assets": "^3.1.2",
     "@bbc/psammead-grid": "^3.0.10",
     "@bbc/psammead-live-label": "^2.0.8",
-    "@bbc/psammead-styles": "^7.0.3",
+    "@bbc/psammead-styles": "^7.2.0",
     "@bbc/psammead-timestamp-container": "^5.0.17",
     "@bbc/psammead-detokeniser": "^1.0.0"
   },

--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.10 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-script-link/package-lock.json
+++ b/packages/components/psammead-script-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-script-link/package.json
+++ b/packages/components/psammead-script-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-script-link/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 7.0.10 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 7.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 7.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-section-label/package-lock.json
+++ b/packages/components/psammead-section-label/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-sitewide-links/CHANGELOG.md
+++ b/packages/components/psammead-sitewide-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 6.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-sitewide-links/package-lock.json
+++ b/packages/components/psammead-sitewide-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-sitewide-links/package.json
+++ b/packages/components/psammead-sitewide-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-sitewide-links",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "description": "React component for a sitewide-links",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-sitewide-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.1.6 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.1.5         | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11                                 |
 | 3.1.4         | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles       |
 | 3.1.3         | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles       |

--- a/packages/components/psammead-social-embed/package-lock.json
+++ b/packages/components/psammead-social-embed/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-social-embed/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.9 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.8 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 6.0.7 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 6.0.6 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo-list/package-lock.json
+++ b/packages/components/psammead-story-promo-list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.11 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 8.0.10 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 8.0.9 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 8.0.8 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-story-promo/package-lock.json
+++ b/packages/components/psammead-story-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.10 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 4.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 4.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-timestamp/package-lock.json
+++ b/packages/components/psammead-timestamp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-useful-links/CHANGELOG.md
+++ b/packages/components/psammead-useful-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.10 | [PR#4256](https://github.com/bbc/psammead/pull/4256) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.9 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
 | 3.0.8 | [PR#4226](https://github.com/bbc/psammead/pull/4226) Talos - Bump Dependencies - @bbc/psammead-styles |
 | 3.0.7 | [PR#4189](https://github.com/bbc/psammead/pull/4189) Talos - Bump Dependencies - @bbc/psammead-styles |

--- a/packages/components/psammead-useful-links/package-lock.json
+++ b/packages/components/psammead-useful-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-4J5bASYmI5i7tniJkDpN7ZDlWHgZEvS4Ij4CEiVSQ1dz9zGzoWu8A3yBJ5cyAs2MTX97ZgHV8ZDR9les9C9CcQ=="
     },
     "@bbc/psammead-styles": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.0.3.tgz",
-      "integrity": "sha512-2VdLMpkyjRukJPFgE1T+M5f7BOsOawvzKVfRIb12I6njUSfViLR3QqNteeGzvrGnDrY9JX2qW/mlAlDtCH1txw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.0.tgz",
+      "integrity": "sha512-Tvshia3KDj1hCcFPWBkC5qagCTVzOSL15GF+vYHAFEhoFyjGAWcdpktVhvbhl8dYU5cP4H18ZTscuTZXuT/Uug=="
     }
   }
 }

--- a/packages/components/psammead-useful-links/package.json
+++ b/packages/components/psammead-useful-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-useful-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "^6.0.0",
-    "@bbc/psammead-styles": "^7.0.3"
+    "@bbc/psammead-styles": "^7.2.0"
   },
   "peerDependencies": {
     "react": "^16.9.0",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-heading-index

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-grid

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-consent-banner

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-episode-list

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-social-embed

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-live-label

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-brand

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-bulletin

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-byline

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-image-placeholder

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-most-read

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-podcast-promo

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-bulleted-list

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-radio-schedule

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-inline-link

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-caption

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-embed-error

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-copyright

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-headings

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-story-promo

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-sitewide-links

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-paragraph

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-media-indicator

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-play-button

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-script-link

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-section-label

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-navigation

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-useful-links

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-story-promo-list

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>


@bbc/psammead-timestamp

<details>
<summary>Details</summary>
@bbc/psammead-styles  ^7.0.3  →  ^7.2.0

| Version | Description |
|---------|-------------|
| 7.2.0 | [PR#4245](https://github.com/bbc/psammead/pull/4245) Add consent focus colour required for the consent banner |
| 7.1.0 | [PR#4253](https://github.com/bbc/psammead/pull/4231) Corrects fonts constant name from newsbeat to newsround |
| 7.0.4 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
</details>

