### PR TITLE
Canonical ConsentBanner a11y changes

### DIFF
--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.2.0 | [PR#4299](https://github.com/bbc/psammead/pull/4299) A11y fixes |
 | 5.1.0 | [PR#4293](https://github.com/bbc/psammead/pull/4293) UX and a11y amendments |
 | 5.0.0 | [PR#4225](https://github.com/bbc/psammead/pull/4225) Update design |
 | 4.0.11 | [PR#4271](https://github.com/bbc/psammead/pull/4271) change react peer dep to >=16.9.0 |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  border-top: solid 0.125rem transparent;
+  border-top: solid 0.0625rem transparent;
 }
 
 @media (max-width:24.9375rem) {
@@ -37,10 +37,6 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: solid 0.0625rem #AEAEB5;
-}
-
-.emotion-2 a:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
@@ -160,7 +156,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   color: #222222;
   font-weight: bold;
   background-color: #FDFDFD;
-  border: none;
+  border: solid 0.0625rem transparent;
   margin: 0;
   cursor: pointer;
 }
@@ -183,10 +179,6 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 .emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.emotion-8 button:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,
@@ -259,7 +251,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  border-top: solid 0.125rem transparent;
+  border-top: solid 0.0625rem transparent;
 }
 
 @media (max-width:24.9375rem) {
@@ -290,10 +282,6 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: solid 0.0625rem #AEAEB5;
-}
-
-.emotion-2 a:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
@@ -413,7 +401,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
   color: #222222;
   font-weight: bold;
   background-color: #FDFDFD;
-  border: none;
+  border: solid 0.0625rem transparent;
   margin: 0;
   cursor: pointer;
 }
@@ -436,10 +424,6 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 .emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.emotion-8 button:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,
@@ -512,7 +496,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   font-weight: 400;
   font-style: normal;
   background-color: #323232;
-  border-top: solid 0.125rem transparent;
+  border-top: solid 0.0625rem transparent;
 }
 
 @media (max-width:24.9375rem) {
@@ -543,10 +527,6 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: solid 0.0625rem #AEAEB5;
-}
-
-.emotion-2 a:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-2 a:focus,
@@ -666,7 +646,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
   color: #222222;
   font-weight: bold;
   background-color: #FDFDFD;
-  border: none;
+  border: solid 0.0625rem transparent;
   margin: 0;
   cursor: pointer;
 }
@@ -689,10 +669,6 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 .emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.emotion-8 button:focus {
-  outline: solid #68A1F8;
 }
 
 .emotion-8 button:focus,

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -11,19 +11,19 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
+    padding: calc(2rem - 0.0625rem) 1rem 2rem 1rem;
   }
 }
 
@@ -256,19 +256,19 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
+    padding: calc(2rem - 0.0625rem) 1rem 2rem 1rem;
   }
 }
 
@@ -501,19 +501,19 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.125rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-0 {
-    padding: calc(2rem - 0.125rem) 1rem 2rem 1rem;
+    padding: calc(2rem - 0.0625rem) 1rem 2rem 1rem;
   }
 }
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -6,7 +6,6 @@ import {
   C_CONSENT_BACKGROUND,
   C_CONSENT_ACTION,
   C_CONSENT_CONTENT,
-  C_CONSENT_FOCUS,
   C_WHITE,
   C_PEBBLE,
   C_EBON,
@@ -35,9 +34,6 @@ import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 const transparentBorderHeight = '0.125rem';
 
 const hoverFocusStyles = `
-  &:focus {
-    outline: solid ${C_CONSENT_FOCUS};
-  }
   &:focus,
   &:hover {
     color: ${C_EBON};
@@ -48,7 +44,7 @@ const hoverFocusStyles = `
 const Wrapper = styled.div`
   ${({ service }) => getSansRegular(service)}
   background-color: ${C_CONSENT_BACKGROUND};
-  border-top: solid ${transparentBorderHeight} transparent;
+  border-top: solid 0.0625rem transparent;
 
   @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
@@ -147,7 +143,7 @@ const ListItem = styled.li`
     color: ${C_EBON};
     font-weight: bold;
     background-color: ${C_GHOST};
-    border: none;
+    border: solid 0.0625rem transparent;
     margin: 0;
     cursor: pointer;
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -143,7 +143,7 @@ const ListItem = styled.li`
     color: ${C_EBON};
     font-weight: bold;
     background-color: ${C_GHOST};
-    border: solid 0.0625rem transparent;
+    border: solid ${transparentBorderHeight} transparent;
     margin: 0;
     cursor: pointer;
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -31,7 +31,7 @@ import {
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
 // Transparent border is to show edge of component and link underline on hover/focus in high-contrast mode
-const transparentBorderHeight = '0.125rem';
+const transparentBorderHeight = '0.0625rem';
 
 const hoverFocusStyles = `
   &:focus,
@@ -44,7 +44,7 @@ const hoverFocusStyles = `
 const Wrapper = styled.div`
   ${({ service }) => getSansRegular(service)}
   background-color: ${C_CONSENT_BACKGROUND};
-  border-top: solid 0.0625rem transparent;
+  border-top: solid ${transparentBorderHeight} transparent;
 
   @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
@@ -74,7 +74,7 @@ const CenterWrapper = styled.div`
 
   a:hover,
   a:focus {
-    border-bottom: solid ${transparentBorderHeight} transparent;
+    border-bottom: solid 0.125rem transparent;
   }
 `;
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -30,7 +30,7 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
-// Transparent border is to show edge of component and link underline on hover/focus in high-contrast mode
+// Transparent border is to show the top of the wrapper and button border in high-contrast mode
 const transparentBorderHeight = '0.0625rem';
 
 const hoverFocusStyles = `


### PR DESCRIPTION
Resolves #4290

**Overall change:** _ Some a11y fixes to the canonical consent banner._

**Code changes:**

- _Changed banner transparent border to 1px._
- _Removed outline styling so that the default is not overridden._
- _Added transparent border to the button so that the button is more visible in windows high contrast mode._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
