### PR TITLE
remove aria-labelledby attribute

### DIFF
--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 7.1.5 | [PR#4558](https://github.com/bbc/psammead/pull/4558) remove aria-labelledby attribute |
 | 7.1.4 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |
 | 7.1.3 | [PR#4547](https://github.com/bbc/psammead/pull/4547) Bumps packages |
 | 7.1.2 | [PR#4545](https://github.com/bbc/psammead/pull/4545) Bump dependencies for @bbc/psammead-styles |

--- a/packages/components/psammead-section-label/README.md
+++ b/packages/components/psammead-section-label/README.md
@@ -23,7 +23,8 @@ The only provided child should be the title for the section, provided as a _stri
 | children | string | yes | N/A | `'Most Read'` |
 | dir | string | no | `'ltr'` | `'rtl'` |
 | href | string | no | `null` | `'https://www.bbc/com/igbo/egwuregwu'` |
-| labelId | string | yes | N/A | `top-stories-label` |
+| id | string | no | N/A | `top-stories-id` |
+| labelId | string | no | N/A | `top-stories-label` |
 | linkText | string | no | `null` | `'See More'` |
 | script | object | yes | N/A | { canon: { groupA: { fontSize: '28', lineHeight: '32',}, groupB: { fontSize: '32', lineHeight: '36' }, groupD: { fontSize: '44', lineHeight: '48' } }, trafalgar: { groupA: { fontSize: '20', lineHeight: '24' }, groupB: { fontSize: '24', lineHeight: '28' }, groupD: { fontSize: '32', lineHeight: '36' } } } |
 | service | string | yes | N/A | `'news'` |
@@ -126,7 +127,7 @@ const WrappingComponent = () => (
       script={latin}
       dir="ltr"
       href="https://www.bbc.com/news/index"
-      labelId="example-section-label"
+      id="example-section-label"
       linkText="See More"
       service="news"
     >

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -376,7 +376,6 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
       class="emotion-6 emotion-7"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
@@ -623,7 +622,6 @@ exports[`SectionLabel With bar With linking title should render correctly with a
       class="emotion-6 emotion-7"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
@@ -870,7 +868,6 @@ exports[`SectionLabel With bar With linking title should render correctly with e
       class="emotion-6 emotion-7"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
@@ -1117,7 +1114,6 @@ exports[`SectionLabel With bar With linking title should render correctly with e
       class="emotion-6 emotion-7"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-8 emotion-9"
         href="/igbo/other-index"
       >
@@ -2374,7 +2370,6 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-6 emotion-7"
         href="/igbo/other-index"
       >
@@ -2596,7 +2591,6 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-6 emotion-7"
         href="/igbo/other-index"
       >
@@ -2818,7 +2812,6 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="test-section-label"
         class="emotion-6 emotion-7"
         href="/igbo/other-index"
       >

--- a/packages/components/psammead-section-label/src/titles.jsx
+++ b/packages/components/psammead-section-label/src/titles.jsx
@@ -152,7 +152,7 @@ export const LinkTitle = ({
   service,
   backgroundColor,
 }) => (
-  <SectionLabelLink href={href} labelId={labelId} aria-labelledby={labelId}>
+  <SectionLabelLink href={href} labelId={labelId}>
     <FlexColumn>
       <FlexRow role="text">
         <Title


### PR DESCRIPTION
Partially resolves https://github.com/bbc/simorgh/issues/9415

**Overall change:**
Removes duplicated aria-labelledby attribute.

**Code changes:**

- removes  aria-labelledby attribute
- updates snapshots

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
