### PR TITLE
Canonical ConsentBanner UX and a11y amendments

### DIFF
--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.0 | [PR#4293](https://github.com/bbc/psammead/pull/4293) UX and a11y amendments |
 | 5.0.0 | [PR#4225](https://github.com/bbc/psammead/pull/4225) Update design |
 | 4.0.11 | [PR#4271](https://github.com/bbc/psammead/pull/4271) change react peer dep to >=16.9.0 |
 | 4.0.10 | [PR#4260](https://github.com/bbc/psammead/pull/4260) Talos - Bump Dependencies - @bbc/gel-foundations |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -6,26 +6,24 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  padding: 1rem 0.5rem;
   border-top: solid 0.125rem transparent;
 }
 
-@media (min-width:25rem) {
+@media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: 1rem;
+    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .emotion-0 {
+    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: calc(2rem - 0.125rem);
-    padding-bottom: 2rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .emotion-0 {
-    padding-top: calc(1rem - 0.125rem);
+    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
   }
 }
 
@@ -261,26 +259,24 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  padding: 1rem 0.5rem;
   border-top: solid 0.125rem transparent;
 }
 
-@media (min-width:25rem) {
+@media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: 1rem;
+    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .emotion-0 {
+    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: calc(2rem - 0.125rem);
-    padding-bottom: 2rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .emotion-0 {
-    padding-top: calc(1rem - 0.125rem);
+    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
   }
 }
 
@@ -516,26 +512,24 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  padding: 1rem 0.5rem;
   border-top: solid 0.125rem transparent;
 }
 
-@media (min-width:25rem) {
+@media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: 1rem;
+    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .emotion-0 {
+    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: calc(2rem - 0.125rem);
-    padding-bottom: 2rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .emotion-0 {
-    padding-top: calc(1rem - 0.125rem);
+    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
   }
 }
 

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   font-style: normal;
   background-color: #323232;
   padding: 1rem 0.5rem;
+  border-top: solid 0.125rem transparent;
 }
 
 @media (min-width:25rem) {
@@ -17,8 +18,14 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    padding-top: calc(2rem - 0.125rem);
     padding-bottom: 2rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .emotion-0 {
+    padding-top: calc(1rem - 0.125rem);
   }
 }
 
@@ -29,21 +36,24 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 
 .emotion-2 a {
   color: #F6A21D;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-text-decoration-color: #AEAEB5;
-  text-decoration-color: #AEAEB5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: solid 0.0625rem #AEAEB5;
 }
 
 .emotion-2 a:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
 .emotion-2 a:hover {
   color: #222222;
   background-color: #F6A21D;
+}
+
+.emotion-2 a:hover,
+.emotion-2 a:focus {
+  border-bottom: solid 0.125rem transparent;
 }
 
 .emotion-4 {
@@ -79,6 +89,10 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   color: #F6A21D;
   font-weight: 600;
   padding: 0;
@@ -101,7 +115,9 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 .emotion-6 li+li {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -165,9 +181,14 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   }
 }
 
+.emotion-8 button:hover,
 .emotion-8 button:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8 button:focus {
+  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,
@@ -176,7 +197,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   background-color: #F6A21D;
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:25rem) {
   .emotion-8 {
     width: 17.3125rem;
   }
@@ -204,6 +225,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
       <ul
         class="emotion-6 emotion-7"
         dir="ltr"
+        role="list"
       >
         <li
           class="emotion-8 emotion-9"
@@ -219,11 +241,13 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
           class="emotion-8 emotion-9"
           dir="ltr"
         >
-          <a
-            href="https://foobar.com"
-          >
-            Reject
-          </a>
+          <span>
+            <a
+              href="https://foobar.com"
+            >
+              Reject
+            </a>
+          </span>
         </li>
       </ul>
     </div>
@@ -238,6 +262,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   font-style: normal;
   background-color: #323232;
   padding: 1rem 0.5rem;
+  border-top: solid 0.125rem transparent;
 }
 
 @media (min-width:25rem) {
@@ -248,8 +273,14 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    padding-top: calc(2rem - 0.125rem);
     padding-bottom: 2rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .emotion-0 {
+    padding-top: calc(1rem - 0.125rem);
   }
 }
 
@@ -260,21 +291,24 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 
 .emotion-2 a {
   color: #F6A21D;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-text-decoration-color: #AEAEB5;
-  text-decoration-color: #AEAEB5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: solid 0.0625rem #AEAEB5;
 }
 
 .emotion-2 a:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
 .emotion-2 a:hover {
   color: #222222;
   background-color: #F6A21D;
+}
+
+.emotion-2 a:hover,
+.emotion-2 a:focus {
+  border-bottom: solid 0.125rem transparent;
 }
 
 .emotion-4 {
@@ -310,6 +344,10 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   color: #F6A21D;
   font-weight: 600;
   padding: 0;
@@ -332,7 +370,9 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 .emotion-6 li+li {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -396,9 +436,14 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   }
 }
 
+.emotion-8 button:hover,
 .emotion-8 button:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8 button:focus {
+  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,
@@ -407,7 +452,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   background-color: #F6A21D;
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:25rem) {
   .emotion-8 {
     width: 17.3125rem;
   }
@@ -435,6 +480,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
       <ul
         class="emotion-6 emotion-7"
         dir="rtl"
+        role="list"
       >
         <li
           class="emotion-8 emotion-9"
@@ -450,11 +496,13 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
           class="emotion-8 emotion-9"
           dir="rtl"
         >
-          <a
-            href="https://foobar.com"
-          >
-            رفض
-          </a>
+          <span>
+            <a
+              href="https://foobar.com"
+            >
+              رفض
+            </a>
+          </span>
         </li>
       </ul>
     </div>
@@ -469,6 +517,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   font-style: normal;
   background-color: #323232;
   padding: 1rem 0.5rem;
+  border-top: solid 0.125rem transparent;
 }
 
 @media (min-width:25rem) {
@@ -479,8 +528,14 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    padding-top: calc(2rem - 0.125rem);
     padding-bottom: 2rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .emotion-0 {
+    padding-top: calc(1rem - 0.125rem);
   }
 }
 
@@ -491,21 +546,24 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 
 .emotion-2 a {
   color: #F6A21D;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-text-decoration-color: #AEAEB5;
-  text-decoration-color: #AEAEB5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: solid 0.0625rem #AEAEB5;
 }
 
 .emotion-2 a:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
 .emotion-2 a:hover {
   color: #222222;
   background-color: #F6A21D;
+}
+
+.emotion-2 a:hover,
+.emotion-2 a:focus {
+  border-bottom: solid 0.125rem transparent;
 }
 
 .emotion-4 {
@@ -541,6 +599,10 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   color: #F6A21D;
   font-weight: 600;
   padding: 0;
@@ -563,7 +625,9 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 .emotion-6 li+li {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -627,9 +691,14 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   }
 }
 
+.emotion-8 button:hover,
 .emotion-8 button:focus {
-  outline: none;
-  box-shadow: 0rem 0rem 0.0625rem 0.1875rem #68A1F8;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8 button:focus {
+  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,
@@ -638,7 +707,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   background-color: #F6A21D;
 }
 
-@media (min-width:37.5rem) {
+@media (min-width:25rem) {
   .emotion-8 {
     width: 17.3125rem;
   }
@@ -667,6 +736,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
       <ul
         class="emotion-6 emotion-7"
         dir="ltr"
+        role="list"
       >
         <li
           class="emotion-8 emotion-9"
@@ -682,11 +752,13 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
           class="emotion-8 emotion-9"
           dir="ltr"
         >
-          <a
-            href="https://foobar.com"
-          >
-            Reject
-          </a>
+          <span>
+            <a
+              href="https://foobar.com"
+            >
+              Reject
+            </a>
+          </span>
         </li>
       </ul>
     </div>

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -25,16 +25,19 @@ import {
 import {
   GEL_MARGIN_BELOW_400PX,
   GEL_MARGIN_ABOVE_400PX,
+  GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
+// Transparent border is to show edge of component in high-contrast mode
+const transparentBorderHeight = '0.125rem';
+
 const hoverFocusStyles = `
   &:focus {
-    outline: none;
-    box-shadow: 0rem 0rem 0.0625rem 0.1875rem ${C_CONSENT_FOCUS};
+    outline: solid ${C_CONSENT_FOCUS};
   }
   &:focus,
   &:hover {
@@ -47,14 +50,19 @@ const Wrapper = styled.div`
   ${({ service }) => getSansRegular(service)}
   background-color: ${C_CONSENT_BACKGROUND};
   padding: ${GEL_SPACING_DBL} ${GEL_MARGIN_BELOW_400PX};
+  border-top: solid 0.125rem transparent;
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     padding: ${GEL_MARGIN_ABOVE_400PX};
   }
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    padding-top: ${GEL_SPACING_QUAD};
+    padding-top: calc(${GEL_SPACING_QUAD} - ${transparentBorderHeight});
     padding-bottom: ${GEL_SPACING_QUAD};
+  }
+
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    padding-top: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight});
   }
 `;
 
@@ -64,10 +72,15 @@ const CenterWrapper = styled.div`
 
   a {
     color: ${C_CONSENT_ACTION};
-    text-decoration: underline;
-    text-decoration-color: ${C_PEBBLE};
+    text-decoration: none;
+    border-bottom: solid 0.0625rem ${C_PEBBLE};
 
     ${hoverFocusStyles}
+  }
+
+  a:hover,
+  a:focus {
+    border-bottom: solid 0.125rem transparent;
   }
 `;
 
@@ -86,6 +99,7 @@ const Options = styled.ul`
   ${({ script }) => script && getLongPrimer(script)};
   display: flex;
   flex-direction: column;
+  align-items: center;
   color: ${C_CONSENT_ACTION};
   font-weight: 600;
   padding: 0;
@@ -93,7 +107,9 @@ const Options = styled.ul`
   list-style-type: none;
 
   & li + li {
-    margin-top: ${GEL_SPACING_DBL};
+    margin-top: ${GEL_SPACING};
+    padding-top: ${GEL_SPACING_DBL};
+    padding-bottom: ${GEL_SPACING_DBL};
     display: flex;
     align-items: center;
     justify-content: center;
@@ -137,10 +153,15 @@ const ListItem = styled.li`
     margin: 0;
     cursor: pointer;
 
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+
     ${hoverFocusStyles}
   }
 
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     width: 17.3125rem;
   }
 `;
@@ -162,12 +183,12 @@ export const ConsentBanner = ({
         {title}
       </Title>
       {text}
-      <Options dir={dir} script={script}>
+      <Options dir={dir} script={script} role="list">
         <ListItem dir={dir} script={script}>
           {accept}
         </ListItem>
         <ListItem dir={dir} script={script}>
-          {reject}
+          <span>{reject}</span>
         </ListItem>
       </Options>
     </CenterWrapper>

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -18,13 +18,12 @@ import {
   getBodyCopy,
 } from '@bbc/gel-foundations/typography';
 import {
+  GEL_GROUP_1_SCREEN_WIDTH_MAX,
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_2_SCREEN_WIDTH_MAX,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import {
-  GEL_MARGIN_BELOW_400PX,
-  GEL_MARGIN_ABOVE_400PX,
   GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
@@ -32,7 +31,7 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-// Transparent border is to show edge of component in high-contrast mode
+// Transparent border is to show edge of component and link underline on hover/focus in high-contrast mode
 const transparentBorderHeight = '0.125rem';
 
 const hoverFocusStyles = `
