### PR TITLE
fix a11y Talkback reading nested spans incorrectly in psammead navigation

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 9.2.13 | [PR#4587](https://github.com/bbc/psammead/pull/4587) Fix a11y spans and comma bugs |
+| 9.2.13 | [PR#4587](https://github.com/bbc/psammead/pull/4587) Fix TalkBack reading nested spans incorrectly |
 | 9.2.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 9.2.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 9.2.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.2.13 | [PR#4587](https://github.com/bbc/psammead/pull/4587) Fix a11y spans and comma bugs |
 | 9.2.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 9.2.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 9.2.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.2.12",
+  "version": "9.2.13",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.2.13",
+  "version": "9.2.14",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -210,19 +210,21 @@ exports[`Navigation should render correctly 1`] = `
           role="listitem"
         >
           <a
+            aria-labelledby="NavigationLinks-Akụkọ"
             class="emotion-8 emotion-9"
             data-navigation="test_navigation"
             href="/igbo"
           >
             <span
               class="emotion-10 emotion-11"
+              id="NavigationLinks-Akụkọ"
               role="text"
             >
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page,
+                 
               </span>
               Akụkọ
             </span>
@@ -489,19 +491,21 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
           role="listitem"
         >
           <a
+            aria-labelledby="NavigationLinks-Akụkọ"
             class="emotion-8 emotion-9"
             data-navigation="test_navigation"
             href="/igbo"
           >
             <span
               class="emotion-10 emotion-11"
+              id="NavigationLinks-Akụkọ"
               role="text"
             >
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page,
+                 
               </span>
               Akụkọ
             </span>
@@ -762,19 +766,21 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
           role="listitem"
         >
           <a
+            aria-labelledby="NavigationLinks-Akụkọ"
             class="emotion-8 emotion-9"
             data-navigation="test_navigation"
             href="/igbo"
           >
             <span
               class="emotion-10 emotion-11"
+              id="NavigationLinks-Akụkọ"
               role="text"
             >
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page,
+                 
               </span>
               Akụkọ
             </span>
@@ -1079,19 +1085,21 @@ exports[`Scrollable Navigation should render correctly 1`] = `
             role="listitem"
           >
             <a
+              aria-labelledby="NavigationLinks-Akụkọ"
               class="emotion-10 emotion-11"
               data-navigation="test_navigation"
               href="/igbo"
             >
               <span
                 class="emotion-12 emotion-13"
+                id="NavigationLinks-Akụkọ"
                 role="text"
               >
                 <span
                   class="emotion-14 emotion-15"
                 >
-                  Current page
-                  , 
+                  Current page,
+                   
                 </span>
                 Akụkọ
               </span>

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -223,8 +223,8 @@ exports[`Navigation should render correctly 1`] = `
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page,
-                 
+                Current page
+                , 
               </span>
               Akụkọ
             </span>
@@ -504,8 +504,8 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page,
-                 
+                Current page
+                , 
               </span>
               Akụkọ
             </span>
@@ -779,8 +779,8 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page,
-                 
+                Current page
+                , 
               </span>
               Akụkọ
             </span>
@@ -1098,8 +1098,8 @@ exports[`Scrollable Navigation should render correctly 1`] = `
                 <span
                   class="emotion-14 emotion-15"
                 >
-                  Current page,
-                   
+                  Current page
+                  , 
                 </span>
                 Akụkọ
               </span>

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -128,6 +128,7 @@ const CurrentLink = ({
       role="text"
       script={script}
       brandHighlightColour={brandHighlightColour}
+      // This is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
       id={`NavigationLinks-${linkId}`}
     >
       <VisuallyHiddenText>{`${currentPageText}, `}</VisuallyHiddenText>
@@ -187,6 +188,7 @@ export const NavigationLi = ({
           currentLink
           brandForegroundColour={brandForegroundColour}
           brandHighlightColour={brandHighlightColour}
+          // This is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
           aria-labelledby={`NavigationLinks-${link}`}
           {...props}
         >

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -116,6 +116,7 @@ const StyledSpan = styled.span`
 `;
 
 const CurrentLink = ({
+  linkId,
   children: link,
   script,
   currentPageText,
@@ -127,14 +128,16 @@ const CurrentLink = ({
       role="text"
       script={script}
       brandHighlightColour={brandHighlightColour}
+      id={`NavigationLinks-${linkId}`}
     >
-      <VisuallyHiddenText>{currentPageText}, </VisuallyHiddenText>
+      <VisuallyHiddenText>{`${currentPageText},`} </VisuallyHiddenText>
       {link}
     </StyledSpan>
   </>
 );
 
 CurrentLink.propTypes = {
+  linkId: string.isRequired,
   children: string.isRequired,
   script: shape(scriptPropType).isRequired,
   currentPageText: string,
@@ -184,9 +187,11 @@ export const NavigationLi = ({
           currentLink
           brandForegroundColour={brandForegroundColour}
           brandHighlightColour={brandHighlightColour}
+          aria-labelledby={`NavigationLinks-${link}`}
           {...props}
         >
           <CurrentLink
+            linkId={link}
             script={script}
             currentPageText={currentPageText}
             brandHighlightColour={brandHighlightColour}

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -130,7 +130,7 @@ const CurrentLink = ({
       brandHighlightColour={brandHighlightColour}
       id={`NavigationLinks-${linkId}`}
     >
-      <VisuallyHiddenText>{`${currentPageText},`} </VisuallyHiddenText>
+      <VisuallyHiddenText>{currentPageText}, </VisuallyHiddenText>
       {link}
     </StyledSpan>
   </>


### PR DESCRIPTION
Resolves [#9561](https://github.com/bbc/simorgh/issues/9561)

**Overall change:** 
fix a11y Talkback nested spans bug in psammead navigation

**Code changes:**

- Added aria-labelledby attribute to navigation link
- Added id to parent span nested in link

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
