### PR TITLE
fix a11y comma bug in psammead-navigation

### DIFF
--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.2.13 | [PR#4590](https://github.com/bbc/psammead/pull/4590) Fix talkback comma bug |
 | 9.2.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 9.2.11 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 9.2.10 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.2.12",
+  "version": "9.2.13",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -221,8 +221,7 @@ exports[`Navigation should render correctly 1`] = `
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page, 
               </span>
               Akụkọ
             </span>
@@ -500,8 +499,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page, 
               </span>
               Akụkọ
             </span>
@@ -773,8 +771,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
               <span
                 class="emotion-12 emotion-13"
               >
-                Current page
-                , 
+                Current page, 
               </span>
               Akụkọ
             </span>
@@ -1090,8 +1087,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
                 <span
                   class="emotion-14 emotion-15"
                 >
-                  Current page
-                  , 
+                  Current page, 
                 </span>
                 Akụkọ
               </span>

--- a/packages/components/psammead-navigation/src/index.jsx
+++ b/packages/components/psammead-navigation/src/index.jsx
@@ -128,7 +128,7 @@ const CurrentLink = ({
       script={script}
       brandHighlightColour={brandHighlightColour}
     >
-      <VisuallyHiddenText>{currentPageText}, </VisuallyHiddenText>
+      <VisuallyHiddenText>{`${currentPageText}, `}</VisuallyHiddenText>
       {link}
     </StyledSpan>
   </>


### PR DESCRIPTION
Resolves [#9561](https://github.com/bbc/simorgh/issues/9616)

Concatenated comma to the text.

**Code changes:**
- As Above

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
