### PR TITLE
Section Label - Make Mobile Divider Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@bbc/psammead-play-button": "3.0.22",
     "@bbc/psammead-rich-text-transforms": "2.0.6",
     "@bbc/psammead-script-link": "3.0.20",
-    "@bbc/psammead-section-label": "7.0.20",
+    "@bbc/psammead-section-label": "7.1.0",
     "@bbc/psammead-social-embed": "3.1.16",
     "@bbc/psammead-story-promo": "8.0.21",
     "@bbc/psammead-story-promo-list": "6.0.19",

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 7.1.0 | [PR#?](https://github.com/bbc/psammead/pull/?) Allows the bar to be toggled off on mobile |
+| 7.1.0 | [PR#4528](https://github.com/bbc/psammead/pull/4528) Allows the mobile divider to be toggled off |
 | 7.0.20 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 7.0.19 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 7.0.17 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 7.1.0 | [PR#?](https://github.com/bbc/psammead/pull/?) Allows the bar to be toggled off on mobile |
 | 7.0.20 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 7.0.19 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 7.0.17 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-section-label/README.md
+++ b/packages/components/psammead-section-label/README.md
@@ -18,6 +18,7 @@ The only provided child should be the title for the section, provided as a _stri
 | Argument  | Type | Required | Default | Example |
 | --------- | ---- | -------- | ------- | ------- |
 | bar | boolean | no | `true` | `false` |
+| mobileDivider | boolean | no | `true` | `false` |
 | visuallyHidden | boolean | no | `false` | `true` |
 | children | string | yes | N/A | `'Most Read'` |
 | dir | string | no | `'ltr'` | `'rtl'` |
@@ -61,6 +62,27 @@ const WrappingComponent = () => (
       script={latin}
       dir="ltr"
       bar={false}
+      labelId="example-section-label"
+      service="news"
+    >
+      Example section
+    </SectionLabel>
+  </div>
+);
+```
+
+On mobile, this component places a dividing line above the title. This can be disabled by setting the `mobileDivider` prop to `false`:
+
+```jsx
+import SectionLabel from '@bbc/psammead-section-label';
+import { latin } from '@bbc/gel-foundations/scripts';
+
+const WrappingComponent = () => (
+  <div aria-labelledby="example-section-label">
+    <SectionLabel
+      script={latin}
+      dir="ltr"
+      mobileDivider={false}
       labelId="example-section-label"
       service="news"
     >

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "7.0.20",
+  "version": "7.1.0",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -28,11 +28,28 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 .emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,7 +59,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   flex-direction: column;
 }
 
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -62,7 +79,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -70,7 +87,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -90,27 +107,27 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
@@ -119,17 +136,20 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   <div
     class="emotion-0 emotion-1"
   >
-    <h2
+    <div
       class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
     >
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
       >
         <span
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-8 emotion-9"
+            class="emotion-10 emotion-11"
             dir="ltr"
             id="test-section-label"
           >
@@ -165,6 +185,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 .emotion-2 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
+  display: none;
 }
 
 @media screen and (-ms-high-contrast: active) {
@@ -175,6 +196,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
+    display: block;
     position: absolute;
     left: 0;
     right: 0;
@@ -183,23 +205,40 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 .emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
+.emotion-8:focus,
+.emotion-8:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -209,7 +248,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -229,7 +268,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -237,7 +276,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   }
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -257,32 +296,32 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     padding-right: 1rem;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -304,21 +343,21 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     margin: 0;
   }
 }
@@ -330,23 +369,26 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
     <div
       class="emotion-2 emotion-3"
     />
-    <h2
+    <div
       class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
     >
       <a
         aria-labelledby="test-section-label"
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="ltr"
               id="test-section-label"
             >
@@ -354,7 +396,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               dir="ltr"
             >
               See All
@@ -390,6 +432,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 .emotion-2 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
+  display: none;
 }
 
 @media screen and (-ms-high-contrast: active) {
@@ -400,6 +443,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
+    display: block;
     position: absolute;
     left: 0;
     right: 0;
@@ -408,23 +452,40 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 .emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
+.emotion-8:focus,
+.emotion-8:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -434,7 +495,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -454,7 +515,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -462,7 +523,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   }
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -482,32 +543,32 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     padding-left: 1rem;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -529,21 +590,21 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     margin: 0;
   }
 }
