### PR TITLE
 fix a11y Talkback reading nested spans incorrectly in in psammead-brand

### DIFF
--- a/.yarn/versions/bac76bec.yml
+++ b/.yarn/versions/bac76bec.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-navigation"

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.3.13 | [PR#4586](https://github.com/bbc/psammead/pull/4586) Fix a11y spans and comma bugs |
 | 7.3.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 7.3.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 7.3.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 7.3.13 | [PR#4586](https://github.com/bbc/psammead/pull/4586) Fix a11y spans and comma bugs |
+| 7.3.13 | [PR#4586](https://github.com/bbc/psammead/pull/4586) Fix TalkBack reading nested spans incorrectly |
 | 7.3.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 7.3.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 7.3.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.3.13",
+  "version": "7.3.14",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.3.12",
+  "version": "7.3.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -127,10 +127,12 @@ exports[`Brand should render correctly with link not provided 1`] = `
         <span
           lang="en-GB"
         >
+          \`$
           Default Brand Name
+          , $
+          Service
+          \`
         </span>
-        , 
-        Service
       </span>
     </div>
   </div>
@@ -285,10 +287,12 @@ exports[`Brand should render correctly with link provided 1`] = `
           <span
             lang="en-GB"
           >
+            \`$
             Default Brand Name
+            , $
+            Service
+            \`
           </span>
-          , 
-          Service
         </span>
       </a>
     </div>

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -127,11 +127,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
         <span
           lang="en-GB"
         >
-          \`$
-          Default Brand Name
-          , $
-          Service
-          \`
+          Default Brand Name, Service
         </span>
       </span>
     </div>
@@ -287,11 +283,7 @@ exports[`Brand should render correctly with link provided 1`] = `
           <span
             lang="en-GB"
           >
-            \`$
-            Default Brand Name
-            , $
-            Service
-            \`
+            Default Brand Name, Service
           </span>
         </span>
       </a>

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -128,8 +128,10 @@ exports[`Brand should render correctly with link not provided 1`] = `
         <span
           lang="en-GB"
         >
-          Default Brand Name, Service
+          Default Brand Name
         </span>
+        , 
+        Service
       </span>
     </div>
   </div>
@@ -286,8 +288,10 @@ exports[`Brand should render correctly with link provided 1`] = `
           <span
             lang="en-GB"
           >
-            Default Brand Name, Service
+            Default Brand Name
           </span>
+          , 
+          Service
         </span>
       </a>
     </div>

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -122,6 +122,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
       </svg>
       <span
         class="emotion-6 emotion-7"
+        id="BrandLink-null"
         role="text"
       >
         <span
@@ -257,6 +258,7 @@ exports[`Brand should render correctly with link provided 1`] = `
       class="emotion-2 emotion-3"
     >
       <a
+        aria-labelledby="BrandLink-null"
         class="emotion-4 emotion-5"
         href="https://www.bbc.co.uk/news"
       >
@@ -278,6 +280,7 @@ exports[`Brand should render correctly with link provided 1`] = `
         </svg>
         <span
           class="emotion-8 emotion-9"
+          id="BrandLink-null"
           role="text"
         >
           <span

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -122,17 +122,20 @@ const BrandSvg = styled.svg`
   /* stylelint-enable */
 `;
 
-const LocalisedBrandName = ({ product, serviceLocalisedName }) =>
+const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
-    <VisuallyHiddenText role="text">
-      <span lang="en-GB">{product}</span>, {serviceLocalisedName}
+    <VisuallyHiddenText role="text" id={linkId}>
+      <span lang="en-GB">
+        `${product}, ${serviceLocalisedName}`
+      </span>
     </VisuallyHiddenText>
   ) : (
     <VisuallyHiddenText>{product}</VisuallyHiddenText>
   );
 
 LocalisedBrandName.propTypes = {
+  linkId: string.isRequired,
   product: string.isRequired,
   serviceLocalisedName: string,
 };
@@ -142,6 +145,7 @@ LocalisedBrandName.defaultProps = {
 };
 
 const StyledBrand = ({
+  linkId,
   product,
   serviceLocalisedName,
   svgHeight,
@@ -169,6 +173,7 @@ const StyledBrand = ({
           {svg.group}
         </BrandSvg>
         <LocalisedBrandName
+          linkId={linkId}
           product={product}
           serviceLocalisedName={serviceLocalisedName}
         />
@@ -178,6 +183,7 @@ const StyledBrand = ({
 );
 
 const brandProps = {
+  linkId: string.isRequired,
   product: string.isRequired,
   serviceLocalisedName: string,
   maxWidth: number.isRequired,
@@ -234,6 +240,7 @@ const Brand = forwardRef((props, ref) => {
             maxWidth={maxWidth}
             minWidth={minWidth}
             id={linkId}
+            aria-labelledby={linkId}
           >
             <StyledBrand {...props} />
           </StyledLink>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -126,7 +126,7 @@ const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
     <VisuallyHiddenText role="text" id={`BrandLink-${linkId}`}>
-      <span lang="en-GB">{`${product}, ${serviceLocalisedName}`}</span>
+      <span lang="en-GB">{product}</span>, {serviceLocalisedName}
     </VisuallyHiddenText>
   ) : (
     <VisuallyHiddenText>{product}</VisuallyHiddenText>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -125,7 +125,7 @@ const BrandSvg = styled.svg`
 const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
-    <VisuallyHiddenText role="text" id={linkId}>
+    <VisuallyHiddenText role="text" id={`BrandLink-${linkId}`}>
       <span lang="en-GB">{`${product}, ${serviceLocalisedName}`}</span>
     </VisuallyHiddenText>
   ) : (
@@ -238,7 +238,7 @@ const Brand = forwardRef((props, ref) => {
             maxWidth={maxWidth}
             minWidth={minWidth}
             id={linkId}
-            aria-labelledby={linkId}
+            aria-labelledby={`BrandLink-${linkId}`}
           >
             <StyledBrand {...props} />
           </StyledLink>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -126,9 +126,7 @@ const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
     <VisuallyHiddenText role="text" id={linkId}>
-      <span lang="en-GB">
-        `${product}, ${serviceLocalisedName}`
-      </span>
+      <span lang="en-GB">{`${product}, ${serviceLocalisedName}`}</span>
     </VisuallyHiddenText>
   ) : (
     <VisuallyHiddenText>{product}</VisuallyHiddenText>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -124,6 +124,7 @@ const BrandSvg = styled.svg`
 
 const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
+    // id={`BrandLink-${linkId}` is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
     // eslint-disable-next-line jsx-a11y/aria-role
     <VisuallyHiddenText role="text" id={`BrandLink-${linkId}`}>
       <span lang="en-GB">{`${product}, `}</span>
@@ -239,6 +240,7 @@ const Brand = forwardRef((props, ref) => {
             maxWidth={maxWidth}
             minWidth={minWidth}
             id={linkId}
+            // This is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
             aria-labelledby={`BrandLink-${linkId}`}
           >
             <StyledBrand {...props} />


### PR DESCRIPTION
Resolves [#9561](https://github.com/bbc/simorgh/issues/9561)

**Overall change:**

fix a11y Talkback reading nested spans incorrectly in psammead-brand

**Code changes:**

-concatenate span content 
- Added aria-labelledby to brand Link
- Added id to parent span with role="text"

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
