### PR TITLE
Forward onClick to anchor in TopicTag

### DIFF
--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.9 | [PR#????](https://github.com/bbc/psammead/pull/????) Forward onClick to anchor on TopicTag |
 | 0.1.0-alpha.8 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 0.1.0-alpha.7 | [PR#4496](https://github.com/bbc/psammead/pull/4496) Forward ref in TopicTag and check single child type |
 | 0.1.0-alpha.6 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 0.1.0-alpha.9 | [PR#????](https://github.com/bbc/psammead/pull/????) Forward onClick to anchor on TopicTag |
+| 0.1.0-alpha.9 | [PR#4500](https://github.com/bbc/psammead/pull/4500) Forward onClick to anchor on TopicTag |
 | 0.1.0-alpha.8 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 0.1.0-alpha.7 | [PR#4496](https://github.com/bbc/psammead/pull/4496) Forward ref in TopicTag and check single child type |
 | 0.1.0-alpha.6 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/components/psammead-topic-tags/package.json
+++ b/packages/components/psammead-topic-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-topic-tags",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-topic-tags/src/index.jsx
+++ b/packages/components/psammead-topic-tags/src/index.jsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { string, shape, node } from 'prop-types';
+import { string, shape, node, func } from 'prop-types';
 import styled from '@emotion/styled';
 import { C_LUNAR, C_EBON, C_METAL } from '@bbc/psammead-styles/colours';
 import {
@@ -57,8 +57,8 @@ const SingleTopicTagItem = styled.div`
   }
 `;
 
-export const TopicTag = forwardRef(({ name, link }, ref) => (
-  <a href={link} ref={ref}>
+export const TopicTag = forwardRef(({ name, link, onClick }, ref) => (
+  <a href={link} onClick={onClick} ref={ref}>
     {name}
   </a>
 ));
@@ -100,7 +100,10 @@ export const TopicTags = ({ children, script, service }) => {
 TopicTag.propTypes = {
   name: string.isRequired,
   link: string.isRequired,
+  onClick: func,
 };
+
+TopicTag.defaultProps = { onClick: null };
 
 TopicTags.propTypes = {
   children: node,


### PR DESCRIPTION
**Overall change:** Enables click tracking on the topic tag.

**Code changes:**

- Forwards the `onClick` prop on to the anchor that makes up the `TopicTag` component.
- Updates the version number to `0.1.0-alpha.9`.

---

- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
