### PR TITLE
Talos - Bump @bbc/psammead-radio-schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.79 | [PR#4262](https://github.com/bbc/psammead/pull/4262) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |
 | 4.0.78 | [PR#4259](https://github.com/bbc/psammead/pull/4259) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulletin, @bbc/psammead-episode-list, @bbc/psammead-media-player, @bbc/psammead-most-read, @bbc/psammead-radio-schedule, @bbc/psammead-timestamp-container |
 | 4.0.77 | [PR#4260](https://github.com/bbc/psammead/pull/4260) Talos - Bump Dependencies - @bbc/gel-foundations |
 | 4.0.76 | [PR#4258](https://github.com/bbc/psammead/pull/4258) Talos - Bump Dependencies - @bbc/psammead-brand, @bbc/psammead-bulleted-list, @bbc/psammead-bulletin, @bbc/psammead-byline, @bbc/psammead-caption, @bbc/psammead-consent-banner, @bbc/psammead-copyright, @bbc/psammead-embed-error, @bbc/psammead-episode-list, @bbc/psammead-grid, @bbc/psammead-heading-index, @bbc/psammead-headings, @bbc/psammead-image-placeholder, @bbc/psammead-inline-link, @bbc/psammead-live-label, @bbc/psammead-media-indicator, @bbc/psammead-most-read, @bbc/psammead-navigation, @bbc/psammead-paragraph, @bbc/psammead-play-button, @bbc/psammead-radio-schedule, @bbc/psammead-script-link, @bbc/psammead-section-label, @bbc/psammead-sitewide-links, @bbc/psammead-social-embed, @bbc/psammead-story-promo, @bbc/psammead-story-promo-list, @bbc/psammead-timestamp, @bbc/psammead-useful-links |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.78",
+  "version": "4.0.79",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1695,18 +1695,18 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.14.tgz",
-      "integrity": "sha512-g4H8FrycgAdwiXR4W3kbIx0aP5KzXJU/0HiM3uBd3oUr0JbHEQW9frKHecNl7TDocsdgd/uN4ObBTWd5cLBR1g==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.16.tgz",
+      "integrity": "sha512-KbghMlc9x0spx38CYWFLnHYSEwmMnbrnnEQVeWeGItSmHoptTYKP190d02cd9p/6hmCrpMMI0XoDWck9roI7FA==",
       "dev": true,
       "requires": {
-        "@bbc/gel-foundations": "^6.0.0",
+        "@bbc/gel-foundations": "^6.1.0",
         "@bbc/psammead-assets": "^3.1.2",
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-grid": "^3.0.12",
         "@bbc/psammead-live-label": "^2.0.10",
         "@bbc/psammead-styles": "^7.2.0",
-        "@bbc/psammead-timestamp-container": "^5.0.17"
+        "@bbc/psammead-timestamp-container": "^5.0.18"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.78",
+  "version": "4.0.79",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -86,7 +86,7 @@
     "@bbc/psammead-navigation": "^9.0.3",
     "@bbc/psammead-paragraph": "^4.0.9",
     "@bbc/psammead-play-button": "^3.0.11",
-    "@bbc/psammead-radio-schedule": "5.1.14",
+    "@bbc/psammead-radio-schedule": "5.1.16",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.10",
     "@bbc/psammead-section-label": "^7.0.10",


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-radio-schedule  5.1.14  →  5.1.16

| Version | Description |
|---------|-------------|
| 5.1.16 | [PR#4259](https://github.com/bbc/psammead/pull/4259) Talos - Bump Dependencies - @bbc/psammead-timestamp-container |
| 5.1.15 | [PR#4260](https://github.com/bbc/psammead/pull/4260) Talos - Bump Dependencies - @bbc/gel-foundations |
</details>

