### PR TITLE
Sinhala font bold url fix

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.3.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 7.3.9 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 7.3.8 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 7.3.7 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.3.9",
+  "version": "7.3.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -23,8 +23,8 @@
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },
   "devDependencies": {
-    "@bbc/psammead-script-link": "3.0.26",
-    "@bbc/psammead-styles": "7.6.2",
+    "@bbc/psammead-script-link": "3.0.27",
+    "@bbc/psammead-styles": "7.6.3",
     "@emotion/styled": "^11.3.0",
     "react": "^17.0.2"
   },

--- a/packages/components/psammead-bulleted-list/CHANGELOG.md
+++ b/packages/components/psammead-bulleted-list/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 3.1.7 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.1.6         | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles                                                   |
 | 3.1.5         | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles                             |
 | 3.1.4         | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies                                                     |

--- a/packages/components/psammead-bulleted-list/package.json
+++ b/packages/components/psammead-bulleted-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulleted-list",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-bulleted-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.43 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 5.0.42 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 5.0.41 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 5.0.40 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.42",
+  "version": "5.0.43",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,9 +21,9 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-live-label": "2.0.27",
-    "@bbc/psammead-story-promo": "8.0.27",
-    "@bbc/psammead-styles": "7.6.2",
+    "@bbc/psammead-live-label": "2.0.28",
+    "@bbc/psammead-story-promo": "8.0.28",
+    "@bbc/psammead-styles": "7.6.3",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },
   "peerDependencies": {

--- a/packages/components/psammead-byline/CHANGELOG.md
+++ b/packages/components/psammead-byline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.0.25 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.25 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.24 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.23 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-byline/CHANGELOG.md
+++ b/packages/components/psammead-byline/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| 3.0.25 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
+| 3.0.26 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.25 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.24 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.23 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-byline/package.json
+++ b/packages/components/psammead-byline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-byline",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-byline/package.json
+++ b/packages/components/psammead-byline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-byline",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-byline/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.21 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 4.1.20 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 4.1.19 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 4.1.18 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.20",
+  "version": "4.1.21",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-caption/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-consent-banner/CHANGELOG.md
+++ b/packages/components/psammead-consent-banner/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.5.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 5.5.9 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 5.5.8 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 5.5.7 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-consent-banner/package.json
+++ b/packages/components/psammead-consent-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-consent-banner",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-consent-banner/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-content-anchor/CHANGELOG.md
+++ b/packages/components/psammead-content-anchor/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.0-alpha.27 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 2.0.0-alpha.26 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 2.0.0-alpha.25 | [PR#4561](https://github.com/bbc/psammead/pull/4561) bump dependencies |
 | 2.0.0-alpha.24 | [PR#4534](https://github.com/bbc/psammead/pull/4534) Fixes prop warnings in storybook |

--- a/packages/components/psammead-content-anchor/package.json
+++ b/packages/components/psammead-content-anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-content-anchor",
-  "version": "2.0.0-alpha.26",
+  "version": "2.0.0-alpha.27",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -28,7 +28,7 @@
     "react": ">=16.9.0"
   },
   "devDependencies": {
-    "@bbc/psammead-headings": "5.0.24",
+    "@bbc/psammead-headings": "5.0.25",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "react": "^17.0.2"

--- a/packages/components/psammead-copyright/CHANGELOG.md
+++ b/packages/components/psammead-copyright/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.26 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.25 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.24 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.23 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-copyright/package.json
+++ b/packages/components/psammead-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-copyright",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-copyright/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version        | Description                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 3.0.29 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.28 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.27 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles                                     |
 | 3.0.26 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-embed-error/package.json
+++ b/packages/components/psammead-embed-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.9 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.1.8 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.1.7 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.1.6 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-heading-index/CHANGELOG.md
+++ b/packages/components/psammead-heading-index/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.25 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.24 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.23 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.22 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-heading-index/package.json
+++ b/packages/components/psammead-heading-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-heading-index",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-heading-index/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-headings/CHANGELOG.md
+++ b/packages/components/psammead-headings/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.25 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 5.0.24 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 5.0.23 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 5.0.22 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-headings/package.json
+++ b/packages/components/psammead-headings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-headings",
-  "version": "5.0.24",
+  "version": "5.0.25",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-headings/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.4.7 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.4.6 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.4.5 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.4.4 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-inline-link/CHANGELOG.md
+++ b/packages/components/psammead-inline-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.23 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.22 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.21 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.20 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-inline-link/package.json
+++ b/packages/components/psammead-inline-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-inline-link",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "description": "React component for an Inline Link",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-inline-link/README.md",
   "dependencies": {
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.28 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 2.0.27 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 2.0.26 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles|
 | 2.0.25 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-live-label/package.json
+++ b/packages/components/psammead-live-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-live-label",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-live-label/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2",
+    "@bbc/psammead-styles": "7.6.3",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.1.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 6.1.9 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 6.1.8 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 6.1.7 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.1.9",
+  "version": "6.1.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.1.11 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 5.1.10 |[PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 5.1.9 | [PR#4561](https://github.com/bbc/psammead/pull/4561) bump dependencies |
 | 5.1.8 | [PR#4534](https://github.com/bbc/psammead/pull/4534) Fixes prop warnings in storybook |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.1.10",
+  "version": "5.1.11",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -31,8 +31,8 @@
   "dependencies": {
     "@bbc/psammead-assets": "3.1.9",
     "@bbc/psammead-image": "2.0.8",
-    "@bbc/psammead-image-placeholder": "3.4.6",
-    "@bbc/psammead-play-button": "3.0.28"
+    "@bbc/psammead-image-placeholder": "3.4.7",
+    "@bbc/psammead-play-button": "3.0.29"
   },
   "devDependencies": {
     "@emotion/styled": "^11.3.0",

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.2.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 9.2.9 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 9.2.8 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 9.2.7 | [PR#4534](https://github.com/bbc/psammead/pull/4534) Fixes prop warnings in storybook |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.2.9",
+  "version": "9.2.10",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-styles": "7.6.2",
+    "@bbc/psammead-styles": "7.6.3",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },
   "peerDependencies": {

--- a/packages/components/psammead-paragraph/CHANGELOG.md
+++ b/packages/components/psammead-paragraph/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.25 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 4.0.24 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 4.0.23 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 4.0.22 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-paragraph/package.json
+++ b/packages/components/psammead-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-paragraph",
-  "version": "4.0.24",
+  "version": "4.0.25",
   "description": "React component for a Paragraph",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-paragraph/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-play-button/CHANGELOG.md
+++ b/packages/components/psammead-play-button/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------------- | ----------- |
+| 3.0.29 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.28 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.27 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.26 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-play-button/package.json
+++ b/packages/components/psammead-play-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "description": "Provides a play button, with optional duration, for playable media.",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-podcast-promo/CHANGELOG.md
+++ b/packages/components/psammead-podcast-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 0.1.0-alpha.44 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 0.1.0-alpha.43 [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 0.1.0-alpha.42 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 0.1.0-alpha.41 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-podcast-promo/package.json
+++ b/packages/components/psammead-podcast-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-podcast-promo",
-  "version": "0.1.0-alpha.43",
+  "version": "0.1.0-alpha.44",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -21,8 +21,8 @@
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-image-placeholder": "3.4.6",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-image-placeholder": "3.4.7",
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",
@@ -38,6 +38,5 @@
   "keywords": [
     "bbc",
     "podcast"
-  ],
-  "stableVersion": "0.1.0-alpha.37"
+  ]
 }

--- a/packages/components/psammead-script-link/CHANGELOG.md
+++ b/packages/components/psammead-script-link/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.27 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.26 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.25 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.24 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-script-link/package.json
+++ b/packages/components/psammead-script-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-script-link",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-script-link/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-section-label/CHANGELOG.md
+++ b/packages/components/psammead-section-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 7.1.8 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 7.1.7 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 7.1.6 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 7.1.5 | [PR#4558](https://github.com/bbc/psammead/pull/4558) remove aria-labelledby attribute |

--- a/packages/components/psammead-section-label/package.json
+++ b/packages/components/psammead-section-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-section-label",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "React styled component for a section label",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-section-label/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.3.7 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.3.6 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.3.5 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles                     |
 | 3.3.4 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-social-embed/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.26 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 6.0.25 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 6.0.24 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 6.0.23 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "6.0.25",
+  "version": "6.0.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo-list/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.28 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 8.0.27 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 8.0.26 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 8.0.25 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.27",
+  "version": "8.0.28",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-story-promo/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.4",

--- a/packages/components/psammead-timestamp/CHANGELOG.md
+++ b/packages/components/psammead-timestamp/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.0.26 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 4.0.25 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 4.0.24 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 4.0.23 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-timestamp/package.json
+++ b/packages/components/psammead-timestamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp",
-  "version": "4.0.25",
+  "version": "4.0.26",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-timestamp/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0"

--- a/packages/components/psammead-topic-tags/CHANGELOG.md
+++ b/packages/components/psammead-topic-tags/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 1.0.7 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 1.0.6 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 1.0.5 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 1.0.4 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-topic-tags/package.json
+++ b/packages/components/psammead-topic-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-topic-tags",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-topic-tags/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.1.5",

--- a/packages/components/psammead-useful-links/CHANGELOG.md
+++ b/packages/components/psammead-useful-links/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.27 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 3.0.26 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 3.0.25 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Bump dependencies for @bbc/psammead-styles |
 | 3.0.24 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/components/psammead-useful-links/package.json
+++ b/packages/components/psammead-useful-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-useful-links",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-useful-links/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-styles": "7.6.2"
+    "@bbc/psammead-styles": "7.6.3"
   },
   "peerDependencies": {
     "@emotion/styled": "^11.0.0",

--- a/packages/containers/psammead-timestamp-container/CHANGELOG.md
+++ b/packages/containers/psammead-timestamp-container/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.37 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |
 | 5.0.36 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Bump psammead-styles |
 | 5.0.35 | [PR#4561](https://github.com/bbc/psammead/pull/4561) bump dependencies |
 | 5.0.34 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Bumps dependencies |

--- a/packages/containers/psammead-timestamp-container/package.json
+++ b/packages/containers/psammead-timestamp-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-timestamp-container",
-  "version": "5.0.36",
+  "version": "5.0.37",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "6.3.0",
-    "@bbc/psammead-timestamp": "4.0.25",
+    "@bbc/psammead-timestamp": "4.0.26",
     "moment-timezone": "^0.5.26"
   },
   "devDependencies": {

--- a/packages/utilities/psammead-styles/CHANGELOG.md
+++ b/packages/utilities/psammead-styles/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 7.6.3 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Fixes bold font URL for Noto Serif Sinhala |
 | 7.6.2 | [PR#4562](https://github.com/bbc/psammead/pull/4562) Added Grey 6 colour |
 | 7.6.1 | [PR#4561](https://github.com/bbc/psammead/pull/4561) Correct Tamil font name to Noto Sans Tamil |
 | 7.6.0 | [PR#4548](https://github.com/bbc/psammead/pull/4548) Adds Noto Serif Sinhala font |

--- a/packages/utilities/psammead-styles/package.json
+++ b/packages/utilities/psammead-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-styles",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "A collection of string constants for use in CSS, containing non-GEL styling details that are bespoke to specific BBC services and products.",
   "repository": {
     "type": "git",

--- a/packages/utilities/psammead-styles/src/__snapshots__/fonts.test.js.snap
+++ b/packages/utilities/psammead-styles/src/__snapshots__/fonts.test.js.snap
@@ -262,7 +262,7 @@ exports[`Psammead Styles - Fonts should match NOTO SERIF SINHALA BOLD base font 
     font-family: \\"Noto Serif Sinhala\\";
     font-weight: 700;
     font-style: normal;
-    src: url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/normal.woff2') format('woff2'),url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.woff') format('woff'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.eot') format('eot'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.ttf') format('ttf');
+    src: url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.woff2') format('woff2'),url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.woff') format('woff'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.eot') format('eot'), url('https://ws-downloads.test.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/bold.ttf') format('ttf');
     font-display: swap;
   }
 "
@@ -274,7 +274,7 @@ exports[`Psammead Styles - Fonts should match NOTO SERIF SINHALA BOLD with overr
     font-family: \\"Noto Serif Sinhala\\";
     font-weight: 700;
     font-style: normal;
-    src: url('https://example.com/normal.woff2') format('woff2'),url('https://example.com/bold.woff') format('woff'), url('https://example.com/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
+    src: url('https://example.com/bold.woff2') format('woff2'),url('https://example.com/bold.woff') format('woff'), url('https://example.com/bold.eot') format('eot'), url('https://example.com/bold.ttf') format('ttf');
     font-display: swap;
   }
 "

--- a/packages/utilities/psammead-styles/src/fonts.js
+++ b/packages/utilities/psammead-styles/src/fonts.js
@@ -359,7 +359,7 @@ export const F_NOTO_SERIF_SINHALA_BOLD = baseUrlOverride => `
     font-style: normal;
     src: url('${
       baseUrlOverride || baseUrlNotoSerifSinhala
-    }normal.woff2') format('woff2'),url('${
+    }bold.woff2') format('woff2'),url('${
   baseUrlOverride || baseUrlNotoSerifSinhala
 }bold.woff') format('woff'), url('${
   baseUrlOverride || baseUrlNotoSerifSinhala

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,8 +1689,8 @@ __metadata:
   resolution: "@bbc/psammead-brand@workspace:packages/components/psammead-brand"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-script-link": 3.0.26
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-script-link": 3.0.27
+    "@bbc/psammead-styles": 7.6.3
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
@@ -1705,7 +1705,7 @@ __metadata:
   resolution: "@bbc/psammead-bulleted-list@workspace:packages/components/psammead-bulleted-list"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react-dom: ^17.0.2
   peerDependencies:
@@ -1720,9 +1720,9 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-live-label": 2.0.27
-    "@bbc/psammead-story-promo": 8.0.27
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-live-label": 2.0.28
+    "@bbc/psammead-story-promo": 8.0.28
+    "@bbc/psammead-styles": 7.6.3
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
@@ -1739,7 +1739,7 @@ __metadata:
   resolution: "@bbc/psammead-byline@workspace:packages/components/psammead-byline"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1766,7 +1766,7 @@ __metadata:
   resolution: "@bbc/psammead-caption@workspace:packages/components/psammead-caption"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
@@ -1778,7 +1778,7 @@ __metadata:
   resolution: "@bbc/psammead-consent-banner@workspace:packages/components/psammead-consent-banner"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -1793,7 +1793,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-content-anchor@workspace:packages/components/psammead-content-anchor"
   dependencies:
-    "@bbc/psammead-headings": 5.0.24
+    "@bbc/psammead-headings": 5.0.25
     "@emotion/react": ^11.4.0
     "@emotion/styled": ^11.3.0
     "@juggle/resize-observer": ^2.4.0
@@ -1811,7 +1811,7 @@ __metadata:
   resolution: "@bbc/psammead-copyright@workspace:packages/components/psammead-copyright"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
@@ -1834,7 +1834,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1859,7 +1859,7 @@ __metadata:
   resolution: "@bbc/psammead-grid@workspace:packages/components/psammead-grid"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
@@ -1871,31 +1871,31 @@ __metadata:
   resolution: "@bbc/psammead-heading-index@workspace:packages/components/psammead-heading-index"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-headings@5.0.24, @bbc/psammead-headings@workspace:packages/components/psammead-headings":
+"@bbc/psammead-headings@5.0.25, @bbc/psammead-headings@workspace:packages/components/psammead-headings":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-headings@workspace:packages/components/psammead-headings"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image-placeholder@3.4.6, @bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder":
+"@bbc/psammead-image-placeholder@3.4.7, @bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder"
   dependencies:
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1925,19 +1925,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-inline-link@workspace:packages/components/psammead-inline-link"
   dependencies:
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-live-label@2.0.27, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
+"@bbc/psammead-live-label@2.0.28, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-live-label@workspace:packages/components/psammead-live-label"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
@@ -1967,7 +1967,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1982,8 +1982,8 @@ __metadata:
   dependencies:
     "@bbc/psammead-assets": 3.1.9
     "@bbc/psammead-image": 2.0.8
-    "@bbc/psammead-image-placeholder": 3.4.6
-    "@bbc/psammead-play-button": 3.0.28
+    "@bbc/psammead-image-placeholder": 3.4.7
+    "@bbc/psammead-play-button": 3.0.29
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1998,7 +1998,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
@@ -2026,20 +2026,20 @@ __metadata:
   resolution: "@bbc/psammead-paragraph@workspace:packages/components/psammead-paragraph"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-play-button@3.0.28, @bbc/psammead-play-button@workspace:packages/components/psammead-play-button":
+"@bbc/psammead-play-button@3.0.29, @bbc/psammead-play-button@workspace:packages/components/psammead-play-button":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-play-button@workspace:packages/components/psammead-play-button"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -2054,8 +2054,8 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-image-placeholder": 3.4.6
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-image-placeholder": 3.4.7
+    "@bbc/psammead-styles": 7.6.3
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
@@ -2077,12 +2077,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-script-link@3.0.26, @bbc/psammead-script-link@workspace:packages/components/psammead-script-link":
+"@bbc/psammead-script-link@3.0.27, @bbc/psammead-script-link@workspace:packages/components/psammead-script-link":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-script-link@workspace:packages/components/psammead-script-link"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -2098,7 +2098,7 @@ __metadata:
   resolution: "@bbc/psammead-section-label@workspace:packages/components/psammead-section-label"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -2114,7 +2114,7 @@ __metadata:
   resolution: "@bbc/psammead-social-embed@workspace:packages/components/psammead-social-embed"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -2128,7 +2128,7 @@ __metadata:
   resolution: "@bbc/psammead-story-promo-list@workspace:packages/components/psammead-story-promo-list"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -2139,12 +2139,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-story-promo@8.0.27, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
+"@bbc/psammead-story-promo@8.0.28, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/react": ^11.4.0
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
@@ -2166,7 +2166,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-styles@7.6.2, @bbc/psammead-styles@workspace:packages/utilities/psammead-styles":
+"@bbc/psammead-styles@7.6.3, @bbc/psammead-styles@workspace:packages/utilities/psammead-styles":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-styles@workspace:packages/utilities/psammead-styles"
   dependencies:
@@ -2192,7 +2192,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 6.3.0
     "@bbc/psammead-locales": 5.0.7
-    "@bbc/psammead-timestamp": 4.0.25
+    "@bbc/psammead-timestamp": 4.0.26
     moment: 2.24.0
     moment-timezone: ^0.5.26
     react: ^17.0.2
@@ -2202,12 +2202,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-timestamp@4.0.25, @bbc/psammead-timestamp@workspace:packages/components/psammead-timestamp":
+"@bbc/psammead-timestamp@4.0.26, @bbc/psammead-timestamp@workspace:packages/components/psammead-timestamp":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-timestamp@workspace:packages/components/psammead-timestamp"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
   peerDependencies:
     "@emotion/styled": ^11.0.0
@@ -2219,7 +2219,7 @@ __metadata:
   resolution: "@bbc/psammead-topic-tags@workspace:packages/components/psammead-topic-tags"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -2235,7 +2235,7 @@ __metadata:
   resolution: "@bbc/psammead-useful-links@workspace:packages/components/psammead-useful-links"
   dependencies:
     "@bbc/gel-foundations": 6.3.0
-    "@bbc/psammead-styles": 7.6.2
+    "@bbc/psammead-styles": 7.6.3
     "@emotion/styled": ^11.3.0
     prop-types: ^15.7.2
     react: ^17.0.2


### PR DESCRIPTION
Resolves N/A

**Overall change:** Fixes bold font typo in URL for Noto Serif Sinhala

**Code changes:**

- Replaces `normal` with `bold` in Noto Serif Sinhala font url
- Updates snapshot
- Bumps and updates change-logs for packages
---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
