### PR TITLE
Upgrade psammead-topic-tags to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@bbc/psammead-test-helpers": "6.0.4",
     "@bbc/psammead-timestamp": "4.0.19",
     "@bbc/psammead-timestamp-container": "5.0.30",
+    "@bbc/psammead-topic-tags": "1.0.0",
     "@bbc/psammead-useful-links": "3.0.20",
     "@bbc/psammead-visually-hidden-text": "2.0.7",
     "@emotion/babel-plugin": "^11.1.2",

--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| 1.0.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Remove alpha versioning and halve row spacing |
+| 1.0.0 | [PR#4522](https://github.com/bbc/psammead/pull/4522) Remove alpha versioning and halve row spacing |
 | 0.1.0-alpha.11 | [PR#4521](https://github.com/bbc/psammead/pull/4521) Tweak dimensions of tags |
 | 0.1.0-alpha.10 | [PR#4512](https://github.com/bbc/psammead/pull/4512) Fix line spacing on text wrap |
 | 0.1.0-alpha.9 | [PR#4500](https://github.com/bbc/psammead/pull/4500) Forward onClick to anchor on TopicTag |

--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Remove alpha versioning and halve row spacing |
 | 0.1.0-alpha.11 | [PR#4521](https://github.com/bbc/psammead/pull/4521) Tweak dimensions of tags |
 | 0.1.0-alpha.10 | [PR#4512](https://github.com/bbc/psammead/pull/4512) Fix line spacing on text wrap |
 | 0.1.0-alpha.9 | [PR#4500](https://github.com/bbc/psammead/pull/4500) Forward onClick to anchor on TopicTag |

--- a/packages/components/psammead-topic-tags/README.md
+++ b/packages/components/psammead-topic-tags/README.md
@@ -1,7 +1,3 @@
-# ⛔️ This is an alpha component ⛔️
-
-This component is currently tagged as alpha and is not suitable for production use. Following the passing of an accessibility review this component will be marked as ready for production and the alpha tag removed.
-
 # psammead-topic-tags - [![Known Vulnerabilities](https://snyk.io/test/github/bbc/psammead/badge.svg?targetFile=packages%2Fcomponents%2Fpsammead-topic-tags%2Fpackage.json)](https://snyk.io/test/github/bbc/psammead?targetFile=packages%2Fcomponents%2Fpsammead-topic-tags%2Fpackage.json) [![Dependency Status](https://david-dm.org/bbc/psammead.svg?path=packages/components/psammead-topic-tags)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-topic-tags) [![peerDependencies Status](https://david-dm.org/bbc/psammead/peer-status.svg?path=packages/components/psammead-topic-tags)](https://david-dm.org/bbc/psammead?path=packages/components/psammead-topic-tags&type=peer) [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg?sanitize=true)](https://bbc.github.io/psammead/?path=/story/topic-tags--containing-image) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/bbc/psammead/blob/latest/LICENSE) [![npm version](https://img.shields.io/npm/v/@bbc/psammead-topic-tags.svg)](https://www.npmjs.com/package/@bbc/psammead-topic-tags) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/bbc/psammead/blob/latest/CONTRIBUTING.md)
 
 ## Description

--- a/packages/components/psammead-topic-tags/package.json
+++ b/packages/components/psammead-topic-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-topic-tags",
-  "version": "0.1.0-alpha.11",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,9 +26,6 @@
     "@emotion/styled": "^11.1.5",
     "prop-types": "^15.6.2",
     "react": ">=16.9.0"
-  },
-  "publishConfig": {
-    "tag": "alpha"
   },
   "devDependencies": {
     "@emotion/styled": "^11.3.0",

--- a/packages/components/psammead-topic-tags/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-topic-tags/src/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`TopicTags should correctly render a single topic for news 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -24,7 +24,7 @@ exports[`TopicTags should correctly render a single topic for news 1`] = `
   font-size: 0.875rem;
   line-height: 1.125rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
@@ -97,7 +97,7 @@ exports[`TopicTags should correctly render a single topic tag for burmese 1`] = 
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -111,7 +111,7 @@ exports[`TopicTags should correctly render a single topic tag for burmese 1`] = 
   font-size: 0.875rem;
   line-height: 1.375rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
@@ -184,7 +184,7 @@ exports[`TopicTags should correctly render a single topic tag for persian 1`] = 
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -198,7 +198,7 @@ exports[`TopicTags should correctly render a single topic tag for persian 1`] = 
   font-size: 0.875rem;
   line-height: 1.25rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
@@ -271,7 +271,7 @@ exports[`TopicTags should correctly render multiple topic tags for arabic 1`] = 
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -286,7 +286,7 @@ exports[`TopicTags should correctly render multiple topic tags for arabic 1`] = 
   font-size: 0.875rem;
   line-height: 1.25rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
@@ -387,7 +387,7 @@ exports[`TopicTags should correctly render multiple topic tags for news 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -402,7 +402,7 @@ exports[`TopicTags should correctly render multiple topic tags for news 1`] = `
   font-size: 0.875rem;
   line-height: 1.125rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
@@ -503,7 +503,7 @@ exports[`TopicTags should ignore non-TopicTag children 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-top: -1rem;
+  margin-top: -0.5rem;
   margin-bottom: 0;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
@@ -518,7 +518,7 @@ exports[`TopicTags should ignore non-TopicTag children 1`] = `
   font-size: 0.875rem;
   line-height: 1.125rem;
   word-break: break-word;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }

--- a/packages/components/psammead-topic-tags/src/index.jsx
+++ b/packages/components/psammead-topic-tags/src/index.jsx
@@ -16,7 +16,7 @@ const MIN_TAG_HEIGHT = '2.75rem'; // 44px
 const CONTAINER_STYLES = `
   display: flex;
   flex-wrap: wrap;
-  margin-top: -${GEL_SPACING_DBL};
+  margin-top: -${GEL_SPACING};
   margin-bottom: 0;
   margin-left: -${GEL_SPACING_HLF};
   margin-right: -${GEL_SPACING_HLF};
@@ -37,7 +37,7 @@ const SingleTopicTagItem = styled.div`
   ${({ script }) => script && getBrevier(script)}
 
   word-break: break-word;
-  margin-top: ${GEL_SPACING_DBL};
+  margin-top: ${GEL_SPACING};
   margin-left: ${GEL_SPACING_HLF};
   margin-right: ${GEL_SPACING_HLF};
   a {


### PR DESCRIPTION
(Final psammead topic tag PR from me today I think/hope)

**Overall change:** Halves the row spacing in the topic tags and takes the component out of alpha versioning

**Code changes:**

- Upgrades the component to `1.0.0`.
- Halves the space in between rows to `8px` or `0.5rem` (ignore the rushed commit message).

---

- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
