### PR TITLE
fix a11y Talkback reading nested spans incorrectly in live-labels

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.47 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Bumps dependencies |
 | 5.0.46 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Bumps dependencies |
 | 5.0.45 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 5.0.44 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.46",
+  "version": "5.0.47",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-live-label": "2.0.30",
+    "@bbc/psammead-live-label": "2.0.31",
     "@bbc/psammead-story-promo": "8.0.31",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.0.31 | [PR#4587](https://github.com/bbc/psammead/pull/4587) Fix TalkBack reading nested spans incorrectly |
+| 2.0.31 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Fix TalkBack reading nested spans incorrectly |
 | 2.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 2.0.29 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 2.0.28 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.31 | [PR#4587](https://github.com/bbc/psammead/pull/4587) Fix TalkBack reading nested spans incorrectly |
 | 2.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 2.0.29 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 2.0.28 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-live-label/package.json
+++ b/packages/components/psammead-live-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-live-label",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-live-label/src/index.jsx
+++ b/packages/components/psammead-live-label/src/index.jsx
@@ -26,8 +26,8 @@ const LiveLabel = ({
   children,
   id,
 }) => (
-  // eslint-disable-next-line jsx-a11y/aria-role
   // lines 27, 56,66, 31 concerning with id are a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
+  // eslint-disable-next-line jsx-a11y/aria-role
   <span role="text" id={id}>
     <StyledSpan
       service={service}

--- a/packages/components/psammead-live-label/src/index.jsx
+++ b/packages/components/psammead-live-label/src/index.jsx
@@ -24,9 +24,11 @@ const LiveLabel = ({
   offScreenText,
   lang,
   children,
+  id,
 }) => (
   // eslint-disable-next-line jsx-a11y/aria-role
-  <span role="text">
+  // lines 27, 56,66, 31 concerning with id are a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
+  <span role="text" id={id}>
     <StyledSpan
       service={service}
       dir={dir}
@@ -51,6 +53,7 @@ LiveLabel.propTypes = {
   offScreenText: string,
   lang: string,
   children: node,
+  id: string,
 };
 
 LiveLabel.defaultProps = {
@@ -60,6 +63,7 @@ LiveLabel.defaultProps = {
   offScreenText: null,
   lang: 'en-GB',
   children: null,
+  id: null,
 };
 
 export default LiveLabel;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,7 +1692,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-live-label": 2.0.30
+    "@bbc/psammead-live-label": 2.0.31
     "@bbc/psammead-story-promo": 8.0.31
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
@@ -1904,7 +1904,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-live-label@2.0.30, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
+"@bbc/psammead-live-label@2.0.31, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-live-label@workspace:packages/components/psammead-live-label"
   dependencies:


### PR DESCRIPTION
Resolves  [#9561](https://github.com/bbc/simorgh/issues/9561)

This has to be merged first to solve the issues from this [PR](https://github.com/bbc/simorgh/pull/9598)
**Code changes:**

- added id to props and passed to parent span

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
