### PR TITLE
add flex-basis (min-width) for image when viewport < 400px

### DIFF
--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.24 | [PR#4292](https://github.com/bbc/psammead/pull/4292) adds a width to the image for small viewports |
 | 0.1.0-alpha.23 | [PR#4289](https://github.com/bbc/psammead/pull/4289) fix broken UI in IE11 |
 | 0.1.0-alpha.22 | [PR#4273](https://github.com/bbc/psammead/pull/4273) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.21 | [PR#4271](https://github.com/bbc/psammead/pull/4271) change react peer dep to >=16.9.0 |

--- a/packages/components/psammead-podcast-promo/package-lock.json
+++ b/packages/components/psammead-podcast-promo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.23",
+  "version": "0.1.0-alpha.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.23",
+  "version": "0.1.0-alpha.24",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-podcast-promo/src/__snapshots__/index.test.jsx.snap
@@ -144,11 +144,6 @@ exports[`Podcast Promo Card Image should match snapshot 1`] = `
 @media (min-width:20rem) {
   .emotion-0 {
     display: block;
-  }
-}
-
-@media (min-width:25rem) {
-  .emotion-0 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -156,6 +151,14 @@ exports[`Podcast Promo Card Image should match snapshot 1`] = `
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
+    -webkit-flex-basis: 6.5rem;
+    -ms-flex-preferred-size: 6.5rem;
+    flex-basis: 6.5rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .emotion-0 {
     -webkit-flex-basis: 6.8125rem;
     -ms-flex-preferred-size: 6.8125rem;
     flex-basis: 6.8125rem;
@@ -371,11 +374,6 @@ exports[`Podcast Promo Examples basic example 1`] = `
 @media (min-width:20rem) {
   .emotion-10 {
     display: block;
-  }
-}
-
-@media (min-width:25rem) {
-  .emotion-10 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -383,6 +381,14 @@ exports[`Podcast Promo Examples basic example 1`] = `
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
+    -webkit-flex-basis: 6.5rem;
+    -ms-flex-preferred-size: 6.5rem;
+    flex-basis: 6.5rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .emotion-10 {
     -webkit-flex-basis: 6.8125rem;
     -ms-flex-preferred-size: 6.8125rem;
     flex-basis: 6.8125rem;
@@ -799,11 +805,6 @@ exports[`Podcast Promo Examples on-page example 1`] = `
 @media (min-width:20rem) {
   .emotion-20 {
     display: block;
-  }
-}
-
-@media (min-width:25rem) {
-  .emotion-20 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -811,6 +812,14 @@ exports[`Podcast Promo Examples on-page example 1`] = `
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
+    -webkit-flex-basis: 6.5rem;
+    -ms-flex-preferred-size: 6.5rem;
+    flex-basis: 6.5rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .emotion-20 {
     -webkit-flex-basis: 6.8125rem;
     -ms-flex-preferred-size: 6.8125rem;
     flex-basis: 6.8125rem;

--- a/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
+++ b/packages/components/psammead-podcast-promo/src/components/card-image-wrapper.jsx
@@ -12,10 +12,11 @@ const CardImageWrapper = styled.div`
   display: none;
   @media (min-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
     display: block;
-  }
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     flex-grow: 0;
     flex-shrink: 0;
+    flex-basis: 6.5rem;
+  }
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     flex-basis: 6.8125rem;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8800

**Overall change:**
Fixes jumpy flex box item resizing observed on some mobile devices.

Set the width of the podcast promo image container on viewports less than 400px wide so that flexbox doesn't take control of setting the width. Width was taken from https://app.zeplin.io/project/5d4d77b1fcbfc79bf47e0294/screen/5fa450f1ad5bb11b3b27ace0

Before change
<img width="175" alt="Screenshot 2021-01-27 at 12 49 34" src="https://user-images.githubusercontent.com/4798332/105993329-2c580f80-609e-11eb-8f3b-f27e29338eec.png">

After change
<img width="177" alt="Screenshot 2021-01-27 at 12 48 29" src="https://user-images.githubusercontent.com/4798332/105993342-31b55a00-609e-11eb-89d7-fce9d9bea880.png">


**Code changes:**

- Adds flex basis to set the width of image container when the image shows at 320px width
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
