### PR TITLE
Talos - Bump @bbc/psammead-image-placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.101 | [PR#4377](https://github.com/bbc/psammead/pull/4377) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 4.0.100 | [PR#4374](https://github.com/bbc/psammead/pull/4374) Add --skip-integrity-check flag to ci:packages & add lodash 4.17.21 to resolutions |
 | 4.0.99 | [PR#4352](https://github.com/bbc/psammead/pull/4352) fixes package publishing |
 | 4.0.98 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.100",
+  "version": "4.0.101",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -78,7 +78,7 @@
     "@bbc/psammead-heading-index": "^3.0.12",
     "@bbc/psammead-headings": "^5.0.12",
     "@bbc/psammead-image": "^2.0.4",
-    "@bbc/psammead-image-placeholder": "^3.0.15",
+    "@bbc/psammead-image-placeholder": "^3.1.0",
     "@bbc/psammead-inline-link": "^3.0.10",
     "@bbc/psammead-live-label": "^2.0.15",
     "@bbc/psammead-locales": "^5.0.3",

--- a/packages/components/psammead-episode-list/CHANGELOG.md
+++ b/packages/components/psammead-episode-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 1.0.23 | [PR#4377](https://github.com/bbc/psammead/pull/4377) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 1.0.22 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 1.0.21 | [PR#4294](https://github.com/bbc/psammead/pull/4294) Rename `Metadata` component to `DateTimeDuration`. Fix styling in div wrapping DateTimeDuration |
 | 1.0.20 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-section-label |

--- a/packages/components/psammead-episode-list/package.json
+++ b/packages/components/psammead-episode-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-episode-list",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.1.1",
     "@bbc/psammead-assets": "^3.1.5",
-    "@bbc/psammead-image-placeholder": "^3.0.15",
+    "@bbc/psammead-image-placeholder": "^3.1.0",
     "@bbc/psammead-styles": "^7.2.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-episode-list/yarn.lock
+++ b/packages/components/psammead-episode-list/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@bbc/psammead-assets/-/psammead-assets-3.1.5.tgz#a0448930d5aef020b670b77e65420ded296e150d"
   integrity sha512-ITTfnuup0KLt2oF7rcWUB287ZNSmf8346SWzovv/tJ8RV0qppWyjFJaOTxfnxMjZcU3UkuH20Qf25JJq3Rjt1A==
 
-"@bbc/psammead-image-placeholder@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.0.15.tgz#d839ff12cedb308651010b61d2b0725e7285e77f"
-  integrity sha512-wFnLyeAaCXpBKYpXcWjg0KU4/cyB0aOS7nsyz3xGmaa2rjCD1aTqtI3hzuE4a94Lr807L5lQg952i7wn4OCzkA==
+"@bbc/psammead-image-placeholder@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.1.0.tgz#2d5291d6c2f1e7e4a5a173b62de06a013fd513f1"
+  integrity sha512-Dfq6t+wx5vVDePGKJdZAR0G/cNAKc0dKsbfOPFAjkhU5vWwlhVgEj4pqlcDSwZ9Gbuw43p4T8/jbPsnZGsAsWQ==
   dependencies:
     "@bbc/psammead-assets" "^3.1.5"
     "@bbc/psammead-styles" "^7.2.2"

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.0.29 | [PR#4377](https://github.com/bbc/psammead/pull/4377) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 5.0.28 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.0.27 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-play-button |
 | 5.0.26 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/psammead-image-placeholder, @bbc/psammead-assets, @bbc/psammead-image, @bbc/psammead-play-button |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.0.28",
+  "version": "5.0.29",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bbc/psammead-assets": "^3.1.5",
     "@bbc/psammead-image": "^2.0.4",
-    "@bbc/psammead-image-placeholder": "^3.0.15",
+    "@bbc/psammead-image-placeholder": "^3.1.0",
     "@bbc/psammead-play-button": "^3.0.16"
   }
 }

--- a/packages/components/psammead-media-player/yarn.lock
+++ b/packages/components/psammead-media-player/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@bbc/psammead-assets/-/psammead-assets-3.1.5.tgz#a0448930d5aef020b670b77e65420ded296e150d"
   integrity sha512-ITTfnuup0KLt2oF7rcWUB287ZNSmf8346SWzovv/tJ8RV0qppWyjFJaOTxfnxMjZcU3UkuH20Qf25JJq3Rjt1A==
 
-"@bbc/psammead-image-placeholder@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.0.15.tgz#d839ff12cedb308651010b61d2b0725e7285e77f"
-  integrity sha512-wFnLyeAaCXpBKYpXcWjg0KU4/cyB0aOS7nsyz3xGmaa2rjCD1aTqtI3hzuE4a94Lr807L5lQg952i7wn4OCzkA==
+"@bbc/psammead-image-placeholder@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.1.0.tgz#2d5291d6c2f1e7e4a5a173b62de06a013fd513f1"
+  integrity sha512-Dfq6t+wx5vVDePGKJdZAR0G/cNAKc0dKsbfOPFAjkhU5vWwlhVgEj4pqlcDSwZ9Gbuw43p4T8/jbPsnZGsAsWQ==
   dependencies:
     "@bbc/psammead-assets" "^3.1.5"
     "@bbc/psammead-styles" "^7.2.2"

--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.29 | [PR#4377](https://github.com/bbc/psammead/pull/4377) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.28 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 0.1.0-alpha.27 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-image-placeholder |
 | 0.1.0-alpha.26 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-assets, @bbc/psammead-image-placeholder, @bbc/psammead-styles, @bbc/psammead-visually-hidden-text |

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.28",
+  "version": "0.1.0-alpha.29",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "^6.1.1",
     "@bbc/psammead-assets": "^3.1.5",
-    "@bbc/psammead-image-placeholder": "^3.0.15",
+    "@bbc/psammead-image-placeholder": "^3.1.0",
     "@bbc/psammead-styles": "^7.2.2"
   },
   "peerDependencies": {

--- a/packages/components/psammead-podcast-promo/yarn.lock
+++ b/packages/components/psammead-podcast-promo/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@bbc/psammead-assets/-/psammead-assets-3.1.5.tgz#a0448930d5aef020b670b77e65420ded296e150d"
   integrity sha512-ITTfnuup0KLt2oF7rcWUB287ZNSmf8346SWzovv/tJ8RV0qppWyjFJaOTxfnxMjZcU3UkuH20Qf25JJq3Rjt1A==
 
-"@bbc/psammead-image-placeholder@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.0.15.tgz#d839ff12cedb308651010b61d2b0725e7285e77f"
-  integrity sha512-wFnLyeAaCXpBKYpXcWjg0KU4/cyB0aOS7nsyz3xGmaa2rjCD1aTqtI3hzuE4a94Lr807L5lQg952i7wn4OCzkA==
+"@bbc/psammead-image-placeholder@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.1.0.tgz#2d5291d6c2f1e7e4a5a173b62de06a013fd513f1"
+  integrity sha512-Dfq6t+wx5vVDePGKJdZAR0G/cNAKc0dKsbfOPFAjkhU5vWwlhVgEj4pqlcDSwZ9Gbuw43p4T8/jbPsnZGsAsWQ==
   dependencies:
     "@bbc/psammead-assets" "^3.1.5"
     "@bbc/psammead-styles" "^7.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,14 @@
     "@bbc/psammead-assets" "^3.1.5"
     "@bbc/psammead-styles" "^7.2.2"
 
+"@bbc/psammead-image-placeholder@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.1.0.tgz#2d5291d6c2f1e7e4a5a173b62de06a013fd513f1"
+  integrity sha512-Dfq6t+wx5vVDePGKJdZAR0G/cNAKc0dKsbfOPFAjkhU5vWwlhVgEj4pqlcDSwZ9Gbuw43p4T8/jbPsnZGsAsWQ==
+  dependencies:
+    "@bbc/psammead-assets" "^3.1.5"
+    "@bbc/psammead-styles" "^7.2.2"
+
 "@bbc/psammead-image@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@bbc/psammead-image/-/psammead-image-2.0.4.tgz#fb52d48ad92b5f14700536561501af84de663b3c"


### PR DESCRIPTION
👋 The following packages have been updated:

@bbc/psammead

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^3.0.15  →  ^3.1.0

| Version | Description |
|---------|-------------|
| 3.1.0 | [PR#4334](https://github.com/bbc/psammead/pull/4334) Added amp img placholder support |
| 3.0.16 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
</details>


@bbc/psammead-podcast-promo

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^3.0.15  →  ^3.1.0

| Version | Description |
|---------|-------------|
| 3.1.0 | [PR#4334](https://github.com/bbc/psammead/pull/4334) Added amp img placholder support |
| 3.0.16 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
</details>


@bbc/psammead-episode-list

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^3.0.15  →  ^3.1.0

| Version | Description |
|---------|-------------|
| 3.1.0 | [PR#4334](https://github.com/bbc/psammead/pull/4334) Added amp img placholder support |
| 3.0.16 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
</details>


@bbc/psammead-media-player

<details>
<summary>Details</summary>
@bbc/psammead-image-placeholder  ^3.0.15  →  ^3.1.0

| Version | Description |
|---------|-------------|
| 3.1.0 | [PR#4334](https://github.com/bbc/psammead/pull/4334) Added amp img placholder support |
| 3.0.16 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
</details>

