### PR TITLE
add data-e2e attributes for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@bbc/psammead-media-indicator": "6.1.0",
     "@bbc/psammead-media-player": "5.1.0",
     "@bbc/psammead-most-read": "6.0.28",
-    "@bbc/psammead-navigation": "9.1.0",
+    "@bbc/psammead-navigation": "9.1.1",
     "@bbc/psammead-paragraph": "4.0.16",
     "@bbc/psammead-play-button": "3.0.20",
     "@bbc/psammead-radio-schedule": "5.1.31",

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.1.1 | [PR#4438](https://github.com/bbc/psammead/pull/4438) add data-e2e attribute for e2e tests |
 | 9.1.0 | [PR#4437](https://github.com/bbc/psammead/pull/4437) add data-e2e attribute for e2e tests |
 | 9.0.11 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 9.0.10 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -695,6 +695,7 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
 <div>
   <div
     class="emotion-0 emotion-1"
+    data-e2e="dropdown-nav"
     height="0"
   >
     <ul
@@ -911,6 +912,7 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
 <div>
   <div
     class="emotion-0 emotion-1"
+    data-e2e="dropdown-nav"
     height="0"
   >
     <ul

--- a/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/packages/components/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -55,6 +55,7 @@ export const CanonicalDropdown = ({ isOpen, children }) => {
 
   return (
     <StyledDropdown
+      data-e2e="dropdown-nav"
       ref={heightRef}
       height={heightRef.current ? heightRef.current.scrollHeight : 0}
       isOpen={isOpen}


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Add a data-e2e attribute to the dropdown nav for e2e test DOM selectors

**Code changes:**

- Adds data-e2e attribute to dropdown nav

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
