### PR TITLE
Forward ref and check single child type in topic tags

### DIFF
--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.7 | [PR#????](https://github.com/bbc/psammead/pull/????) Forward ref in TopicTag and check single child type |
+| 0.1.0-alpha.7 | [PR#4496](https://github.com/bbc/psammead/pull/4496) Forward ref in TopicTag and check single child type |
 | 0.1.0-alpha.6 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 0.1.0-alpha.5 | [PR#4419](https://github.com/bbc/psammead/pull/4419) Remove clickable whitespace |
 | 0.1.0-alpha.4 | [PR#4419](https://github.com/bbc/psammead/pull/4419) Update designs |

--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.7 | [PR#????](https://github.com/bbc/psammead/pull/????) Forward ref in TopicTag and check single child type |
 | 0.1.0-alpha.6 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 0.1.0-alpha.5 | [PR#4419](https://github.com/bbc/psammead/pull/4419) Remove clickable whitespace |
 | 0.1.0-alpha.4 | [PR#4419](https://github.com/bbc/psammead/pull/4419) Update designs |

--- a/packages/components/psammead-topic-tags/package.json
+++ b/packages/components/psammead-topic-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-topic-tags",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-topic-tags/src/index.jsx
+++ b/packages/components/psammead-topic-tags/src/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { string, shape, node } from 'prop-types';
 import styled from '@emotion/styled';
 import { C_LUNAR, C_EBON, C_METAL } from '@bbc/psammead-styles/colours';
@@ -57,7 +57,11 @@ const SingleTopicTagItem = styled.div`
   }
 `;
 
-export const TopicTag = ({ name, link }) => <a href={link}>{name}</a>;
+export const TopicTag = forwardRef(({ name, link }, ref) => (
+  <a href={link} ref={ref}>
+    {name}
+  </a>
+));
 
 export const TopicTags = ({ children, script, service }) => {
   const hasMultipleChildren = children.length > 1;

--- a/packages/components/psammead-topic-tags/src/index.jsx
+++ b/packages/components/psammead-topic-tags/src/index.jsx
@@ -89,7 +89,7 @@ export const TopicTags = ({ children, script, service }) => {
       ) : (
         <SingleTopicTagContainer service={service} script={script}>
           <SingleTopicTagItem service={service} script={script}>
-            {children}
+            {children.type === TopicTag && children}
           </SingleTopicTagItem>
         </SingleTopicTagContainer>
       )}


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9170

**Overall change:** Facilitates view tracking in the topic tags and ensures that if there is one child component for the topic tags, that it is a topic tag.

**Code changes:**

- Forwards ref in TopicTag component.
- Checks child type in case of single child and ensure that it is a TopicTag component. This logic exists when there are multiple children, but not in the case of a single child.

---

- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
