### PR TITLE
remove jitterbit/get-changed-files action from change-scanner action

### DIFF
--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -16,14 +16,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get Changed Files
-        id: changedFiles
-        uses: jitterbit/get-changed-files@v1
-
       - name: Install Node Modules
-        if: contains(steps.changedFiles.outputs.all, 'packages')
         run: yarn ci
 
       - name: Change Scanner
-        if: contains(steps.changedFiles.outputs.all, 'packages')
         run: yarn changeScanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.113 | [PR#4442](https://github.com/bbc/psammead/pull/4442) Fix flakey changescanner action |
 | 4.0.111 | [PR#4428](https://github.com/bbc/psammead/pull/4428) Refactoring RadioSchedule component |
 | 4.0.110 | [PR#4425](https://github.com/bbc/psammead/pull/4420) adding deprecation notice to psammead-episode-list |
 | 4.0.109 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.0.112",
+  "version": "4.0.113",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,19 +1100,6 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@bbc/psammead-radio-schedule@5.1.30":
-  version "5.1.30"
-  resolved "https://registry.yarnpkg.com/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.1.30.tgz#6c162c9cbe981afe8282fe1755bba96e2803e503"
-  integrity sha512-cWtXpV6sy3CFnNT+yNKQrxhAMMLs2vgjYDVcenTBG2cnFbDQR0r7mm67d33WEBZq/ObYJpQ5isMlBT9Fooulvg==
-  dependencies:
-    "@bbc/gel-foundations" "^6.1.1"
-    "@bbc/psammead-assets" "^3.1.5"
-    "@bbc/psammead-detokeniser" "^1.0.2"
-    "@bbc/psammead-grid" "^3.0.15"
-    "@bbc/psammead-live-label" "^2.0.15"
-    "@bbc/psammead-styles" "^7.2.2"
-    "@bbc/psammead-timestamp-container" "^5.0.25"
-
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"


### PR DESCRIPTION
**Overall change:**
This is a manual revert of this PR https://github.com/bbc/psammead/pull/4371

The changes in the above PR has made the changescanner action flakey. It was decided it's best to remove these changes from the changescanner action so that PRs are never blocked.


**Code changes:**

- Remove `jitterbit/get-changed-files` from change scanner action
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