@@ -555,23 +616,26 @@ exports[`SectionLabel With bar With linking title should render correctly with a
     <div
       class="emotion-2 emotion-3"
     />
-    <h2
+    <div
       class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
     >
       <a
         aria-labelledby="test-section-label"
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="rtl"
               id="test-section-label"
             >
@@ -579,7 +643,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               dir="rtl"
             >
               See All
@@ -615,6 +679,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 .emotion-2 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
+  display: none;
 }
 
 @media screen and (-ms-high-contrast: active) {
@@ -625,6 +690,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
+    display: block;
     position: absolute;
     left: 0;
     right: 0;
@@ -633,23 +699,40 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 .emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
+.emotion-8:focus,
+.emotion-8:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -659,7 +742,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -679,7 +762,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -687,7 +770,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   }
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -707,32 +790,32 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     padding-right: 1rem;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -754,21 +837,21 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     margin: 0;
   }
 }
@@ -780,23 +863,26 @@ exports[`SectionLabel With bar With linking title should render correctly with e
     <div
       class="emotion-2 emotion-3"
     />
-    <h2
+    <div
       class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
     >
       <a
         aria-labelledby="test-section-label"
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="ltr"
               id="test-section-label"
             >
@@ -804,7 +890,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               dir="ltr"
             >
               See All
@@ -840,6 +926,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 .emotion-2 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
+  display: none;
 }
 
 @media screen and (-ms-high-contrast: active) {
@@ -850,10 +937,1288 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
+    display: block;
     position: absolute;
     left: 0;
     right: 0;
     top: 1.375rem;
+  }
+}
+
+.emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-8 {
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8:focus,
+.emotion-8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-14 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-14 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-14 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-14 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-14 {
+    padding-right: 1rem;
+  }
+}
+
+.emotion-16 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  margin: 1rem 0;
+  color: #222222;
+  background-color: #FDFDFD;
+  white-space: nowrap;
+  padding-left: 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-16 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-16 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-16 {
+    margin: 0;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <div
+      class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
+    >
+      <a
+        aria-labelledby="test-section-label"
+        class="emotion-8 emotion-9"
+        href="/igbo/other-index"
+      >
+        <span
+          class="emotion-10 emotion-11"
+        >
+          <span
+            class="emotion-12 emotion-13"
+            role="text"
+          >
+            <span
+              class="emotion-14 emotion-15"
+              dir="ltr"
+              id="test-section-label"
+            >
+              This is text in a SectionLabel, and there is a bar over to the right
+            </span>
+            <span
+              aria-hidden="true"
+              class="emotion-16 emotion-17"
+              dir="ltr"
+            >
+              See All
+            </span>
+          </span>
+        </span>
+      </a>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With bar With plain title should render correctly 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+  display: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+.emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-12 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-12 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <div
+      class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
+    >
+      <span
+        class="emotion-8 emotion-9"
+      >
+        <span
+          class="emotion-10 emotion-11"
+        >
+          <span
+            class="emotion-12 emotion-13"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel.
+          </span>
+        </span>
+      </span>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With bar With plain title should render correctly with arabic script typography values 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+  display: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.5rem;
+  }
+}
+
+.emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-12 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-12 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    padding-left: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <div
+      class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
+    >
+      <span
+        class="emotion-8 emotion-9"
+      >
+        <span
+          class="emotion-10 emotion-11"
+        >
+          <span
+            class="emotion-12 emotion-13"
+            dir="rtl"
+            id="test-section-label"
+          >
+            بعض محتوى النص
+          </span>
+        </span>
+      </span>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With bar With plain title should render correctly with explicit text direction 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+  display: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+.emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-12 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-12 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <div
+      class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
+    >
+      <span
+        class="emotion-8 emotion-9"
+      >
+        <span
+          class="emotion-10 emotion-11"
+        >
+          <span
+            class="emotion-12 emotion-13"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel rendering in ltr mode.
+          </span>
+        </span>
+      </span>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With bar With plain title should render correctly with explicitly showing the bar 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+  display: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+.emotion-4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    display: none;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-12 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-12 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <div
+      class="emotion-4 emotion-5"
+    />
+    <h2
+      class="emotion-6 emotion-7"
+    >
+      <span
+        class="emotion-8 emotion-9"
+      >
+        <span
+          class="emotion-10 emotion-11"
+        >
+          <span
+            class="emotion-12 emotion-13"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel, and there is a bar over to the right
+          </span>
+        </span>
+      </span>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With bar With plain title should render correctly with mobileDivider set to false 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+  display: none;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
+    >
+      <span
+        class="emotion-6 emotion-7"
+      >
+        <span
+          class="emotion-8 emotion-9"
+        >
+          <span
+            class="emotion-10 emotion-11"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel, and there is no mobile divider
+          </span>
+        </span>
+      </span>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel With heading overriden should render a strong element instead of an h2 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <strong
+      class="emotion-4 emotion-5"
+    >
+      <span
+        class="emotion-6 emotion-7"
+      >
+        <span
+          class="emotion-8 emotion-9"
+        >
+          <span
+            class="emotion-10 emotion-11"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel.
+          </span>
+        </span>
+      </span>
+    </strong>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel Without bar With linking title should render correctly 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
   }
 }
 
