### PR TITLE
Remove a reference to psammead-amp-geo

### DIFF
--- a/scripts/utilities/getPackages/index.test.js
+++ b/scripts/utilities/getPackages/index.test.js
@@ -8,8 +8,8 @@ describe(`Publish Script - getPackages`, () => {
     jest.mock('shelljs', () => ({
       exec: () =>
         JSON.stringify({
-          '@bbc/psammead-amp-geo': {
-            location: 'packages/components/psammead-amp-geo',
+          '@bbc/psammead-consent-banner': {
+            location: 'packages/components/psammead-consent-banner',
           },
           '@bbc/psammead-brand': {
             location: 'packages/components/psammead-brand',
@@ -24,8 +24,8 @@ describe(`Publish Script - getPackages`, () => {
     const actual = getPackages();
     const expected = [
       {
-        location: 'packages/components/psammead-amp-geo',
-        name: '@bbc/psammead-amp-geo',
+        location: 'packages/components/psammead-consent-banner',
+        name: '@bbc/psammead-consent-banner',
       },
       {
         location: 'packages/components/psammead-brand',


### PR DESCRIPTION
**Overall change:** Removes a reference to the newly deprecated psammead package, psammead-amp-geo, from a unit test.

**Code changes:**

- Replaces the mention of psammead-amp-geo with the mention of psammead-consent-banner, a package which is still being maintained.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
