### PR TITLE
Only run chromatic/change scanner when the packages directory has changed

### DIFF
--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -16,8 +16,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Get Changed Files
+        id: changedFiles
+        uses: jitterbit/get-changed-files@v1
+
       - name: Install Node Modules
+        if: contains(steps.changedFiles.outputs.all, 'packages')
         run: yarn ci:packages
 
       - name: Change Scanner
+        if: contains(steps.changedFiles.outputs.all, 'packages')
         run: yarn changeScanner

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -34,7 +34,7 @@ jobs:
           files: 'src' # Returns true if any files within the src directory have changed.
 
       - name: Install Node Modules
-        if: steps.changed_files.outputs.files_changed == 'true'
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
         run: yarn ci:packages
 
       - name: Chromatic UI Tests

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -33,12 +33,12 @@ jobs:
         with:
           files: 'packages' # Returns true if any files within the src directory have changed.
 
-      - name: Install Node Modules
-        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
+      - name: Install Node Modules # (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
+        if: steps.changed_files.outputs.files_changed == 'true'
         run: yarn ci:packages
 
       - name: Chromatic UI Tests
-        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
+        if: steps.changed_files.outputs.files_changed == 'true'
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -27,23 +27,19 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: get changed files
-        id: files
+      - name: Get Changed Files
+        id: changedFiles
         uses: jitterbit/get-changed-files@v1
-      - run: |
-          for changed_file in ${{ steps.files.outputs.all }}; do
-            echo "Do something with this ${changed_file}."
-          done
 
       - name: Install Node Modules
-        if: contains(steps.files.outputs.all, 'packages')
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && contains(steps.changedFiles.outputs.all, 'packages')
         run: yarn ci:packages
 
-      # - name: Chromatic UI Tests
-      #   if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}
-      #   uses: chromaui/action@v1
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-      #     buildScriptName: 'build:storybook'
-      #     exitOnceUploaded: true
+      - name: Chromatic UI Tests
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && contains(steps.changedFiles.outputs.all, 'packages')
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          buildScriptName: 'build:storybook'
+          exitOnceUploaded: true

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -28,15 +28,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: get changed files
-        id: getfile
-        run: |
-          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }}| xargs)"
-
-      - name: echo the changed files
-        run: |
-          for i in ${{ steps.getfile.outputs.files }}
-          do
-              echo $i
+        id: files
+        uses: jitterbit/get-changed-files@v1
+      - run: |
+          for changed_file in ${{ steps.files.outputs.all }}; do
+            echo "Do something with this ${changed_file}."
           done
 
       # - name: Install Node Modules

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -35,8 +35,9 @@ jobs:
             echo "Do something with this ${changed_file}."
           done
 
-      # - name: Install Node Modules
-      #   run: yarn ci:packages
+      - name: Install Node Modules
+        if: contains(steps.files.outputs.all, 'packages')
+        run: yarn ci:packages
 
       # - name: Chromatic UI Tests
       #   if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -22,15 +22,23 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
+
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Check for changed files.
+        id: changed_files
+        uses: jackton1/find-changed-files@v1.1
+        with:
+          files: 'src' # Returns true if any files within the src directory have changed.
+
       - name: Install Node Modules
+        if: steps.changed_files.outputs.files_changed == 'true'
         run: yarn ci:packages
 
       - name: Chromatic UI Tests
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -31,7 +31,7 @@ jobs:
         id: changed_files
         uses: jackton1/find-changed-files@v1.1
         with:
-          files: 'src' # Returns true if any files within the src directory have changed.
+          files: 'packages' # Returns true if any files within the src directory have changed.
 
       - name: Install Node Modules
         if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'

--- a/.github/workflows/psammead-chromaticqa.yml
+++ b/.github/workflows/psammead-chromaticqa.yml
@@ -27,21 +27,26 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Check for changed files.
-        id: changed_files
-        uses: jackton1/find-changed-files@v1.1
-        with:
-          files: 'packages' # Returns true if any files within the src directory have changed.
+      - name: get changed files
+        id: getfile
+        run: |
+          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }}| xargs)"
 
-      - name: Install Node Modules # (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead') && steps.changed_files.outputs.files_changed == 'true'
-        if: steps.changed_files.outputs.files_changed == 'true'
-        run: yarn ci:packages
+      - name: echo the changed files
+        run: |
+          for i in ${{ steps.getfile.outputs.files }}
+          do
+              echo $i
+          done
 
-      - name: Chromatic UI Tests
-        if: steps.changed_files.outputs.files_changed == 'true'
-        uses: chromaui/action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-          buildScriptName: 'build:storybook'
-          exitOnceUploaded: true
+      # - name: Install Node Modules
+      #   run: yarn ci:packages
+
+      # - name: Chromatic UI Tests
+      #   if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/psammead' }}
+      #   uses: chromaui/action@v1
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+      #     buildScriptName: 'build:storybook'
+      #     exitOnceUploaded: true

--- a/packages/components/psammead-amp-geo/CHANGELOG.md
+++ b/packages/components/psammead-amp-geo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| test | [PR#4335](test) test |
 | 1.2.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 1.2.2 | [PR#4303](https://github.com/bbc/psammead/pull/4303) Trigger rebuild following babel config update for emotion 11 |
 | 1.2.1 | [PR#4271](https://github.com/bbc/psammead/pull/4271) change react peer dep to >=16.9.0 |

--- a/packages/components/psammead-amp-geo/CHANGELOG.md
+++ b/packages/components/psammead-amp-geo/CHANGELOG.md
@@ -3,7 +3,6 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| test | [PR#4335](test) test |
 | 1.2.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 1.2.2 | [PR#4303](https://github.com/bbc/psammead/pull/4303) Trigger rebuild following babel config update for emotion 11 |
 | 1.2.1 | [PR#4271](https://github.com/bbc/psammead/pull/4271) change react peer dep to >=16.9.0 |


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**

This PR prevents ChromaticQA or the ChangeScanner from running if a Psammead package hasn't changed.

Working example: This PR only modifies the workflow files which are outside of the `packages/` directory so the change scanner and ChromaticQA are skipped for this PR

![image](https://user-images.githubusercontent.com/14273378/108869153-d28c2c00-75ee-11eb-8c2d-6591ecd15b2e.png)


---

- [X] I have assigned myself to this PR and the corresponding issues
- ~~[] Automated jest tests added (for new features) or updated (for existing features)~~
- ~~[ ] This PR requires manual testing~~
