### PR TITLE
Remove dependency on fixture for onRender prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@bbc/psammead-rich-text-transforms": "2.0.6",
     "@bbc/psammead-script-link": "3.0.20",
     "@bbc/psammead-section-label": "7.1.0",
-    "@bbc/psammead-social-embed": "3.2.0",
+    "@bbc/psammead-social-embed": "3.2.1",
     "@bbc/psammead-story-promo": "8.0.21",
     "@bbc/psammead-story-promo-list": "6.0.19",
     "@bbc/psammead-storybook-helpers": "9.0.14",

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.2.1 | [PR#4536](https://github.com/bbc/psammead/pull/4536) Remove use of fixtures for provider name |
 | 3.2.0 | [PR#4535](https://github.com/bbc/psammead/pull/4535) Add onRender prop |
 | 3.1.16 | [PR#4497](https://github.com/bbc/psammead/pull/4497) Bump psammead-styles |
 | 3.1.15 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -73,14 +73,14 @@ export const providers = {
 };
 
 const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
-  const hasLibraryLoaded = useScript(providers[provider].script);
+  const libraryHasLoaded = useScript(providers[provider].script);
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
-    if (provider === 'twitter' && hasLibraryLoaded && onRender) {
+    if (provider === 'twitter' && libraryHasLoaded && onRender) {
       providers.twitter.onLibraryLoad(onRender);
     }
-  }, [hasLibraryLoaded]);
+  }, [libraryHasLoaded]);
 
   return (
     <OEmbed

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -73,14 +73,14 @@ export const providers = {
 };
 
 const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
-  const isSdkLoaded = useScript(providers[provider].script);
+  const hasLibraryLoaded = useScript(providers[provider].script);
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
-    if (provider === 'twitter' && isSdkLoaded && onRender) {
+    if (provider === 'twitter' && hasLibraryLoaded && onRender) {
       providers.twitter.onSdkLoad(onRender);
     }
-  }, [isSdkLoaded]);
+  }, [hasLibraryLoaded]);
 
   return (
     <OEmbed

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -47,7 +47,7 @@ export const providers = {
         window.twttr.widgets.load();
       }
     },
-    onSdkLoad: onRender => {
+    onLibraryLoad: onRender => {
       window.twttr.ready(twttr => {
         twttr.events.bind('rendered', onRender);
       });
@@ -78,7 +78,7 @@ const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
 
   useEffect(() => {
     if (provider === 'twitter' && hasLibraryLoaded && onRender) {
-      providers.twitter.onSdkLoad(onRender);
+      providers.twitter.onLibraryLoad(onRender);
     }
   }, [hasLibraryLoaded]);
 

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -2,7 +2,6 @@ import React, { memo, useEffect } from 'react';
 import { func, shape, string } from 'prop-types';
 import styled from '@emotion/styled';
 import useScript from './useScript';
-import fixtures from '../fixtures';
 
 const LANDSCAPE_RATIO = '56.25%';
 
@@ -78,8 +77,8 @@ const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
-    if (provider === fixtures.twitter.source && isSdkLoaded && onRender) {
-      providers[fixtures.twitter.source].onSdkLoad(onRender);
+    if (provider === 'twitter' && isSdkLoaded && onRender) {
+      providers.twitter.onSdkLoad(onRender);
     }
   }, [isSdkLoaded]);
 

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { memo, useEffect } from 'react';
 import { func, shape, string } from 'prop-types';
 import styled from '@emotion/styled';
@@ -33,6 +34,8 @@ export const providers = {
         window.instgrm.Embeds.process();
       }
     },
+    onLibraryLoad: () =>
+      console.error('onRender callback function not implemented for Instagram'),
   },
   twitter: {
     script: 'https://platform.twitter.com/widgets.js',
@@ -69,6 +72,8 @@ export const providers = {
       }
     `,
     enrich: () => {},
+    onLibraryLoad: () =>
+      console.error('onRender callback function not implemented for YouTube'),
   },
 };
 
@@ -77,8 +82,10 @@ const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
-    if (provider === 'twitter' && libraryHasLoaded && onRender) {
-      providers.twitter.onLibraryLoad(onRender);
+    const { onLibraryLoad } = providers[provider];
+
+    if (libraryHasLoaded && onLibraryLoad) {
+      onLibraryLoad(onRender);
     }
   }, [libraryHasLoaded]);
 
@@ -99,7 +106,7 @@ CanonicalEmbed.propTypes = {
 };
 
 CanonicalEmbed.defaultProps = {
-  onRender: null,
+  onRender: () => {},
 };
 
 export default memo(CanonicalEmbed);

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -15,6 +15,9 @@ const OEmbed = styled.div`
   justify-content: center;
 `;
 
+const getOnRenderError = providerName =>
+  `onRender callback function not implemented for ${providerName}`;
+
 /**
  * The following object declares a list of supported Canonical providers
  * and their attributes. Not all providers have the same attributes.
@@ -34,8 +37,7 @@ export const providers = {
         window.instgrm.Embeds.process();
       }
     },
-    onLibraryLoad: () =>
-      console.error('onRender callback function not implemented for Instagram'),
+    onLibraryLoad: () => console.error(getOnRenderError('Instagram')),
   },
   twitter: {
     script: 'https://platform.twitter.com/widgets.js',
@@ -72,8 +74,7 @@ export const providers = {
       }
     `,
     enrich: () => {},
-    onLibraryLoad: () =>
-      console.error('onRender callback function not implemented for YouTube'),
+    onLibraryLoad: () => console.error(getOnRenderError('YouTube')),
   },
 };
 
