### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.75 | [PR#4257](https://github.com/bbc/psammead/pull/4257) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.74 | [PR#4222](https://github.com/bbc/psammead/pull/4222) Talos - Bump Dependencies - @bbc/psammead-test-helpers |
 | 4.0.73 | [PR#4231](https://github.com/bbc/psammead/pull/4231) Upgrade psammead styles to Emotion v11 & remove Emotion 10 packages from root dependencies |
 | 4.0.72 | [PR#4250](https://github.com/bbc/psammead/pull/4250) Revert #4249 changes to psammead-manual-talos workflow name |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.74",
+  "version": "4.0.75",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1695,9 +1695,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.10.tgz",
-      "integrity": "sha512-BYckdjNf2/pnv0WUdvPSqWAynfyogTjGsx39sWCH6bhsdZy1wdtLnXMShPeRhGPGJKnsG8d5uFWPODxAXNuRxA==",
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.12.tgz",
+      "integrity": "sha512-tOP9VdIPhd4YSNAebhlRTxRdaeRPBD88d6YIJOij5n1lTix0+DsKAjfMKrPywZRvzaJhZQ2Wb4JMhy3q5R9WeA==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.74",
+  "version": "4.0.75",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^9.0.1",
     "@bbc/psammead-paragraph": "^4.0.7",
     "@bbc/psammead-play-button": "^3.0.9",
-    "@bbc/psammead-radio-schedule": "5.1.10",
+    "@bbc/psammead-radio-schedule": "5.1.12",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.8",
     "@bbc/psammead-section-label": "^7.0.8",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.1.10  →  5.1.12

| Version | Description |
|---------|-------------|
| 5.1.12 | [PR#4255](https://github.com/bbc/psammead/pull/4255) Fix package-lock.json issue causing npm install error |
| 5.1.11 | [PR#4193](https://github.com/bbc/psammead/pull/4193) Upgrade Emotion to v11 |
</details>