@@ -1025,980 +2390,11 @@ exports[`SectionLabel With bar With linking title should render correctly with e
               dir="ltr"
               id="test-section-label"
             >
-              This is text in a SectionLabel, and there is a bar over to the right
-            </span>
-            <span
-              aria-hidden="true"
-              class="emotion-14 emotion-15"
-              dir="ltr"
-            >
-              See All
-            </span>
-          </span>
-        </span>
-      </a>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel With bar With plain title should render correctly 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-10 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <h2
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-            dir="ltr"
-            id="test-section-label"
-          >
-            This is text in a SectionLabel.
-          </span>
-        </span>
-      </span>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel With bar With plain title should render correctly with arabic script typography values 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-10 {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
-  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-left: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    font-size: 1.5rem;
-    line-height: 2rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    padding-left: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <h2
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-            dir="rtl"
-            id="test-section-label"
-          >
-            بعض محتوى النص
-          </span>
-        </span>
-      </span>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel With bar With plain title should render correctly with explicit text direction 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-10 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <h2
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-            dir="ltr"
-            id="test-section-label"
-          >
-            This is text in a SectionLabel rendering in ltr mode.
-          </span>
-        </span>
-      </span>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel With bar With plain title should render correctly with explicitly showing the bar 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-10 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <h2
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-            dir="ltr"
-            id="test-section-label"
-          >
-            This is text in a SectionLabel, and there is a bar over to the right
-          </span>
-        </span>
-      </span>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel With heading overriden should render a strong element instead of an h2 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-8 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <strong
-      class="emotion-2 emotion-3"
-    >
-      <span
-        class="emotion-4 emotion-5"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          <span
-            class="emotion-8 emotion-9"
-            dir="ltr"
-            id="test-section-label"
-          >
-            This is text in a SectionLabel.
-          </span>
-        </span>
-      </span>
-    </strong>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel Without bar With linking title should render correctly 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-4 {
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-4:focus,
-.emotion-4:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-10 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    padding-right: 1rem;
-  }
-}
-
-.emotion-12 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  margin: 1rem 0;
-  color: #222222;
-  background-color: #FDFDFD;
-  white-space: nowrap;
-  padding-left: 1rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    margin: 0;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <h2
-      class="emotion-2 emotion-3"
-    >
-      <a
-        aria-labelledby="test-section-label"
-        class="emotion-4 emotion-5"
-        href="/igbo/other-index"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          <span
-            class="emotion-8 emotion-9"
-            role="text"
-          >
-            <span
-              class="emotion-10 emotion-11"
-              dir="ltr"
-              id="test-section-label"
-            >
               This is text in a SectionLabel.
             </span>
             <span
               aria-hidden="true"
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="ltr"
             >
               See All
@@ -2032,23 +2428,40 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-6:focus,
+.emotion-6:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2058,7 +2471,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2078,7 +2491,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2086,7 +2499,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2106,32 +2519,32 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-12 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-12 {
     padding-left: 1rem;
   }
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2153,21 +2566,21 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-14 {
     margin: 0;
   }
 }
@@ -2176,23 +2589,26 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   <div
     class="emotion-0 emotion-1"
   >
-    <h2
+    <div
       class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
     >
       <a
         aria-labelledby="test-section-label"
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-8 emotion-9"
+            class="emotion-10 emotion-11"
             role="text"
           >
             <span
-              class="emotion-10 emotion-11"
+              class="emotion-12 emotion-13"
               dir="rtl"
               id="test-section-label"
             >
@@ -2200,7 +2616,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
             </span>
             <span
               aria-hidden="true"
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="rtl"
             >
               See All
@@ -2234,20 +2650,247 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-6:focus,
+.emotion-6:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-12 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-12 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    padding-right: 1rem;
+  }
+}
+
+.emotion-14 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  margin: 1rem 0;
+  color: #222222;
+  background-color: #FDFDFD;
+  white-space: nowrap;
+  padding-left: 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-14 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-14 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-14 {
+    margin: 0;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
+    >
+      <a
+        aria-labelledby="test-section-label"
+        class="emotion-6 emotion-7"
+        href="/igbo/other-index"
+      >
+        <span
+          class="emotion-8 emotion-9"
+        >
+          <span
+            class="emotion-10 emotion-11"
+            role="text"
+          >
+            <span
+              class="emotion-12 emotion-13"
+              dir="ltr"
+              id="test-section-label"
+            >
+              This is text in a SectionLabel rendering in ltr mode.
+            </span>
+            <span
+              aria-hidden="true"
+              class="emotion-14 emotion-15"
+              dir="ltr"
+            >
+              See All
+            </span>
+          </span>
+        </span>
+      </a>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel Without bar With plain title should render correctly 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
 }
 
 .emotion-6 {
@@ -2333,211 +2976,24 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
-.emotion-12 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  margin: 1rem 0;
-  color: #222222;
-  background-color: #FDFDFD;
-  white-space: nowrap;
-  padding-left: 1rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    margin: 0;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
   >
-    <h2
+    <div
       class="emotion-2 emotion-3"
-    >
-      <a
-        aria-labelledby="test-section-label"
-        class="emotion-4 emotion-5"
-        href="/igbo/other-index"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          <span
-            class="emotion-8 emotion-9"
-            role="text"
-          >
-            <span
-              class="emotion-10 emotion-11"
-              dir="ltr"
-              id="test-section-label"
-            >
-              This is text in a SectionLabel rendering in ltr mode.
-            </span>
-            <span
-              aria-hidden="true"
-              class="emotion-12 emotion-13"
-              dir="ltr"
-            >
-              See All
-            </span>
-          </span>
-        </span>
-      </a>
-    </h2>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel Without bar With plain title should render correctly 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-8 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
+    />
     <h2
-      class="emotion-2 emotion-3"
+      class="emotion-4 emotion-5"
     >
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
       >
         <span
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-8 emotion-9"
+            class="emotion-10 emotion-11"
             dir="ltr"
             id="test-section-label"
           >
@@ -2571,11 +3027,28 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 .emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2585,7 +3058,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   flex-direction: column;
 }
 
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2605,7 +3078,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2613,7 +3086,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2633,27 +3106,27 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-left: 1rem;
   }
 }
@@ -2662,17 +3135,20 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <div
     class="emotion-0 emotion-1"
   >
-    <h2
+    <div
       class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
     >
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
       >
         <span
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-8 emotion-9"
+            class="emotion-10 emotion-11"
             dir="rtl"
             id="test-section-label"
           >
@@ -2706,11 +3182,28 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 .emotion-2 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .emotion-2 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2720,7 +3213,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   flex-direction: column;
 }
 
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2740,7 +3233,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2748,7 +3241,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -2768,27 +3261,27 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
@@ -2797,17 +3290,20 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <div
     class="emotion-0 emotion-1"
   >
-    <h2
+    <div
       class="emotion-2 emotion-3"
+    />
+    <h2
+      class="emotion-4 emotion-5"
     >
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
       >
         <span
-          class="emotion-6 emotion-7"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-8 emotion-9"
+            class="emotion-10 emotion-11"
             dir="ltr"
             id="test-section-label"
           >

--- a/packages/components/psammead-section-label/src/index.jsx
+++ b/packages/components/psammead-section-label/src/index.jsx
@@ -20,15 +20,25 @@ const Bar = styled.div`
   @media screen and (-ms-high-contrast: active) {
     border-color: windowText;
   }
+`;
+
+const DesktopBar = styled(Bar)`
+  display: none;
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    display: block;
     position: absolute;
     left: 0;
     right: 0;
 
     /* Placing bar at the vertical midpoint of the section title */
-    top: ${({ script }) =>
-      0.5 + script.doublePica.groupD.lineHeight / 2 / 16}rem;
+    top: ${({ script }) => 0.5 + script.doublePica.groupD.lineHeight / 32}rem;
+  }
+`;
+
+const MobileBar = styled(Bar)`
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    display: none;
   }
 `;
 
@@ -71,6 +81,7 @@ const Heading = styled.h2`
 
 const SectionLabel = ({
   bar,
+  mobileDivider,
   children: title,
   dir,
   href,
@@ -84,7 +95,8 @@ const SectionLabel = ({
   ...props
 }) => (
   <SectionLabelWrapper visuallyHidden={visuallyHidden} {...props}>
-    {bar && <Bar script={script} />}
+    {bar && <DesktopBar script={script} />}
+    {mobileDivider && <MobileBar />}
     <Heading as={overrideHeadingAs}>
       {linkText && href ? (
         <LinkTitle
@@ -115,6 +127,7 @@ const SectionLabel = ({
 
 SectionLabel.defaultProps = {
   bar: true,
+  mobileDivider: true,
   dir: 'ltr',
   href: null,
   linkText: null,
@@ -125,6 +138,7 @@ SectionLabel.defaultProps = {
 
 SectionLabel.propTypes = {
   bar: bool,
+  mobileDivider: bool,
   children: string.isRequired,
   dir: oneOf(['ltr', 'rtl']),
   href: string,

--- a/packages/components/psammead-section-label/src/index.stories.jsx
+++ b/packages/components/psammead-section-label/src/index.stories.jsx
@@ -25,6 +25,7 @@ storiesOf(STORY_KIND, module)
         script={script}
         dir={dir}
         bar={boolean('show bar?', true)}
+        mobileDivider={boolean('show divider on mobile?', true)}
         visuallyHidden={boolean(
           'visually hide component for all breakpoints?',
           false,
@@ -44,6 +45,7 @@ storiesOf(STORY_KIND, module)
         script={script}
         dir={dir}
         bar={boolean('show bar?', true)}
+        mobileDivider={boolean('show divider on mobile?', true)}
         visuallyHidden={boolean(
           'visually hide component for all breakpoints?',
           false,
@@ -64,6 +66,7 @@ storiesOf(STORY_KIND, module)
         script={script}
         dir={dir}
         bar={boolean('show bar?', true)}
+        mobileDivider={boolean('show divider on mobile?', true)}
         visuallyHidden={boolean(
           'visually hide component for all breakpoints?',
           false,

--- a/packages/components/psammead-section-label/src/index.test.jsx
+++ b/packages/components/psammead-section-label/src/index.test.jsx
@@ -32,6 +32,18 @@ describe('SectionLabel', () => {
       );
 
       shouldMatchSnapshot(
+        'should render correctly with mobileDivider set to false',
+        <SectionLabel
+          script={latin}
+          labelId="test-section-label"
+          mobileDivider={false}
+          service="news"
+        >
+          This is text in a SectionLabel, and there is no mobile divider
+        </SectionLabel>,
+      );
+
+      shouldMatchSnapshot(
         'should render correctly with explicit text direction',
         <SectionLabel
           script={latin}


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/9278

**Overall change:** _Allow the horizontal bar to be controlled individually for mobile and desktop._

**Code changes:**

- _Add new prop and update bar logic._

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
