### PR TITLE
Add onRender prop to Canonical social embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@bbc/psammead-rich-text-transforms": "2.0.6",
     "@bbc/psammead-script-link": "3.0.20",
     "@bbc/psammead-section-label": "7.1.0",
-    "@bbc/psammead-social-embed": "3.1.16",
+    "@bbc/psammead-social-embed": "3.2.0",
     "@bbc/psammead-story-promo": "8.0.21",
     "@bbc/psammead-story-promo-list": "6.0.19",
     "@bbc/psammead-storybook-helpers": "9.0.14",

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| 3.2.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Add onRender prop |
+| 3.2.0 | [PR#4535](https://github.com/bbc/psammead/pull/4535) Add onRender prop |
 | 3.1.16 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 3.1.15 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 3.1.13 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.2.0 | [PR#????](https://github.com/bbc/psammead/pull/????) Add onRender prop |
 | 3.1.16 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 3.1.15 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 3.1.13 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-social-embed/README.md
+++ b/packages/components/psammead-social-embed/README.md
@@ -111,6 +111,49 @@ The component supports integration with the [react-lazyload](https://www.npmjs.c
 </LazyLoad>
 ```
 
+### onRender
+This component takes an `onRender` prop which is invoked when the embed is fully rendered (currently only for twitter embeds), this can be used to change styling on render to help reduce layout shift.
+
+#### Example
+```jsx
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+
+const DEFAULT_MIN_HEIGHT = '18.75rem';
+
+const Wrapper = styled.div`
+  min-height: ${({ minHeight }) => minHeight};
+`;
+
+const SocialEmbedWithWrapper = ({
+  provider,
+  oEmbed,
+  skipLink,
+  fallback,
+  service,
+  }) => {
+
+  const [wrapperMinHeight, setWrapperMinHeight] = useState(DEFAULT_MIN_HEIGHT);
+
+  return (
+    <Wrapper minHeight={wrapperMinHeight}>
+      <CanonicalSocialEmbed
+        provider={provider}
+        oEmbed={oEmbed}
+        skipLink={skipLink}
+        fallback={fallback}
+        service={service}
+        onRender={() => {
+          setMinHeight('0');
+        }}
+      />
+    </Wrapper>
+  );
+};
+
+export default SocialEmbedWithWrapper;
+```
+
 ### AMP
 
 Pass a [supported provider](#supported-providers). If this case cannot be met, a fallback will be rendered containing a link to the source content.

--- a/packages/components/psammead-social-embed/README.md
+++ b/packages/components/psammead-social-embed/README.md
@@ -30,7 +30,7 @@ npm install @bbc/psammead-social-embed --save
 | `fallback` | Object | Yes      | n/a     | See [fallback](#fallback).                                                                                          |
 | `skipLink` | Object | Yes      | n/a     | See [skipLink](#skipLink).                                                                                          |
 | `caption`  | Object | No       | `null`  | See [caption](#caption).                                                                                            |
-
+| `onRender` | Function | No      | `null`     | `() => console.log('rendered')` |
 ### AMP
 
 | Argument   | Type   | Required | Default | Example                                          |

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.1.16",
+  "version": "3.2.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -2,6 +2,7 @@ import React, { memo, useEffect } from 'react';
 import { func, shape, string } from 'prop-types';
 import styled from '@emotion/styled';
 import useScript from './useScript';
+import fixtures from '../fixtures';
 
 const LANDSCAPE_RATIO = '56.25%';
 
@@ -77,8 +78,8 @@ const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
-    if (provider === 'twitter' && isSdkLoaded && onRender) {
-      providers.twitter.onSdkLoad(onRender);
+    if (provider === fixtures.twitter.source && isSdkLoaded && onRender) {
+      providers[fixtures.twitter.source].onSdkLoad(onRender);
     }
   }, [isSdkLoaded]);
 

--- a/packages/components/psammead-social-embed/src/Canonical/useScript.js
+++ b/packages/components/psammead-social-embed/src/Canonical/useScript.js
@@ -1,17 +1,21 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * useScript is a custom hook that appends a non-blocking script element
  * to the head if it doesn't already exist and removes it in clean-up.
  * @param {string} src The URL of the script to be appended.
  */
-const useScript = src =>
+const useScript = src => {
+  const [isLoaded, setIsLoaded] = useState(false);
   // eslint-disable-next-line consistent-return
   useEffect(() => {
     const hasScript = !!document.querySelector(`head script[src="${src}"]`);
 
     if (src && !hasScript) {
       const script = document.createElement('script');
+      script.onload = () => {
+        setIsLoaded(true);
+      };
       script.src = src;
       script.async = true;
       document.head.appendChild(script);
@@ -21,5 +25,8 @@ const useScript = src =>
       };
     }
   }, [src]);
+
+  return isLoaded;
+};
 
 export default useScript;

--- a/packages/components/psammead-social-embed/src/index.jsx
+++ b/packages/components/psammead-social-embed/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shape, string } from 'prop-types';
+import { shape, string, func } from 'prop-types';
 
 import SkipLinkWrapper from './SkipLinkWrapper';
 import CaptionWrapper from './CaptionWrapper';
@@ -19,6 +19,7 @@ export const CanonicalSocialEmbed = ({
   oEmbed,
   caption,
   fallback,
+  onRender,
 }) => {
   const isSupportedProvider = Object.keys(providers).includes(provider);
   const hasCaption = caption && caption.text;
@@ -34,10 +35,18 @@ export const CanonicalSocialEmbed = ({
     <SkipLinkWrapper service={service} provider={provider} {...skipLink}>
       {hasCaption ? (
         <CaptionWrapper service={service} {...caption}>
-          <CanonicalEmbed provider={provider} oEmbed={oEmbed} />
+          <CanonicalEmbed
+            provider={provider}
+            oEmbed={oEmbed}
+            onRender={onRender}
+          />
         </CaptionWrapper>
       ) : (
-        <CanonicalEmbed provider={provider} oEmbed={oEmbed} />
+        <CanonicalEmbed
+          provider={provider}
+          oEmbed={oEmbed}
+          onRender={onRender}
+        />
       )}
     </SkipLinkWrapper>
   );
@@ -101,6 +110,7 @@ const sharedPropTypes = {
 
 CanonicalSocialEmbed.defaultProps = {
   oEmbed: null,
+  onRender: null,
 };
 
 CanonicalSocialEmbed.propTypes = {
@@ -108,6 +118,7 @@ CanonicalSocialEmbed.propTypes = {
   oEmbed: shape({
     html: string.isRequired,
   }),
+  onRender: func,
 };
 
 AmpSocialEmbed.propTypes = {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9253

**Overall change:** Adds an `onRender` prop to the psammead-social-embed component (on canonical), which allows us to update the styling of the component while trying to keep page layout shift to a minimum.

**Code changes:**

- Bump psammead-social-embed to `3.2.0`
- Add `onRender` to CanonicalEmbed, which is bound to the twitter `'rendered'` event once the script has loaded.
- `useScript` now returns state which describes whether or not the embed script has finished loading.

---

- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
