### PR TITLE
Make consent banner and brand components externally focusable

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.1.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Add focusRef prop |
 | 7.0.31 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 7.0.30 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-script-link |
 | 7.0.29 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-visually-hidden-text, @bbc/psammead-script-link, @bbc/psammead-styles |

--- a/packages/components/psammead-brand/README.md
+++ b/packages/components/psammead-brand/README.md
@@ -58,7 +58,7 @@ When using `Brand` in the header, you should ensure that `borderBottom` prop is 
 
 `ScriptLink` component should be passed to `scriptLink` only when linking to a service variant.
 
-The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`;
+The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
 
 ```jsx
 import Brand from '@bbc/psammead-brand';

--- a/packages/components/psammead-brand/README.md
+++ b/packages/components/psammead-brand/README.md
@@ -48,6 +48,7 @@ The `scriptLink` can be used to render [ScriptLink](https://github.com/bbc/psamm
 | borderBottom | Boolean | no | `false` | `true` |
 | scriptLink | Node | no | `null` | `<ScriptLink service='news' script={latin} href='https://www.bbc.com/serbian/lat'> Lat </ScriptLink>` |
 | skipLink | Node | no | `null` | `<SkipLink service='news' script={latin} href='#content'> Skip to content </SkipLink>` |
+| focusRef | [Reference](https://reactjs.org/docs/refs-and-the-dom.html) | no | `null` | `useRef(null)` |
 
 ## Usage
 
@@ -56,6 +57,8 @@ The typical use-case of this component is at the top of pages in a [`header` ele
 When using `Brand` in the header, you should ensure that `borderBottom` prop is set to true. Similarly, when using brand on the footer you should set `borderTop` to true. This ensures when in High Contrast Mode on PC and when the user changes colour preferences in FireFox that the top/bottom of the `Brand` component is visible.
 
 `ScriptLink` component should be passed to `scriptLink` only when linking to a service variant.
+
+The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`;
 
 ```jsx
 import Brand from '@bbc/psammead-brand';

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.0.31",
+  "version": "7.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -213,6 +213,7 @@ const Brand = props => {
     logoColour,
     scriptLink,
     skipLink,
+    focusRef,
     ...rest
   } = props;
 
@@ -228,7 +229,12 @@ const Brand = props => {
     >
       <SvgWrapper>
         {url ? (
-          <StyledLink href={url} maxWidth={maxWidth} minWidth={minWidth}>
+          <StyledLink
+            href={url}
+            maxWidth={maxWidth}
+            minWidth={minWidth}
+            ref={focusRef}
+          >
             <StyledBrand {...props} />
           </StyledLink>
         ) : (

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { string, number, node, shape, bool } from 'prop-types';
+import {
+  string,
+  number,
+  node,
+  shape,
+  bool,
+  oneOfType,
+  func,
+  instanceOf,
+} from 'prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
@@ -254,6 +263,7 @@ Brand.defaultProps = {
   borderBottom: false,
   scriptLink: null,
   skipLink: null,
+  focusRef: null,
 };
 
 Brand.propTypes = {
@@ -264,6 +274,10 @@ Brand.propTypes = {
   borderBottom: bool,
   scriptLink: node,
   skipLink: node,
+  focusRef: oneOfType([
+    func,
+    shape({ current: instanceOf(HTMLAnchorElement) }),
+  ]),
 };
 
 export default Brand;

--- a/packages/components/psammead-brand/src/index.test.jsx
+++ b/packages/components/psammead-brand/src/index.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { render } from '@testing-library/react';
 import { C_POSTBOX, C_WHITE } from '@bbc/psammead-styles/colours';
@@ -135,6 +135,36 @@ describe('Brand', () => {
         'header',
       );
     });
+
+    it('should be focusable with a ref', () => {
+      const TestComponent = () => {
+        const focusRef = useRef(null);
+
+        useEffect(() => {
+          focusRef.current.focus();
+        });
+
+        return (
+          <Brand
+            product="Default Brand Name"
+            svgHeight={24}
+            maxWidth={280}
+            minWidth={180}
+            svg={svg}
+            url="https://www.bbc.co.uk/news"
+            backgroundColour={C_POSTBOX}
+            logoColour={C_WHITE}
+            data-brand="header"
+            focusRef={focusRef}
+          />
+        );
+      };
+
+      const { getByText } = render(<TestComponent />);
+      const brand = getByText('Default Brand Name');
+      expect(document.activeElement).toBe(brand);
+    });
+
     it('should render script, frontpage and skip to content links', () => {
       const scriptLinkComponent = (
         <ScriptLink

--- a/packages/components/psammead-brand/src/index.test.jsx
+++ b/packages/components/psammead-brand/src/index.test.jsx
@@ -160,8 +160,8 @@ describe('Brand', () => {
         );
       };
 
-      const { getByText } = render(<TestComponent />);
-      const brand = getByText('Default Brand Name');
+      const { container } = render(<TestComponent />);
+      const brand = container.querySelector('a');
       expect(document.activeElement).toBe(brand);
     });
 

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.3.4 | [PR#????](https://github.com/bbc/psammead/pull/????) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |
 | 5.3.1 | [PR#4303](https://github.com/bbc/psammead/pull/4303) Trigger rebuild following babel config update for emotion 11 |

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.3.4 | [PR#????](https://github.com/bbc/psammead/pull/????) Make banner heading focusable |
+| 5.3.4 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |
 | 5.3.1 | [PR#4303](https://github.com/bbc/psammead/pull/4303) Trigger rebuild following babel config update for emotion 11 |

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.3.4 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
+| 5.4.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |
 | 5.3.1 | [PR#4303](https://github.com/bbc/psammead/pull/4303) Trigger rebuild following babel config update for emotion 11 |

--- a/packages/components/psammead-consent-banner/README.md
+++ b/packages/components/psammead-consent-banner/README.md
@@ -24,10 +24,13 @@ The `psammead-consent-banner` component is a styled `div` that encapsulates info
 | dir | string | No | `'ltr'` | One of `'rtl'` `'ltr'` |
 | script | script | Yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, } |
 | service | string | Yes | N/A | `'news'` |
+| focusRef | [Reference](https://reactjs.org/docs/refs-and-the-dom.html) | no | `null` | `useRef(null)` |
 
 ## Usage
 
 The typical use-case of this component is on top of the webpage of all page types. It is visible for new users.
+
+The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
 
 ```jsx
 import { ConsentBanner, ConsentBannerText } from '@bbc/psammead-consent-banner';

--- a/packages/components/psammead-consent-banner/README.md
+++ b/packages/components/psammead-consent-banner/README.md
@@ -30,7 +30,7 @@ The `psammead-consent-banner` component is a styled `div` that encapsulates info
 
 The typical use-case of this component is on top of the webpage of all page types. It is visible for new users.
 
-The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
+The `focusRef` prop is used so that the title of the consent banner can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML heading element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
 
 ```jsx
 import { ConsentBanner, ConsentBannerText } from '@bbc/psammead-consent-banner';

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -51,33 +51,6 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 .emotion-4 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  color: #FFFFFF;
-  font-weight: 700;
-  padding: 0;
-  margin: 0;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-.emotion-4:focus {
-  outline: none;
-}
-
-.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   display: -webkit-box;
@@ -99,20 +72,20 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-6 li+li {
+.emotion-4 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -131,7 +104,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -140,18 +113,18 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
     justify-content: space-between;
   }
 
-  .emotion-6 li+li {
+  .emotion-4 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-8 {
+.emotion-6 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-8 button {
+.emotion-6 button {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   width: 100%;
@@ -165,33 +138,33 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-8 button:focus,
-.emotion-8 button:hover {
+.emotion-6 button:focus,
+.emotion-6 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-8 button:hover,
-.emotion-8 button:focus {
+.emotion-6 button:hover,
+.emotion-6 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 17.3125rem;
   }
 }
@@ -207,9 +180,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
       dir="ltr"
     >
       <h2
-        class="emotion-4 emotion-5"
         dir="ltr"
-        script="[object Object]"
         tabindex="-1"
       >
         We've updated our Privacy and Cookies Policy
@@ -218,12 +189,12 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
         Hello
       </p>
       <ul
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="ltr"
         >
           <button
@@ -233,7 +204,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
           </button>
         </li>
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="ltr"
         >
           <span>
@@ -301,33 +272,6 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 .emotion-4 {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
-  color: #FFFFFF;
-  font-weight: 700;
-  padding: 0;
-  margin: 0;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    font-size: 1.5rem;
-    line-height: 2rem;
-  }
-}
-
-.emotion-4:focus {
-  outline: none;
-}
-
-.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   display: -webkit-box;
@@ -349,20 +293,20 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-6 li+li {
+.emotion-4 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -381,7 +325,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -390,18 +334,18 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
     justify-content: space-between;
   }
 
-  .emotion-6 li+li {
+  .emotion-4 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-8 {
+.emotion-6 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-8 button {
+.emotion-6 button {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   width: 100%;
@@ -415,33 +359,33 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-8 button:focus,
-.emotion-8 button:hover {
+.emotion-6 button:focus,
+.emotion-6 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-8 button:hover,
-.emotion-8 button:focus {
+.emotion-6 button:hover,
+.emotion-6 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 17.3125rem;
   }
 }
@@ -457,9 +401,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
       dir="rtl"
     >
       <h2
-        class="emotion-4 emotion-5"
         dir="rtl"
-        script="[object Object]"
         tabindex="-1"
       >
         عنوان
@@ -468,12 +410,12 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
         مرحبا
       </p>
       <ul
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         dir="rtl"
         role="list"
       >
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="rtl"
         >
           <button
@@ -483,7 +425,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
           </button>
         </li>
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="rtl"
         >
           <span>
@@ -551,33 +493,6 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 .emotion-4 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  color: #FFFFFF;
-  font-weight: 700;
-  padding: 0;
-  margin: 0;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-.emotion-4:focus {
-  outline: none;
-}
-
-.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   display: -webkit-box;
@@ -599,20 +514,20 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-6 li+li {
+.emotion-4 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -631,7 +546,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-4 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -640,18 +555,18 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
     justify-content: space-between;
   }
 
-  .emotion-6 li+li {
+  .emotion-4 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-8 {
+.emotion-6 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-8 button {
+.emotion-6 button {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   width: 100%;
@@ -665,33 +580,33 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 button {
+  .emotion-6 button {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-8 button:focus,
-.emotion-8 button:hover {
+.emotion-6 button:focus,
+.emotion-6 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-8 button:hover,
-.emotion-8 button:focus {
+.emotion-6 button:hover,
+.emotion-6 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 17.3125rem;
   }
 }
@@ -708,9 +623,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
       dir="ltr"
     >
       <h2
-        class="emotion-4 emotion-5"
         dir="ltr"
-        script="[object Object]"
         tabindex="-1"
       >
         We've updated our Privacy and Cookies Policy
@@ -719,12 +632,12 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
         Hello
       </p>
       <ul
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="ltr"
         >
           <button
@@ -734,7 +647,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
           </button>
         </li>
         <li
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
           dir="ltr"
         >
           <span>

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -51,6 +51,33 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 .emotion-4 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  color: #FFFFFF;
+  font-weight: 700;
+  padding: 0;
+  margin: 0;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-4 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+.emotion-4:focus {
+  outline: none;
+}
+
+.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   display: -webkit-box;
@@ -72,20 +99,20 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-4 li+li {
+.emotion-6 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -104,7 +131,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -113,18 +140,18 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
     justify-content: space-between;
   }
 
-  .emotion-4 li+li {
+  .emotion-6 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-6 {
+.emotion-8 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-6 button {
+.emotion-8 button {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   width: 100%;
@@ -138,33 +165,33 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-6 button:focus,
-.emotion-6 button:hover {
+.emotion-8 button:focus,
+.emotion-8 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-6 button:hover,
-.emotion-6 button:focus {
+.emotion-8 button:hover,
+.emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 17.3125rem;
   }
 }
@@ -180,6 +207,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
       dir="ltr"
     >
       <h2
+        class="emotion-4 emotion-5"
         dir="ltr"
         tabindex="-1"
       >
@@ -189,12 +217,12 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
         Hello
       </p>
       <ul
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="ltr"
         >
           <button
@@ -204,7 +232,7 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
           </button>
         </li>
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="ltr"
         >
           <span>
@@ -272,6 +300,33 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 .emotion-4 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  color: #FFFFFF;
+  font-weight: 700;
+  padding: 0;
+  margin: 0;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-4 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+}
+
+.emotion-4:focus {
+  outline: none;
+}
+
+.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   display: -webkit-box;
@@ -293,20 +348,20 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-4 li+li {
+.emotion-6 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -325,7 +380,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -334,18 +389,18 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
     justify-content: space-between;
   }
 
-  .emotion-4 li+li {
+  .emotion-6 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-6 {
+.emotion-8 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-6 button {
+.emotion-8 button {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   width: 100%;
@@ -359,33 +414,33 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-6 button:focus,
-.emotion-6 button:hover {
+.emotion-8 button:focus,
+.emotion-8 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-6 button:hover,
-.emotion-6 button:focus {
+.emotion-8 button:hover,
+.emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 17.3125rem;
   }
 }
@@ -401,6 +456,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
       dir="rtl"
     >
       <h2
+        class="emotion-4 emotion-5"
         dir="rtl"
         tabindex="-1"
       >
@@ -410,12 +466,12 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
         مرحبا
       </p>
       <ul
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         dir="rtl"
         role="list"
       >
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="rtl"
         >
           <button
@@ -425,7 +481,7 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
           </button>
         </li>
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="rtl"
         >
           <span>
@@ -493,6 +549,33 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 .emotion-4 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  color: #FFFFFF;
+  font-weight: 700;
+  padding: 0;
+  margin: 0;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-4 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+.emotion-4:focus {
+  outline: none;
+}
+
+.emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   display: -webkit-box;
@@ -514,20 +597,20 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-4 li+li {
+.emotion-6 li+li {
   margin-top: 0.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -546,7 +629,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-6 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -555,18 +638,18 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
     justify-content: space-between;
   }
 
-  .emotion-4 li+li {
+  .emotion-6 li+li {
     margin-top: 0;
   }
 }
 
-.emotion-6 {
+.emotion-8 {
   text-align: center;
   width: 100%;
   word-break: break-word;
 }
 
-.emotion-6 button {
+.emotion-8 button {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   width: 100%;
@@ -580,33 +663,33 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 button {
+  .emotion-8 button {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-6 button:focus,
-.emotion-6 button:hover {
+.emotion-8 button:focus,
+.emotion-8 button:hover {
   color: #222222;
   background-color: #F6A21D;
 }
 
-.emotion-6 button:hover,
-.emotion-6 button:focus {
+.emotion-8 button:hover,
+.emotion-8 button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 @media (min-width: 25rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 17.3125rem;
   }
 }
@@ -623,6 +706,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
       dir="ltr"
     >
       <h2
+        class="emotion-4 emotion-5"
         dir="ltr"
         tabindex="-1"
       >
@@ -632,12 +716,12 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
         Hello
       </p>
       <ul
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="ltr"
         >
           <button
@@ -647,7 +731,7 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
           </button>
         </li>
         <li
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
           dir="ltr"
         >
           <span>

--- a/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-consent-banner/src/__snapshots__/index.test.jsx.snap
@@ -73,6 +73,10 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
   }
 }
 
+.emotion-4:focus {
+  outline: none;
+}
+
 .emotion-6 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
@@ -205,6 +209,8 @@ exports[`ConsentBanner should correctly render for ltr service 1`] = `
       <h2
         class="emotion-4 emotion-5"
         dir="ltr"
+        script="[object Object]"
+        tabindex="-1"
       >
         We've updated our Privacy and Cookies Policy
       </h2>
@@ -315,6 +321,10 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
     font-size: 1.5rem;
     line-height: 2rem;
   }
+}
+
+.emotion-4:focus {
+  outline: none;
 }
 
 .emotion-6 {
@@ -449,6 +459,8 @@ exports[`ConsentBanner should correctly render for rtl service 1`] = `
       <h2
         class="emotion-4 emotion-5"
         dir="rtl"
+        script="[object Object]"
+        tabindex="-1"
       >
         عنوان
       </h2>
@@ -559,6 +571,10 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
+}
+
+.emotion-4:focus {
+  outline: none;
 }
 
 .emotion-6 {
@@ -694,6 +710,8 @@ exports[`ConsentBanner with hidden attribute on wrapper should correctly render 
       <h2
         class="emotion-4 emotion-5"
         dir="ltr"
+        script="[object Object]"
+        tabindex="-1"
       >
         We've updated our Privacy and Cookies Policy
       </h2>

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -225,7 +225,7 @@ ConsentBanner.propTypes = {
   service: string.isRequired,
   focusRef: oneOfType([
     func,
-    shape({ current: instanceOf(HTMLAnchorElement) }),
+    shape({ current: instanceOf(HTMLHeadingElement) }),
   ]),
 };
 

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -78,12 +78,26 @@ const CenterWrapper = styled.div`
   }
 `;
 
-const Title = styled.h2`
+// eslint-disable-next-line react/prop-types
+const FocusableH2 = ({ children, ...props }) => {
+  // tabIndex="-1" enables the h2 to be focussed
+  return (
+    <h2 {...props} tabIndex="-1">
+      {children}
+    </h2>
+  );
+};
+
+const Title = styled(FocusableH2)`
   ${({ script }) => script && getDoublePica(script)};
   color: ${C_WHITE};
   font-weight: 700;
   padding: 0;
   margin: 0;
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 /*

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -88,7 +88,7 @@ const CenterWrapper = styled.div`
 `;
 
 // eslint-disable-next-line react/prop-types
-const FocusableH2 = forwardRef(({ className, children, dir, ref }) => {
+const FocusableH2 = forwardRef(({ className, children, dir }, ref) => {
   // tabIndex="-1" enables the h2 to be focussed
   return (
     <h2 className={className} dir={dir} tabIndex="-1" ref={ref}>

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -79,10 +79,10 @@ const CenterWrapper = styled.div`
 `;
 
 // eslint-disable-next-line react/prop-types
-const FocusableH2 = ({ children, ...props }) => {
+const FocusableH2 = ({ children, dir }) => {
   // tabIndex="-1" enables the h2 to be focussed
   return (
-    <h2 {...props} tabIndex="-1">
+    <h2 dir={dir} tabIndex="-1">
       {children}
     </h2>
   );

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -1,5 +1,14 @@
-import React from 'react';
-import { string, element, bool, oneOf, shape } from 'prop-types';
+import React, { forwardRef } from 'react';
+import {
+  string,
+  element,
+  bool,
+  oneOf,
+  shape,
+  func,
+  oneOfType,
+  instanceOf,
+} from 'prop-types';
 import styled from '@emotion/styled';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import {
@@ -79,14 +88,14 @@ const CenterWrapper = styled.div`
 `;
 
 // eslint-disable-next-line react/prop-types
-const FocusableH2 = ({ children, dir }) => {
+const FocusableH2 = forwardRef(({ className, children, dir, ref }) => {
   // tabIndex="-1" enables the h2 to be focussed
   return (
-    <h2 dir={dir} tabIndex="-1">
+    <h2 className={className} dir={dir} tabIndex="-1" ref={ref}>
       {children}
     </h2>
   );
-};
+});
 
 const Title = styled(FocusableH2)`
   ${({ script }) => script && getDoublePica(script)};
@@ -184,10 +193,11 @@ export const ConsentBanner = ({
   hidden,
   script,
   service,
+  focusRef,
 }) => (
   <Wrapper dir={dir} hidden={hidden} id={id} service={service}>
     <CenterWrapper dir={dir}>
-      <Title dir={dir} script={script}>
+      <Title dir={dir} script={script} ref={focusRef}>
         {title}
       </Title>
       {text}
@@ -213,10 +223,15 @@ ConsentBanner.propTypes = {
   hidden: bool,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
+  focusRef: oneOfType([
+    func,
+    shape({ current: instanceOf(HTMLAnchorElement) }),
+  ]),
 };
 
 ConsentBanner.defaultProps = {
   dir: 'ltr',
   id: null,
   hidden: null,
+  focusRef: null,
 };

--- a/packages/components/psammead-consent-banner/src/index.test.jsx
+++ b/packages/components/psammead-consent-banner/src/index.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { arabic, latin } from '@bbc/gel-foundations/scripts';
 import { render } from '@testing-library/react';
@@ -54,6 +54,23 @@ it('heading should be focusable', () => {
   const { getByText } = render(<ConsentBanner {...baseProps} />);
   const heading = getByText("We've updated our Privacy and Cookies Policy");
   heading.focus();
+  expect(document.activeElement).toBe(heading);
+});
+
+it('heading should be externally focusable', () => {
+  const TestContainer = () => {
+    const ref = useRef(null);
+
+    useEffect(() => {
+      ref.current.focus();
+    });
+
+    return <ConsentBanner {...baseProps} focusRef={ref} />;
+  };
+
+  const { getByText } = render(<TestContainer />);
+
+  const heading = getByText("We've updated our Privacy and Cookies Policy");
   expect(document.activeElement).toBe(heading);
 });
 

--- a/packages/components/psammead-consent-banner/src/index.test.jsx
+++ b/packages/components/psammead-consent-banner/src/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { arabic, latin } from '@bbc/gel-foundations/scripts';
+import { render } from '@testing-library/react';
 import { ConsentBanner, ConsentBannerText } from '.';
 
 const baseProps = {
@@ -47,6 +48,13 @@ describe('ConsentBanner', () => {
       <ConsentBanner {...props} />,
     );
   });
+});
+
+it('heading should be focusable', () => {
+  const { getByText } = render(<ConsentBanner {...baseProps} />);
+  const heading = getByText("We've updated our Privacy and Cookies Policy");
+  heading.focus();
+  expect(document.activeElement).toBe(heading);
 });
 
 describe('ConsentBannerText', () => {


### PR DESCRIPTION
Contributes to completion of https://github.com/bbc/simorgh/issues/8855

**Overall change:** _Makes the consent banner heading and brand link focusable, enabling focus management in simorgh._

**Code changes:**
- In Consent Banner
  - Add `tabindex="-1"` to the `h2`.
  - Add a unit test to check if the heading is focusable.
  - Override default outline styling on the `h2`.
  - Add prop to pass in ref; this allow external focus of the consent banner heading
  - Add unit test using this ref
- In Brand
  - Add prop to pass in ref; this allow external focus of the brand link
  - Add unit test using this ref

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
