### PR TITLE
bump psammead-navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@bbc/psammead-media-indicator": "6.1.0",
     "@bbc/psammead-media-player": "5.1.0",
     "@bbc/psammead-most-read": "6.0.28",
-    "@bbc/psammead-navigation": "9.0.12",
+    "@bbc/psammead-navigation": "9.1.0",
     "@bbc/psammead-paragraph": "4.0.16",
     "@bbc/psammead-play-button": "3.0.20",
     "@bbc/psammead-radio-schedule": "5.1.31",

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.1.0 | [PR#4437](https://github.com/bbc/psammead/pull/4437) add data-e2e attribute for e2e tests |
 | 9.0.11 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 9.0.10 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |
 | 9.0.9 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.0.12",
+  "version": "9.1.0",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Bumps psammead-navigation so that a new version containing the data-e2e attributes is released.

**Code changes:**

- Bumps psammead-navigation to v9.1.0

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
