### PR TITLE
Change focusRef prop-type to any for consent banner and brand

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 7.2.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Change focusRef prop-type |
+| 7.2.0 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
 | 7.1.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Add focusRef prop |
 | 7.0.31 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 7.0.30 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-script-link |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 7.2.0 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
+| 7.1.1 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
 | 7.1.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Add focusRef prop |
 | 7.0.31 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 7.0.30 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-script-link |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.2.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Change focusRef prop-type |
 | 7.1.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Add focusRef prop |
 | 7.0.31 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 7.0.30 | [PR#4305](https://github.com/bbc/psammead/pull/4305) Talos - Bump Dependencies - @bbc/psammead-script-link |

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.2.0",
+  "version": "7.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {
-  string,
-  number,
-  node,
-  shape,
-  bool,
-  oneOfType,
-  func,
-  instanceOf,
-} from 'prop-types';
+import { string, number, node, shape, bool, any } from 'prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
@@ -274,10 +265,8 @@ Brand.propTypes = {
   borderBottom: bool,
   scriptLink: node,
   skipLink: node,
-  focusRef: oneOfType([
-    func,
-    shape({ current: instanceOf(HTMLAnchorElement) }),
-  ]),
+  // eslint-disable-next-line react/forbid-prop-types
+  focusRef: any,
 };
 
 export default Brand;

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { string, number, node, shape, bool, any } from 'prop-types';
+import {
+  string,
+  number,
+  node,
+  shape,
+  bool,
+  any,
+  oneOfType,
+  func,
+} from 'prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
@@ -266,7 +275,7 @@ Brand.propTypes = {
   scriptLink: node,
   skipLink: node,
   // eslint-disable-next-line react/forbid-prop-types
-  focusRef: any,
+  focusRef: oneOfType([func, shape({ current: any })]),
 };
 
 export default Brand;

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.5.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Change focusRef prop-type |
 | 5.4.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.5.0 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
+| 5.4.1 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
 | 5.4.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.5.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Change focusRef prop-type |
+| 5.5.0 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |
 | 5.4.0 | [PR#4380](https://github.com/bbc/psammead/pull/4380) Make banner heading focusable |
 | 5.3.3 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |
 | 5.3.2 | [PR#4304](https://github.com/bbc/psammead/pull/4304) Talos - Bump Dependencies - @bbc/gel-foundations, @bbc/psammead-styles |

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.5.0",
+  "version": "5.4.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -1,5 +1,14 @@
 import React, { forwardRef } from 'react';
-import { string, element, bool, oneOf, shape, any } from 'prop-types';
+import {
+  string,
+  element,
+  bool,
+  oneOf,
+  shape,
+  func,
+  oneOfType,
+  any,
+} from 'prop-types';
 import styled from '@emotion/styled';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import {
@@ -215,7 +224,7 @@ ConsentBanner.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  focusRef: any,
+  focusRef: oneOfType([func, shape({ current: any })]),
 };
 
 ConsentBanner.defaultProps = {

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -1,14 +1,5 @@
 import React, { forwardRef } from 'react';
-import {
-  string,
-  element,
-  bool,
-  oneOf,
-  shape,
-  func,
-  oneOfType,
-  instanceOf,
-} from 'prop-types';
+import { string, element, bool, oneOf, shape, any } from 'prop-types';
 import styled from '@emotion/styled';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import {
@@ -223,10 +214,8 @@ ConsentBanner.propTypes = {
   hidden: bool,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
-  focusRef: oneOfType([
-    func,
-    shape({ current: instanceOf(HTMLHeadingElement) }),
-  ]),
+  // eslint-disable-next-line react/forbid-prop-types
+  focusRef: any,
 };
 
 ConsentBanner.defaultProps = {


### PR DESCRIPTION
Contributes to completion of https://github.com/bbc/simorgh/issues/8855

**Overall change:** Change focusRef prop-type to fix `HTMLAnchorElement is not defined` error in Simorgh, for both psammead-brand and psammead-consent-banner.

**Code changes:**

- Change focusRef prop-type to `any`.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
