### PR TITLE
psammead-brand forwardRefs to SvgWrapper

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.2.0 | [PR#4426](https://github.com/bbc/psammead/pull/4426) Wrap component in forwardRef and remove focusRef prop |
 | 7.1.3 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 7.1.2 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |
 | 7.1.1 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |

--- a/packages/components/psammead-brand/README.md
+++ b/packages/components/psammead-brand/README.md
@@ -48,7 +48,6 @@ The `scriptLink` can be used to render [ScriptLink](https://github.com/bbc/psamm
 | borderBottom | Boolean | no | `false` | `true` |
 | scriptLink | Node | no | `null` | `<ScriptLink service='news' script={latin} href='https://www.bbc.com/serbian/lat'> Lat </ScriptLink>` |
 | skipLink | Node | no | `null` | `<SkipLink service='news' script={latin} href='#content'> Skip to content </SkipLink>` |
-| focusRef | [Reference](https://reactjs.org/docs/refs-and-the-dom.html) | no | `null` | `useRef(null)` |
 
 ## Usage
 
@@ -57,8 +56,6 @@ The typical use-case of this component is at the top of pages in a [`header` ele
 When using `Brand` in the header, you should ensure that `borderBottom` prop is set to true. Similarly, when using brand on the footer you should set `borderTop` to true. This ensures when in High Contrast Mode on PC and when the user changes colour preferences in FireFox that the top/bottom of the `Brand` component is visible.
 
 `ScriptLink` component should be passed to `scriptLink` only when linking to a service variant.
-
-The `focusRef` prop is used so that the brand can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML anchor element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
 
 ```jsx
 import Brand from '@bbc/psammead-brand';

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -103,6 +103,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
+      tabindex="-1"
     >
       <svg
         aria-hidden="true"
@@ -257,6 +258,7 @@ exports[`Brand should render correctly with link provided 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
+      tabindex="-1"
     >
       <a
         class="emotion-4 emotion-5"
@@ -399,6 +401,7 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
+      tabindex="-1"
     >
       <svg
         aria-hidden="true"
@@ -531,6 +534,7 @@ exports[`Brand should render correctly with transparent borders 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
+      tabindex="-1"
     >
       <svg
         aria-hidden="true"

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -103,7 +103,6 @@ exports[`Brand should render correctly with link not provided 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
-      tabindex="-1"
     >
       <svg
         aria-hidden="true"
@@ -258,7 +257,6 @@ exports[`Brand should render correctly with link provided 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
-      tabindex="-1"
     >
       <a
         class="emotion-4 emotion-5"
@@ -401,7 +399,6 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
-      tabindex="-1"
     >
       <svg
         aria-hidden="true"
@@ -534,7 +531,6 @@ exports[`Brand should render correctly with transparent borders 1`] = `
   >
     <div
       class="emotion-2 emotion-3"
-      tabindex="-1"
     >
       <svg
         aria-hidden="true"

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -1,15 +1,6 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
-import {
-  string,
-  number,
-  node,
-  shape,
-  bool,
-  any,
-  oneOfType,
-  func,
-} from 'prop-types';
+import { string, number, node, shape, bool } from 'prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_GROUP_0_SCREEN_WIDTH_MAX,
@@ -210,7 +201,7 @@ StyledBrand.defaultProps = {
   serviceLocalisedName: null,
 };
 
-const Brand = props => {
+const Brand = forwardRef((props, ref) => {
   const {
     svgHeight,
     maxWidth,
@@ -222,7 +213,6 @@ const Brand = props => {
     logoColour,
     scriptLink,
     skipLink,
-    focusRef,
     ...rest
   } = props;
 
@@ -236,14 +226,9 @@ const Brand = props => {
       scriptLink={scriptLink}
       {...rest}
     >
-      <SvgWrapper>
+      <SvgWrapper ref={ref} tabIndex="-1">
         {url ? (
-          <StyledLink
-            href={url}
-            maxWidth={maxWidth}
-            minWidth={minWidth}
-            ref={focusRef}
-          >
+          <StyledLink href={url} maxWidth={maxWidth} minWidth={minWidth}>
             <StyledBrand {...props} />
           </StyledLink>
         ) : (
@@ -254,7 +239,7 @@ const Brand = props => {
       </SvgWrapper>
     </Banner>
   );
-};
+});
 
 Brand.defaultProps = {
   url: null,
@@ -263,7 +248,6 @@ Brand.defaultProps = {
   borderBottom: false,
   scriptLink: null,
   skipLink: null,
-  focusRef: null,
 };
 
 Brand.propTypes = {
@@ -274,8 +258,6 @@ Brand.propTypes = {
   borderBottom: bool,
   scriptLink: node,
   skipLink: node,
-  // eslint-disable-next-line react/forbid-prop-types
-  focusRef: oneOfType([func, shape({ current: any })]),
 };
 
 export default Brand;

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -226,7 +226,7 @@ const Brand = forwardRef((props, ref) => {
       scriptLink={scriptLink}
       {...rest}
     >
-      <SvgWrapper ref={ref} tabIndex="-1">
+      <SvgWrapper ref={ref}>
         {url ? (
           <StyledLink href={url} maxWidth={maxWidth} minWidth={minWidth}>
             <StyledBrand {...props} />

--- a/packages/components/psammead-brand/src/index.test.jsx
+++ b/packages/components/psammead-brand/src/index.test.jsx
@@ -142,7 +142,7 @@ describe('Brand', () => {
 
         useEffect(() => {
           brandRef.current?.querySelector('a')?.focus();
-        });
+        }, []);
 
         return (
           <Brand
@@ -159,38 +159,12 @@ describe('Brand', () => {
           />
         );
       };
-
+      const initialFocus = document.activeElement;
       const { container } = render(<TestComponent />);
       const brand = container.querySelector('a');
+
       expect(document.activeElement).toBe(brand);
-    });
-
-    it('should let the SvgWrapper be focussed with a ref if no url prop', () => {
-      const TestComponent = () => {
-        const brandRef = useRef(null);
-
-        useEffect(() => {
-          brandRef.current?.focus();
-        });
-
-        return (
-          <Brand
-            product="Default Brand Name"
-            svgHeight={24}
-            maxWidth={280}
-            minWidth={180}
-            svg={svg}
-            backgroundColour={C_POSTBOX}
-            logoColour={C_WHITE}
-            data-brand="header"
-            ref={brandRef}
-          />
-        );
-      };
-
-      const { container } = render(<TestComponent />);
-      const brand = container.querySelector('div[tabindex="-1"]');
-      expect(document.activeElement).toBe(brand);
+      expect(document.activeElement).not.toBe(initialFocus);
     });
 
     it('should render script, frontpage and skip to content links', () => {

--- a/packages/components/psammead-brand/src/index.test.jsx
+++ b/packages/components/psammead-brand/src/index.test.jsx
@@ -136,12 +136,12 @@ describe('Brand', () => {
       );
     });
 
-    it('should be focusable with a ref', () => {
+    it('should let the brand link be focussed with a ref', () => {
       const TestComponent = () => {
-        const focusRef = useRef(null);
+        const brandRef = useRef(null);
 
         useEffect(() => {
-          focusRef.current.focus();
+          brandRef.current?.querySelector('a')?.focus();
         });
 
         return (
@@ -155,13 +155,41 @@ describe('Brand', () => {
             backgroundColour={C_POSTBOX}
             logoColour={C_WHITE}
             data-brand="header"
-            focusRef={focusRef}
+            ref={brandRef}
           />
         );
       };
 
       const { container } = render(<TestComponent />);
       const brand = container.querySelector('a');
+      expect(document.activeElement).toBe(brand);
+    });
+
+    it('should let the SvgWrapper be focussed with a ref if no url prop', () => {
+      const TestComponent = () => {
+        const brandRef = useRef(null);
+
+        useEffect(() => {
+          brandRef.current?.focus();
+        });
+
+        return (
+          <Brand
+            product="Default Brand Name"
+            svgHeight={24}
+            maxWidth={280}
+            minWidth={180}
+            svg={svg}
+            backgroundColour={C_POSTBOX}
+            logoColour={C_WHITE}
+            data-brand="header"
+            ref={brandRef}
+          />
+        );
+      };
+
+      const { container } = render(<TestComponent />);
+      const brand = container.querySelector('div[tabindex="-1"]');
       expect(document.activeElement).toBe(brand);
     });
 

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.5.0 | [PR#4426](https://github.com/bbc/psammead/pull/4426) Change focusRef to headingRef |
 | 5.4.3 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 5.4.2 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |
 | 5.4.1 | [PR#4382](https://github.com/bbc/psammead/pull/4382) Change focusRef prop-type |

--- a/packages/components/psammead-consent-banner/README.md
+++ b/packages/components/psammead-consent-banner/README.md
@@ -24,13 +24,13 @@ The `psammead-consent-banner` component is a styled `div` that encapsulates info
 | dir | string | No | `'ltr'` | One of `'rtl'` `'ltr'` |
 | script | script | Yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36', }, groupD: { fontSize: '44', lineHeight: '48', }, }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24', }, groupB: { fontSize: '24', lineHeight: '28', }, groupD: { fontSize: '32', lineHeight: '36', }, }, } |
 | service | string | Yes | N/A | `'news'` |
-| focusRef | [Reference](https://reactjs.org/docs/refs-and-the-dom.html) | no | `null` | `useRef(null)` |
+| headingRef | [Reference](https://reactjs.org/docs/refs-and-the-dom.html) | no | `null` | `useRef(null)` |
 
 ## Usage
 
 The typical use-case of this component is on top of the webpage of all page types. It is visible for new users.
 
-The `focusRef` prop is used so that the title of the consent banner can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML heading element which can be focussed using the DOM APIs: `focusRef.current.focus()`.
+The `headingRef` prop is used so that the title of the consent banner can be programmatically focussed for accessibility reasons. This ref will be assigned to an HTML heading element which can be focussed using the DOM APIs: `headingRef.current.focus()`.
 
 ```jsx
 import { ConsentBanner, ConsentBannerText } from '@bbc/psammead-consent-banner';

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.4.3",
+  "version": "5.5.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-consent-banner/src/index.jsx
+++ b/packages/components/psammead-consent-banner/src/index.jsx
@@ -193,11 +193,11 @@ export const ConsentBanner = ({
   hidden,
   script,
   service,
-  focusRef,
+  headingRef,
 }) => (
   <Wrapper dir={dir} hidden={hidden} id={id} service={service}>
     <CenterWrapper dir={dir}>
-      <Title dir={dir} script={script} ref={focusRef}>
+      <Title dir={dir} script={script} ref={headingRef}>
         {title}
       </Title>
       {text}
@@ -224,12 +224,12 @@ ConsentBanner.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  focusRef: oneOfType([func, shape({ current: any })]),
+  headingRef: oneOfType([func, shape({ current: any })]),
 };
 
 ConsentBanner.defaultProps = {
   dir: 'ltr',
   id: null,
   hidden: null,
-  focusRef: null,
+  headingRef: null,
 };

--- a/packages/components/psammead-consent-banner/src/index.test.jsx
+++ b/packages/components/psammead-consent-banner/src/index.test.jsx
@@ -65,7 +65,7 @@ it('heading should be externally focusable', () => {
       ref.current.focus();
     });
 
-    return <ConsentBanner {...baseProps} focusRef={ref} />;
+    return <ConsentBanner {...baseProps} headingRef={ref} />;
   };
 
   const { getByText } = render(<TestContainer />);


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8855

**Overall change:** Makes changes to the psammead-brand and psammead-consent-banner component so that focus for these components can better be managed in Simorgh.

**Code changes:**

- Wraps the psammead-component in a `forwardRef`.
- Places the ref on the `SvgWrapper` styled component, instead of on the link, since the link is conditionally rendered.
- Adds the `tabindex="-1"` attribute to the SvgWrapper so that it can be focussed without disrupting the tab order.
- Adds a test to check that the `SvgWrapper` can be focussed using the ref when no url is given to the Banner.
- Ref naming changes.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
