### PR TITLE
Link to repository use guidelines from PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,5 +38,8 @@ If applicable, add screenshots to help explain your problem.
 
 - [ ] This bug fix is expected to need manual testing.
 
+**Checklist**
+- [ ] (BBC contributors only) This issue follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
+
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,5 +20,8 @@ Dev insight: Will there be any potential regression? etc
 
 - [ ] This feature is expected to need manual testing.
 
+**Checklist**
+- [ ] (BBC contributors only) This issue follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Resolves #NUMBER
 
 ---
 
+- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
 - [ ] I have assigned myself to this PR and the corresponding issues
 - [ ] Automated jest tests added (for new features) or updated (for existing features)
 - [ ] This PR requires manual testing


### PR DESCRIPTION
(no issue)

**Overall change:**
Links to the repository use guidelines added in https://github.com/bbc/simorgh-infrastructure/pull/1368 from within issue and pull request templates. This is analogous to https://github.com/bbc/simorgh/pull/9083 but for psammead

**Code changes:**

- Update template files in `.github` folder

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
