### PR TITLE
Psammead root package tidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.107 | [PR#4368](https://github.com/bbc/psammead/pull/4368) Remove root dev dependencies |
 | 4.0.106 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |
 | 4.0.105 | [PR#4402](https://github.com/bbc/psammead/pull/4402) remove dependabot config |
 | 4.0.104 | [PR#4220](https://github.com/bbc/psammead/pull/4220) Configure Renovate |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.106",
+  "version": "4.0.107",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,
@@ -47,9 +47,7 @@
   "homepage": "https://github.com/bbc/psammead#readme",
   "dependencies": {
     "@emotion/react": "^11.1.4",
-    "@emotion/styled": "^11.0.0"
-  },
-  "devDependencies": {
+    "@emotion/styled": "^11.0.0",
     "@babel/cli": "^7.11.5",
     "@babel/core": "^7.11.1",
     "@babel/plugin-proposal-export-default-from": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "test:ci": "yarn test:lint && yarn test:unit:ci",
     "test:lint": "eslint --ext .js,jsx,json ./packages ./scripts && stylelint 'packages/**/*.js' 'packages/**/*.jsx' 'scripts/**/*.js'",
     "test:unit": "yarn build && jest --verbose --coverage",
-    "test:unit:ci": "jest --verbose --coverage",
-    "updateMinorPatch": "rm -rf node_modules/ && yarn install && yarn upgrade && yarn install"
+    "test:unit:ci": "jest --verbose --coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Overall change:**

Add dev deps to deps in root package.json.

> The root package.json of a monorepo is not published so whether a dependency is in devDependencies or dependencies does not make a difference and having one place to put dependencies in the root means that people do not have to arbitrarily decide where a dependency should go every time they install one.
_https://github.com/Thinkmill/manypkg#root-has-devdependencies_

Renovate pins root devDependencies so this change means no root dependencies will be pinned.

**Code changes:**

- Move devDependencies to dependencies
- Removes a redundant script used to update minor and patch

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