@@ -84,7 +85,7 @@ const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
   useEffect(() => {
     const { onLibraryLoad } = providers[provider];
 
-    if (hasLoadedLibrary && onLibraryLoad) {
+    if (onRender && hasLoadedLibrary && onLibraryLoad) {
       onLibraryLoad(onRender);
     }
   }, [hasLoadedLibrary]);
@@ -106,7 +107,7 @@ CanonicalEmbed.propTypes = {
 };
 
 CanonicalEmbed.defaultProps = {
-  onRender: () => {},
+  onRender: null,
 };
 
 export default memo(CanonicalEmbed);

--- a/packages/components/psammead-social-embed/src/Canonical/index.jsx
+++ b/packages/components/psammead-social-embed/src/Canonical/index.jsx
@@ -78,16 +78,16 @@ export const providers = {
 };
 
 const CanonicalEmbed = ({ provider, oEmbed, onRender }) => {
-  const libraryHasLoaded = useScript(providers[provider].script);
+  const hasLoadedLibrary = useScript(providers[provider].script);
   useEffect(providers[provider].enrich);
 
   useEffect(() => {
     const { onLibraryLoad } = providers[provider];
 
-    if (libraryHasLoaded && onLibraryLoad) {
+    if (hasLoadedLibrary && onLibraryLoad) {
       onLibraryLoad(onRender);
     }
-  }, [libraryHasLoaded]);
+  }, [hasLoadedLibrary]);
 
   return (
     <OEmbed

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -838,6 +838,169 @@ exports[`CanonicalSocialEmbed Twitter should render correctly for Twitter 1`] = 
 </div>
 `;
 
+exports[`CanonicalSocialEmbed YouTube should render correctly for YouTube 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-2 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  background-color: #FFFFFF;
+  border: 0.125rem solid #222222;
+  color: #222222;
+  display: block;
+  left: 0;
+  line-height: 1;
+  padding: 0.75rem;
+  position: absolute;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  top: 0;
+  z-index: 10;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-2 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    font-size: 0.8125rem;
+  }
+}
+
+.emotion-2:not(:focus):not(:active) {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.emotion-4 {
+  background-color: #000000;
+  margin: 0;
+}
+
+.emotion-6 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.emotion-6>iframe {
+  border: none;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.emotion-8 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  color: #FFFFFF;
+  padding: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-8 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    font-size: 0.8125rem;
+  }
+}
+
+.emotion-8>span {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.emotion-10 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+<div
+  class="emotion-0 emotion-1"
+>
+  <a
+    class="emotion-2 emotion-3"
+    href="#skip-youtube-content"
+  >
+    Skip YouTube content
+  </a>
+  <figure
+    class="emotion-4 emotion-5"
+  >
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <iframe
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen=""
+        frameborder="0"
+        height="270"
+        src="https://www.youtube.com/embed/chiWVxreqhU?feature=oembed"
+        width="480"
+      />
+    </div>
+    <figcaption
+      class="emotion-8 emotion-9"
+    >
+      <span>
+        Video caption, 
+      </span>
+      Warning: Third party content may contain adverts
+    </figcaption>
+  </figure>
+  <p
+    class="emotion-10 emotion-11"
+    id="skip-youtube-content"
+    tabindex="-1"
+  >
+    End of YouTube content
+  </p>
+</div>
+`;
+
 exports[`CanonicalSocialEmbed should render a notice when the provider is unsupported 1`] = `
 .emotion-0 {
   position: relative;
@@ -1135,168 +1298,5 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
       End of Twitter content
     </p>
   </div>
-</div>
-`;
-
-exports[`CanonicalSocialEmbed should render correctly for YouTube 1`] = `
-.emotion-0 {
-  position: relative;
-}
-
-.emotion-2 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.875rem;
-  line-height: 1rem;
-  background-color: #FFFFFF;
-  border: 0.125rem solid #222222;
-  color: #222222;
-  display: block;
-  left: 0;
-  line-height: 1;
-  padding: 0.75rem;
-  position: absolute;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  top: 0;
-  z-index: 10;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-2 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    font-size: 0.8125rem;
-  }
-}
-
-.emotion-2:not(:focus):not(:active) {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.emotion-4 {
-  background-color: #000000;
-  margin: 0;
-}
-
-.emotion-6 {
-  padding-top: 56.25%;
-  position: relative;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-}
-
-.emotion-6>iframe {
-  border: none;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.emotion-8 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.875rem;
-  line-height: 1rem;
-  color: #FFFFFF;
-  padding: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    font-size: 0.8125rem;
-  }
-}
-
-.emotion-8>span {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.emotion-10 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-<div
-  class="emotion-0 emotion-1"
->
-  <a
-    class="emotion-2 emotion-3"
-    href="#skip-youtube-content"
-  >
-    Skip YouTube content
-  </a>
-  <figure
-    class="emotion-4 emotion-5"
-  >
-    <div
-      class="emotion-6 emotion-7"
-    >
-      <iframe
-        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen=""
-        frameborder="0"
-        height="270"
-        src="https://www.youtube.com/embed/chiWVxreqhU?feature=oembed"
-        width="480"
-      />
-    </div>
-    <figcaption
-      class="emotion-8 emotion-9"
-    >
-      <span>
-        Video caption, 
-      </span>
-      Warning: Third party content may contain adverts
-    </figcaption>
-  </figure>
-  <p
-    class="emotion-10 emotion-11"
-    id="skip-youtube-content"
-    tabindex="-1"
-  >
-    End of YouTube content
-  </p>
 </div>
 `;


### PR DESCRIPTION
**Overall change:** Allows the psammead-social-embed to correctly function when integrated into Simorgh.

**Code changes:**

- Uses a string literal for the provider name instead of referring to a fixture

---

- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
