### PR TITLE
Bump psammead-live-label to solve merge to Simorgh issue

### DIFF
--- a/.yarn/versions/dd6154a6.yml
+++ b/.yarn/versions/dd6154a6.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-live-label"

--- a/.yarn/versions/dd6154a6.yml
+++ b/.yarn/versions/dd6154a6.yml
@@ -1,3 +1,0 @@
-undecided:
-  - "@bbc/psammead"
-  - "@bbc/psammead-live-label"

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |
 | 5.0.47 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Bumps dependencies |
 | 5.0.46 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.9",
-    "@bbc/psammead-live-label": "2.0.31",
+    "@bbc/psammead-live-label": "2.0.32",
     "@bbc/psammead-story-promo": "8.0.32",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.48",
+  "version": "5.0.49",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 2.0.32 | [PR#](https://github.com/bbc/psammead/pull/) Bump to solve deploying issue|
+| 2.0.32 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bump to solve deploying issue|
 | 2.0.31 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Fix TalkBack reading nested spans incorrectly |
 | 2.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 2.0.29 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-live-label/CHANGELOG.md
+++ b/packages/components/psammead-live-label/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 2.0.32 | [PR#](https://github.com/bbc/psammead/pull/) Bump to solve deploying issue|
 | 2.0.31 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Fix TalkBack reading nested spans incorrectly |
 | 2.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 2.0.29 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-live-label/package.json
+++ b/packages/components/psammead-live-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-live-label",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,7 +1692,7 @@ __metadata:
   dependencies:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.9
-    "@bbc/psammead-live-label": 2.0.31
+    "@bbc/psammead-live-label": 2.0.32
     "@bbc/psammead-story-promo": 8.0.32
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
@@ -1904,7 +1904,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-live-label@2.0.31, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
+"@bbc/psammead-live-label@2.0.32, @bbc/psammead-live-label@workspace:packages/components/psammead-live-label":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-live-label@workspace:packages/components/psammead-live-label"
   dependencies:


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/pull/9677

I am trying to push Renovate PR into simorgh. For some reasons the psammead-live-label cannot be found due to a 404 error.

<img width="1792" alt="screenshot_2021-11-16_at_12 04 00" src="https://user-images.githubusercontent.com/90621252/142008979-fe41548d-0e6f-4f8f-a625-3cc1568c2b14.png">

When I try to run yarn on Visual studio I get the same error:
<img width="903" alt="screenshot_2021-11-16_at_09 58 46" src="https://user-images.githubusercontent.com/90621252/142009165-ab550167-b217-4491-94fe-2f78298cf95a.png">

I already tried to re-run the following workflow to correctly upload to npm, but that seemed not to help at all.
Workflow before re-run: https://github.com/bbc/psammead/runs/4213883216?check_suite_focus=true
New Workflow run: https://github.com/bbc/psammead/runs/4224879029?check_suite_focus=true

**Code changes:**

- Bumped psammead-live-label

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