@@ -49,20 +48,19 @@ const hoverFocusStyles = `
 const Wrapper = styled.div`
   ${({ service }) => getSansRegular(service)}
   background-color: ${C_CONSENT_BACKGROUND};
-  padding: ${GEL_SPACING_DBL} ${GEL_MARGIN_BELOW_400PX};
-  border-top: solid 0.125rem transparent;
+  border-top: solid ${transparentBorderHeight} transparent;
 
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    padding: ${GEL_MARGIN_ABOVE_400PX};
+  @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
+    padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
+      ${GEL_SPACING} ${GEL_SPACING_DBL} ${GEL_SPACING};
   }
-
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
+      ${GEL_SPACING_DBL} ${GEL_SPACING_DBL} ${GEL_SPACING_DBL};
+  }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    padding-top: calc(${GEL_SPACING_QUAD} - ${transparentBorderHeight});
-    padding-bottom: ${GEL_SPACING_QUAD};
-  }
-
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    padding-top: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight});
+    padding: calc(${GEL_SPACING_QUAD} - ${transparentBorderHeight})
+      ${GEL_SPACING_DBL} ${GEL_SPACING_QUAD} ${GEL_SPACING_DBL};
   }
 `;
 
@@ -80,7 +78,7 @@ const CenterWrapper = styled.div`
 
   a:hover,
   a:focus {
-    border-bottom: solid 0.125rem transparent;
+    border-bottom: solid ${transparentBorderHeight} transparent;
   }
 `;
 


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/4290

**Overall change:** _Updated consent banner component after recent amendments._

**Code changes:**

- _Padding updated to that of amended design._
- _Option width remains `277px` in GEL group 2._
- _`text-decoration: underline;` replaced with `border-bottom ` where the `<a>` is wrapped in a `span`._
- _Underline added to `<button>` hover/focus._
- _Reinstated `outline`._
- _Added `role="list"` to the Options `<ul>`._
- _Added a `2px` transparent `border-bottom` to links on focus and hover._
- _Added a `2px` transparent `border-top` to the Wrapper, and adjusted padding accordingly using `calc._`
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
