### PR TITLE
fix publish script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.6 | [PR#4450](https://github.com/bbc/psammead/pull/4450) fixes publish script |
 | 4.1.5 | [PR#4445](https://github.com/bbc/psammead/pull/4445) security patches |
 | 4.1.4 | [PR#4444](https://github.com/bbc/psammead/pull/4444) remove lerna package |
 | 4.1.3 | [PR#4443](https://github.com/bbc/psammead/pull/4443) fixes versioning and changelogs link in docs |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Core Components Library Developed & Maintained By The Articles and Reach & Languages Team",
   "main": "index.js",
   "private": true,

--- a/scripts/publish/index.js
+++ b/scripts/publish/index.js
@@ -8,13 +8,12 @@ const attempted = { success: [], failure: [] };
 const ROOT_PACKAGE = 'psammead';
 const PACKAGE_FILE = 'package.json';
 
-const getPackageFilePath = packageDir =>
-  packageDir === ROOT_PACKAGE
-    ? `./${PACKAGE_FILE}`
-    : `./${packageDir}/${PACKAGE_FILE}`;
-
 const publishPackage = packageDir => {
-  const packageFilePath = getPackageFilePath(packageDir);
+  if (packageDir === ROOT_PACKAGE) {
+    // we do not publish the root package
+    return;
+  }
+  const packageFilePath = `./${packageDir}/${PACKAGE_FILE}`;
   const packageJson = JSON.parse(fs.readFileSync(packageFilePath));
 
   if (shouldPublish(packageJson)) {

--- a/scripts/publish/index.js
+++ b/scripts/publish/index.js
@@ -6,14 +6,13 @@ const getPackages = require('../utilities/getPackages');
 
 const attempted = { success: [], failure: [] };
 const ROOT_PACKAGE = 'psammead';
-const PACKAGE_FILE = 'package.json';
 
 const publishPackage = packageDir => {
   if (packageDir === ROOT_PACKAGE) {
     // we do not publish the root package
     return;
   }
-  const packageFilePath = `./${packageDir}/${PACKAGE_FILE}`;
+  const packageFilePath = `./${packageDir}/package.json`;
   const packageJson = JSON.parse(fs.readFileSync(packageFilePath));
 
   if (shouldPublish(packageJson)) {

--- a/scripts/publish/index.js
+++ b/scripts/publish/index.js
@@ -5,9 +5,17 @@ const shouldPublish = require('./src/shouldPublish');
 const getPackages = require('../utilities/getPackages');
 
 const attempted = { success: [], failure: [] };
+const ROOT_PACKAGE = 'psammead';
+const PACKAGE_FILE = 'package.json';
+
+const getPackageFilePath = packageDir =>
+  packageDir === ROOT_PACKAGE
+    ? `./${PACKAGE_FILE}`
+    : `./${packageDir}/${PACKAGE_FILE}`;
 
 const publishPackage = packageDir => {
-  const packageJson = JSON.parse(fs.readFileSync(`${packageDir}/package.json`));
+  const packageFilePath = getPackageFilePath(packageDir);
+  const packageJson = JSON.parse(fs.readFileSync(packageFilePath));
 
   if (shouldPublish(packageJson)) {
     publish(packageDir, packageJson, attempted);


### PR DESCRIPTION
**Overall change:**
Fixes publish script and refactors unit tests to test the `publish/index.js` script rather than the `publish/src/publish.js` function.

**Code changes:**

- returns early if `packageDir` is `psammead` i.e. the root package. This caused a readfile error since changes in the getPackages function were introduced because the root package file path is now as `./psammead/package.json` whereas previously it was `./package.json`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
