### PR TITLE
fix deploys - use node script publish not yarn publish

### DIFF
--- a/.github/workflows/psammead-publish.yml
+++ b/.github/workflows/psammead-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn ci:packages
 
       - name: Publish to NPM
-        run: yarn publish
+        run: yarn run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.99 | [PR#4352](https://github.com/bbc/psammead/pull/4352) fixes package publishing |
 | 4.0.98 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 4.0.97 | [PR#4330](https://github.com/bbc/psammead/pull/4330) Talos - Bump Dependencies - @bbc/psammead-episode-list |
 | 4.0.96 | [PR#4307](https://github.com/bbc/psammead/pull/4307) Talos - Bump Dependencies - @bbc/psammead-radio-schedule |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.98",
+  "version": "4.0.99",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,

--- a/scripts/changeScanner/getChanges.js
+++ b/scripts/changeScanner/getChanges.js
@@ -20,7 +20,7 @@ const getChanges = () => {
 
     const isValidPackageName = validPackageNamePattern.test(fileName);
 
-    const [packageName, filePath] = isValidPackageName
+    const [packageName] = isValidPackageName
       ? [nameParts[2], nameParts.splice(3).join('/')]
       : [DEFAULT_PACKAGE_NAME, fileName];
 
@@ -29,7 +29,7 @@ const getChanges = () => {
       : DEFAULT_PACKAGE_NAME;
 
     (changedPackages[revisedPackageName] =
-      changedPackages[revisedPackageName] || []).push(filePath);
+      changedPackages[revisedPackageName] || []).push(fileName);
   });
 
   return changedPackages;

--- a/scripts/changeScanner/getChanges.test.js
+++ b/scripts/changeScanner/getChanges.test.js
@@ -32,11 +32,14 @@ describe(`changeScanner - getChanges`, () => {
     const getChanges = require('./getChanges');
 
     expect(getChanges()).toEqual({
-      barfoo: ['package.json'],
-      foobar: ['index.js', 'index.test.js'],
-      apples: ['dist/package.json'],
-      'foo-bar': ['dist/package.json'],
-      'bar-foo': ['dist/package.json'],
+      foobar: [
+        'packages/components/foobar/index.js',
+        'packages/components/foobar/index.test.js',
+      ],
+      barfoo: ['packages/components/barfoo/package.json'],
+      apples: ['packages/components/apples/dist/package.json'],
+      'foo-bar': ['packages/containers/foo-bar/dist/package.json'],
+      'bar-foo': ['packages/utilities/bar-foo/dist/package.json'],
       psammead: [
         'scripts/getChanges.js',
         'scripts/changeScanner/index.js',

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -21,7 +21,7 @@ Object.keys(changes).forEach(packageName => {
           packageLockFileName,
           packageFileName,
         );
-        console.log('xxx', packageFilePath);
+        console.log('xxx', requiredFile);
         const localPackageFile = readFileSync(packageFilePath);
         const remotePackageFile = exec(`git show latest:${packageFilePath}`, {
           silent: true,

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -26,6 +26,10 @@ Object.keys(changes).forEach(packageName => {
           silent: true,
         }).stdout;
 
+        console.log('packageFilePath', packageFilePath);
+        console.log('localPackageFile', localPackageFile);
+        console.log('remotePackageFile', remotePackageFile);
+
         const localDeps = JSON.parse(localPackageFile).dependencies;
         const localDevDeps = JSON.parse(localPackageFile).devDependencies;
         const remoteDeps = JSON.parse(remotePackageFile).dependencies;

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -21,7 +21,7 @@ Object.keys(changes).forEach(packageName => {
           packageLockFileName,
           packageFileName,
         );
-        const localPackageFile = readFileSync(packageFilePath);
+        const localPackageFile = readFileSync(packageFilePath, 'utf8');
         const remotePackageFile = exec(`git show latest:${packageFilePath}`, {
           silent: true,
         }).stdout;

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -22,9 +22,12 @@ Object.keys(changes).forEach(packageName => {
           packageFileName,
         );
         const localPackageFile = readFileSync(packageFilePath, 'utf8');
-        const remotePackageFile = exec(`git show latest:${packageFilePath}`, {
-          silent: true,
-        }).stdout;
+        const remotePackageFile = exec(
+          `git show origin/latest:${packageFilePath}`,
+          {
+            silent: true,
+          },
+        ).stdout;
 
         console.log('packageFilePath', packageFilePath);
         console.log('localPackageFile', localPackageFile);

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -21,6 +21,7 @@ Object.keys(changes).forEach(packageName => {
           packageLockFileName,
           packageFileName,
         );
+        console.log('xxx', packageFilePath);
         const localPackageFile = readFileSync(packageFilePath);
         const remotePackageFile = exec(`git show latest:${packageFilePath}`, {
           silent: true,

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -38,7 +38,11 @@ Object.keys(changes).forEach(packageName => {
         if (depsHasChanged || devDepsHasChanged) {
           throw new Error();
         }
-      } else if (!changes[packageName].includes(requiredFile)) {
+      } else if (
+        !changes[packageName].some(changedFile =>
+          changedFile.includes(requiredFile),
+        )
+      ) {
         throw new Error();
       }
     } catch (error) {

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -21,7 +21,6 @@ Object.keys(changes).forEach(packageName => {
           packageLockFileName,
           packageFileName,
         );
-        console.log('xxx', requiredFile);
         const localPackageFile = readFileSync(packageFilePath);
         const remotePackageFile = exec(`git show latest:${packageFilePath}`, {
           silent: true,
@@ -47,6 +46,7 @@ Object.keys(changes).forEach(packageName => {
         throw new Error();
       }
     } catch (error) {
+      console.log('error', error);
       errors.push(`Branch must update ${requiredFile} in ${packageName}`);
     }
   });

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -30,8 +30,6 @@ Object.keys(changes).forEach(packageName => {
           },
         ).stdout;
 
-        console.log(`git show origin/latest:${packageFilePath}`);
-
         const localDeps = JSON.parse(localPackageFile).dependencies;
         const localDevDeps = JSON.parse(localPackageFile).devDependencies;
         const remoteDeps = JSON.parse(remotePackageFile).dependencies;

--- a/scripts/changeScanner/index.js
+++ b/scripts/changeScanner/index.js
@@ -12,30 +12,30 @@ const lockFileName = 'yarn.lock';
 // Files always required to have been changed with every psammead package change.
 const requiredChanges = ['CHANGELOG.md', packageFileName];
 
-const changes = getChanges();
+const changedPackages = getChanges();
 
 const getChangedFilePath = ({ packageName, matchFile }) =>
-  changes[packageName].find(changedFile => changedFile.includes(matchFile));
+  changedPackages[packageName].find(changedFile =>
+    changedFile.includes(matchFile),
+  );
 
 const isMissingRequiredChangedFile = ({ packageName, requiredFile }) =>
-  !changes[packageName].some(changedFile => changedFile.includes(requiredFile));
+  !changedPackages[packageName].some(changedFile =>
+    changedFile.includes(requiredFile),
+  );
 
 const someDepsHaveChanged = ({ localPackageFile, remotePackageFile }) => {
-  const {
-    dependencies: localDeps,
-    devDependencies: localDevDeps,
-    peerDependencies: localPeerDeps,
-  } = JSON.parse(localPackageFile);
+  const { dependencies: localDeps, devDependencies: localDevDeps } = JSON.parse(
+    localPackageFile,
+  );
   const {
     dependencies: remoteDeps,
     devDependencies: remoteDevDeps,
-    peerDependencies: remotePeerDeps,
   } = JSON.parse(remotePackageFile);
   const depsHaveChanged = !equals(localDeps, remoteDeps);
   const devDepsHaveChanged = !equals(localDevDeps, remoteDevDeps);
-  const peerDepsHaveChanged = !equals(localPeerDeps, remotePeerDeps);
 
-  return depsHaveChanged || devDepsHaveChanged || peerDepsHaveChanged;
+  return depsHaveChanged || devDepsHaveChanged;
 };
 
 const getFileChangeError = packageName => requiredFile => {
@@ -74,7 +74,8 @@ const getFileChangeError = packageName => requiredFile => {
   return '';
 };
 
-const errors = Object.keys(changes)
+const changedPackageNames = Object.keys(changedPackages);
+const errors = changedPackageNames
   .map(packageName => requiredChanges.map(getFileChangeError(packageName)))
   .flat()
   .filter(Boolean);

--- a/scripts/changeScanner/index.test.js
+++ b/scripts/changeScanner/index.test.js
@@ -75,18 +75,23 @@ describe(`changeScanner - index`, () => {
     expect(mockExit).toHaveBeenCalled();
 
     const expectedMessages = [
-      'Branch must update CHANGELOG.md in barfoo',
-      'Branch must update yarn.lock in barfoo',
-      'Branch must update CHANGELOG.md in foobar',
-      'Branch must update package.json in foobar',
-      'Branch must update CHANGELOG.md in apples',
-      'Branch must update yarn.lock in apples',
-      '', // empty line for spacing
+      [
+        'Please update the version number and CHANGELOG for every package that is being',
+        'changed in this branch. The following problems were found:',
+      ]
+        .join('\n')
+        .concat('\n'),
+      [
+        'Branch must update CHANGELOG.md in barfoo',
+        'Branch must update yarn.lock in barfoo',
+        'Branch must update CHANGELOG.md in foobar',
+        'Branch must update package.json in foobar',
+        'Branch must update CHANGELOG.md in apples',
+        'Branch must update yarn.lock in apples',
+      ]
+        .join('\n')
+        .concat('\n'),
     ];
-
-    expect(consoleErrorOutput).toHaveBeenCalledWith(
-      expect.stringContaining('Please update the version number'),
-    );
 
     expectedMessages.forEach(msg =>
       expect(consoleErrorOutput).toHaveBeenCalledWith(msg),


### PR DESCRIPTION
**Overall change:**
Fixes package publishing by running the publish node script instead of Yarn's own publish command.

Also fixes the `changeScanner` script. It currently fails if you bump a `package.json` version without bumping the dependencies because no changes occur in the yarn.lock since yarn doesn't output the package version in `yarn.lock`
The `changeScanner` script now checks that if no dependencies have changed, then you don't need to update the `yarn.lock` file.

**Code changes:**

- replace `yarn publish` with `yarn run publish` to run the node script in `scripts/publish`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
