### PR TITLE
fix comma bug in psammead-brand

### DIFF
--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.3.13 | [PR#4589](https://github.com/bbc/psammead/pull/4589) Fix comma bug in TalkBack |
 | 7.3.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 7.3.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 7.3.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.3.12",
+  "version": "7.3.13",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -127,10 +127,11 @@ exports[`Brand should render correctly with link not provided 1`] = `
         <span
           lang="en-GB"
         >
-          Default Brand Name
+          Default Brand Name, 
         </span>
-        , 
-        Service
+        <span>
+          Service
+        </span>
       </span>
     </div>
   </div>
@@ -285,10 +286,11 @@ exports[`Brand should render correctly with link provided 1`] = `
           <span
             lang="en-GB"
           >
-            Default Brand Name
+            Default Brand Name, 
           </span>
-          , 
-          Service
+          <span>
+            Service
+          </span>
         </span>
       </a>
     </div>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -126,7 +126,8 @@ const LocalisedBrandName = ({ product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
     <VisuallyHiddenText role="text">
-      <span lang="en-GB">{product}</span>, {serviceLocalisedName}
+      <span lang="en-GB">{$`{product}, `}</span>
+      <span>{serviceLocalisedName}</span>
     </VisuallyHiddenText>
   ) : (
     <VisuallyHiddenText>{product}</VisuallyHiddenText>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -126,7 +126,7 @@ const LocalisedBrandName = ({ product, serviceLocalisedName }) =>
   serviceLocalisedName ? (
     // eslint-disable-next-line jsx-a11y/aria-role
     <VisuallyHiddenText role="text">
-      <span lang="en-GB">{$`{product}, `}</span>
+      <span lang="en-GB">{`${product}, `}</span>
       <span>{serviceLocalisedName}</span>
     </VisuallyHiddenText>
   ) : (


### PR DESCRIPTION
Resolves [#9616](https://github.com/bbc/simorgh/issues/9616)

Concatenated comma to the text.

**Code changes:**

- Concatenate the comma to the pre existing span
- Created a new span element for the text inside the visually hidden text

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
