### PR TITLE
Wrapper padding bottom reduced to 8px

### DIFF
--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.3.0 | [PR#4301](https://github.com/bbc/psammead/pull/4301) Wrapper padding-bottom reduced |
 | 5.2.0 | [PR#4299](https://github.com/bbc/psammead/pull/4299) A11y fixes |
 | 5.1.0 | [PR#4293](https://github.com/bbc/psammead/pull/4293) UX and a11y amendments |
 | 5.0.0 | [PR#4225](https://github.com/bbc/psammead/pull/4225) Update design |

--- a/packages/components/psammead-consent-banner/package-lock.json
+++ b/packages/components/psammead-consent-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -11,13 +11,13 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 0.5rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 0.5rem 1rem;
   }
 }
 
@@ -256,13 +256,13 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 0.5rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 0.5rem 1rem;
   }
 }
 
@@ -501,13 +501,13 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 
 @media (max-width:24.9375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 0.5rem 1rem 0.5rem;
+    padding: calc(1rem - 0.0625rem) 0.5rem 0.5rem 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
   .emotion-0 {
-    padding: calc(1rem - 0.0625rem) 1rem 1rem 1rem;
+    padding: calc(1rem - 0.0625rem) 1rem 0.5rem 1rem;
   }
 }
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -48,11 +48,11 @@ const Wrapper = styled.div`
 
   @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
-      ${GEL_SPACING} ${GEL_SPACING_DBL} ${GEL_SPACING};
+      ${GEL_SPACING} ${GEL_SPACING} ${GEL_SPACING};
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     padding: calc(${GEL_SPACING_DBL} - ${transparentBorderHeight})
-      ${GEL_SPACING_DBL} ${GEL_SPACING_DBL} ${GEL_SPACING_DBL};
+      ${GEL_SPACING_DBL} ${GEL_SPACING} ${GEL_SPACING_DBL};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     padding: calc(${GEL_SPACING_QUAD} - ${transparentBorderHeight})


### PR DESCRIPTION
Contributes to completion of https://github.com/bbc/simorgh/issues/8668

**Overall change:** _Reduces spacing from 16px to 8px where viewport is of width 0-599px._

**Code changes:**

- _Wrapper padding-bottom reduced to `GEL_SPACING` instead of `GEL_SPACING_DBL` for GEL groups 0-2._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
