### PR TITLE
Update psammead-most-read for event tracking & Fix snyk vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.2",
     "@testing-library/react-hooks": "^5.0.0",
+    "@testing-library/user-event": "^13.1.9",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "hosted-git-info": ">=3.0.8",
     "semver-regex": "4.0.0",
     "postcss": "8.3.0",
-    "autoprefixer": "10.2.6"
+    "autoprefixer": "10.2.6",
+    "trim-newlines": "3.0.1"
   },
   "workspaces": [
     "packages/*/*"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-locales": "5.0.7",
     "@bbc/psammead-media-indicator": "6.1.1",
     "@bbc/psammead-media-player": "5.1.1",
-    "@bbc/psammead-most-read": "6.0.31",
+    "@bbc/psammead-most-read": "6.1.0",
     "@bbc/psammead-navigation": "9.2.1",
     "@bbc/psammead-paragraph": "4.0.17",
     "@bbc/psammead-play-button": "3.0.21",

--- a/packages/components/psammead-most-read/CHANGELOG.md
+++ b/packages/components/psammead-most-read/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 6.1.0 | [PR#4490](https://github.com/bbc/psammead/pull/4490) Add event tracking capability |
 | 6.0.31 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 6.0.30 | [PR#4484](https://github.com/bbc/psammead/pull/4484) Bump psammead-grid to 3.1.0 |
 | 6.0.29 | [PR#4471](https://github.com/bbc/psammead/pull/4471) Increases the min-width of the rank |

--- a/packages/components/psammead-most-read/README.md
+++ b/packages/components/psammead-most-read/README.md
@@ -154,7 +154,6 @@ import { MostReadRank } from '@bbc/psammead-most-read';
 | href | string | yes | N/A | `"/bbc.co.uk/news/00000027051997"` |
 | children | node | no | null | `<Timestamp datetime="2019-03-01T14:00+00:00" script={script} padding={false} service={service}>Last updated: 5th November 2016</Timestamp>` |
 | size | string | no | 'default' | `'small'` |
-| handleClick | func | no | null | `(event) => event.preventDefault()` |
 
 ### Usage
 

--- a/packages/components/psammead-most-read/README.md
+++ b/packages/components/psammead-most-read/README.md
@@ -154,6 +154,7 @@ import { MostReadRank } from '@bbc/psammead-most-read';
 | href | string | yes | N/A | `"/bbc.co.uk/news/00000027051997"` |
 | children | node | no | null | `<Timestamp datetime="2019-03-01T14:00+00:00" script={script} padding={false} service={service}>Last updated: 5th November 2016</Timestamp>` |
 | size | string | no | 'default' | `'small'` |
+| handleClick | func | no | null | `(event) => event.preventDefault()` |
 
 ### Usage
 

--- a/packages/components/psammead-most-read/package.json
+++ b/packages/components/psammead-most-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-most-read",
-  "version": "6.0.31",
+  "version": "6.1.0",
   "description": "A component for the most read item",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-most-read/src/Item/index.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.jsx
@@ -93,7 +93,7 @@ export const MostReadLink = ({
   href,
   children,
   size,
-  handleClick,
+  onClick,
 }) => (
   <StyledItem dir={dir} size={size}>
     <StyledLink
@@ -101,7 +101,7 @@ export const MostReadLink = ({
       script={script}
       service={service}
       size={size}
-      onClick={handleClick}
+      onClick={onClick}
     >
       {title}
     </StyledLink>
@@ -117,14 +117,14 @@ MostReadLink.propTypes = {
   href: string.isRequired,
   children: node, // this node will be a timestamp container
   size: oneOf(['default', 'small']),
-  handleClick: func,
+  onClick: func,
 };
 
 MostReadLink.defaultProps = {
   dir: 'ltr',
   children: null,
   size: 'default',
-  handleClick: null,
+  onClick: null,
 };
 
 const ItemWrapper = styled.div`

--- a/packages/components/psammead-most-read/src/Item/index.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.jsx
@@ -143,15 +143,18 @@ StyledGrid.defaultProps = {
   role: 'listitem',
 };
 
-export const MostReadItemWrapper = ({ dir, children, columnLayout }) => (
-  <StyledGrid
-    {...mostReadItemGridProps(columnLayout)}
-    parentColumns={getParentColumns(columnLayout)} // parentColumns is required here because on IE, this component would be rendered before it's parent therefore not receiving the parent's grid columns values so we have to explicitly pass it as a prop here so it works on IE
-    dir={dir}
-    as="li"
-  >
-    <ItemWrapper>{children}</ItemWrapper>
-  </StyledGrid>
+export const MostReadItemWrapper = React.forwardRef(
+  ({ dir, children, columnLayout }, ref) => (
+    <StyledGrid
+      {...mostReadItemGridProps(columnLayout)}
+      parentColumns={getParentColumns(columnLayout)} // parentColumns is required here because on IE, this component would be rendered before it's parent therefore not receiving the parent's grid columns values so we have to explicitly pass it as a prop here so it works on IE
+      dir={dir}
+      as="li"
+      ref={ref}
+    >
+      <ItemWrapper>{children}</ItemWrapper>
+    </StyledGrid>
+  ),
 );
 
 MostReadItemWrapper.propTypes = {

--- a/packages/components/psammead-most-read/src/Item/index.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shape, string, oneOf, node } from 'prop-types';
+import { shape, string, oneOf, node, func } from 'prop-types';
 import styled from '@emotion/styled';
 import { getPica, getGreatPrimer } from '@bbc/gel-foundations/typography';
 import { C_EBON } from '@bbc/psammead-styles/colours';
@@ -93,9 +93,16 @@ export const MostReadLink = ({
   href,
   children,
   size,
+  handleClick,
 }) => (
   <StyledItem dir={dir} size={size}>
-    <StyledLink href={href} script={script} service={service} size={size}>
+    <StyledLink
+      href={href}
+      script={script}
+      service={service}
+      size={size}
+      onClick={handleClick}
+    >
       {title}
     </StyledLink>
     {children && <TimestampWrapper>{children}</TimestampWrapper>}
@@ -110,12 +117,14 @@ MostReadLink.propTypes = {
   href: string.isRequired,
   children: node, // this node will be a timestamp container
   size: oneOf(['default', 'small']),
+  handleClick: func,
 };
 
 MostReadLink.defaultProps = {
   dir: 'ltr',
   children: null,
   size: 'default',
+  handleClick: null,
 };
 
 const ItemWrapper = styled.div`

--- a/packages/components/psammead-most-read/src/Item/index.test.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { latin, arabic } from '@bbc/gel-foundations/scripts';
+import userEvent from '@testing-library/user-event';
+import { render, act } from '@testing-library/react';
 import { MostReadLink, getParentColumns } from '.';
 import { getItem, getItemWrapperArray } from '../utilities';
 
@@ -40,6 +42,25 @@ describe('MostReadLink', () => {
       {newsItem.timestamp}
     </MostReadLink>,
   );
+
+  it('should call handleClick on click', () => {
+    const handleClick = jest.fn();
+    const { getByText } = render(
+      <MostReadLink
+        href={newsItem.href}
+        service="news"
+        script={latin}
+        title={newsItem.title}
+        handleClick={handleClick}
+      />,
+    );
+
+    expect(handleClick).not.toHaveBeenCalled();
+
+    act(() => userEvent.click(getByText(newsItem.title)));
+
+    expect(handleClick).toHaveBeenCalled();
+  });
 });
 
 describe('MostReadItemWrapper', () => {

--- a/packages/components/psammead-most-read/src/Item/index.test.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.test.jsx
@@ -43,7 +43,7 @@ describe('MostReadLink', () => {
     </MostReadLink>,
   );
 
-  it('should call handleClick on click', () => {
+  it('should call handleClick on MostReadLink click', () => {
     const handleClick = jest.fn();
     const { getByText } = render(
       <MostReadLink

--- a/packages/components/psammead-most-read/src/Item/index.test.jsx
+++ b/packages/components/psammead-most-read/src/Item/index.test.jsx
@@ -51,7 +51,7 @@ describe('MostReadLink', () => {
         service="news"
         script={latin}
         title={newsItem.title}
-        handleClick={handleClick}
+        onClick={handleClick}
       />,
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,6 +2604,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^13.1.9":
+  version "13.1.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.1.9.tgz#29e49a42659ac3c1023565ff56819e0153a82e99"
+  integrity sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12558,10 +12558,10 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+trim-newlines@3.0.1, trim-newlines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-repeated@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9129

**Overall change:** Enables view and click tracking capability for the psammead-most-read component.

**Code changes:**
- Take `onClick` as a prop and attach it to the `StyledLink` 
- Adds a unit test to check the onClick prop will be invoked when `MostReadLink` is clicked.
- Adds `@testing-library/user-event` as a dependency for the added unit test.
- Use `React.forwardRef` on `MostReadItemWrapper` so that views can be tracked on this component.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
