### PR TITLE
Forward ref in psammead-grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@bbc/psammead-detokeniser": "1.0.5",
     "@bbc/psammead-embed-error": "3.0.20",
     "@bbc/psammead-figure": "2.0.9",
-    "@bbc/psammead-grid": "3.0.19",
+    "@bbc/psammead-grid": "3.1.0",
     "@bbc/psammead-heading-index": "3.0.16",
     "@bbc/psammead-headings": "5.0.16",
     "@bbc/psammead-image": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@bbc/psammead-navigation": "9.2.0",
     "@bbc/psammead-paragraph": "4.0.16",
     "@bbc/psammead-play-button": "3.0.20",
-    "@bbc/psammead-radio-schedule": "5.1.32",
+    "@bbc/psammead-radio-schedule": "5.1.33",
     "@bbc/psammead-rich-text-transforms": "2.0.6",
     "@bbc/psammead-script-link": "3.0.18",
     "@bbc/psammead-section-label": "7.0.18",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-locales": "5.0.6",
     "@bbc/psammead-media-indicator": "6.1.0",
     "@bbc/psammead-media-player": "5.1.0",
-    "@bbc/psammead-most-read": "6.0.29",
+    "@bbc/psammead-most-read": "6.0.30",
     "@bbc/psammead-navigation": "9.2.0",
     "@bbc/psammead-paragraph": "4.0.16",
     "@bbc/psammead-play-button": "3.0.20",

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.0 | [PR#4484](https://github.com/bbc/psammead/pull/4484) Forwards ref to GridComponent |
 | 3.0.18 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 3.0.17 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |
 | 3.0.16 | [PR#4335](https://github.com/bbc/psammead/pull/4335) switch to yarn for package management |

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.0.19",
+  "version": "3.1.0",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/index.jsx
+++ b/packages/components/psammead-grid/src/index.jsx
@@ -354,6 +354,7 @@ Grid.propTypes = {
 Grid.defaultProps = {
   dir: 'ltr',
   enableGelGutters: false,
+  enableNegativeGelMargins: false,
   margins: {
     group1: false,
     group2: false,

--- a/packages/components/psammead-grid/src/index.jsx
+++ b/packages/components/psammead-grid/src/index.jsx
@@ -277,34 +277,43 @@ const GridComponent = styled.div`
   }
 `;
 
-const Grid = ({
-  children,
-  startOffset: gridStartOffset, // alias this prop to prevent it rendering as an element attribute e.g. <div startoffset="[object Object]">
-  ...otherProps
-}) => {
-  const renderChildren = () =>
-    React.Children.map(children, child => {
-      if (child) {
-        const isNestedGridComponent = child.type === Grid;
+const Grid = React.forwardRef(
+  (
+    {
+      children,
+      startOffset: gridStartOffset, // alias this prop to prevent it rendering as an element attribute e.g. <div startoffset="[object Object]">
+      ...otherProps
+    },
+    ref,
+  ) => {
+    const renderChildren = () =>
+      React.Children.map(children, child => {
+        if (child) {
+          const isNestedGridComponent = child.type === Grid;
 
-        if (isNestedGridComponent) {
-          return React.cloneElement(child, {
-            parentColumns: otherProps.columns,
-            parentEnableGelGutters: otherProps.enableGelGutters,
-          });
+          if (isNestedGridComponent) {
+            return React.cloneElement(child, {
+              parentColumns: otherProps.columns,
+              parentEnableGelGutters: otherProps.enableGelGutters,
+            });
+          }
         }
-      }
-      return child;
-    });
+        return child;
+      });
 
-  const renderGridComponent = () => (
-    <GridComponent {...otherProps} gridStartOffset={gridStartOffset}>
-      {renderChildren()}
-    </GridComponent>
-  );
+    const renderGridComponent = () => (
+      <GridComponent
+        {...otherProps}
+        gridStartOffset={gridStartOffset}
+        ref={ref}
+      >
+        {renderChildren()}
+      </GridComponent>
+    );
 
-  return renderGridComponent();
-};
+    return renderGridComponent();
+  },
+);
 
 Grid.propTypes = {
   children: node.isRequired,

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.0.30 | [PR#4484](https://github.com/bbc/psammead/pull/4484) Bump psammead-grid to 3.1.0 |
 | 6.0.29 | [PR#4471](https://github.com/bbc/psammead/pull/4471) Increases the min-width of the rank |
 | 6.0.28 | [PR#4471](https://github.com/bbc/psammead/pull/4471) Fixes most read rank overlapping with the link |
 | 6.0.27 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "6.1.3",
-    "@bbc/psammead-grid": "3.0.19",
+    "@bbc/psammead-grid": "3.1.0",
     "@bbc/psammead-styles": "7.2.5"
   },
   "peerDependencies": {

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "6.0.29",
+  "version": "6.0.30",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-radio-schedule/CHANGELOG.md
+++ b/packages/components/psammead-radio-schedule/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.1.33 | [PR#4484](https://github.com/bbc/psammead/pull/4484) Bump psammead-grid to 3.1.0 |
 | 5.1.32 | [PR#4428](https://github.com/bbc/psammead/pull/4428) Break schedule item header into own component |
 | 5.1.30 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 5.1.29 | [PR#4376](https://github.com/bbc/psammead/pull/4376) Improve screenreader behaviour |

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-radio-schedule",
-  "version": "5.1.32",
+  "version": "5.1.33",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-radio-schedule/package.json
+++ b/packages/components/psammead-radio-schedule/package.json
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "6.1.3",
     "@bbc/psammead-assets": "3.1.8",
     "@bbc/psammead-detokeniser": "1.0.5",
-    "@bbc/psammead-grid": "3.0.19",
+    "@bbc/psammead-grid": "3.1.0",
     "@bbc/psammead-live-label": "2.0.19",
     "@bbc/psammead-styles": "7.2.5",
     "@bbc/psammead-timestamp-container": "5.0.29"


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9127

**Overall change:** Forwards a given reference to a styled div so that views can be tracked on anything contained within psammead-grid.

**Code changes:**

- Uses `React.forwardRef` to forward a `ref` to `GridComponent`
- Bump psammead-grid to `3.1.0`
- Bump psammead-most-read to `6.0.30`
- Bump psammead-radio-schedule to `5.1.33`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
