### PR TITLE
added missing id to Psammead-brand

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
- "singleQuote": true,
- "trailingComma": "all",
- "arrowParens": "avoid"
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }

--- a/packages/components/psammead-brand/CHANGELOG.md
+++ b/packages/components/psammead-brand/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 7.3.15 | [PR#4598](https://github.com/bbc/psammead/pull/4598) Fix missing ID to fix lighthouse failure in Simorgh |
 | 7.3.14 | [PR#4586](https://github.com/bbc/psammead/pull/4586) Fix TalkBack reading nested spans incorrectly |
 | 7.3.13 | [PR#4589](https://github.com/bbc/psammead/pull/4589) Fix comma bug in TalkBack |
 | 7.3.12 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |

--- a/packages/components/psammead-brand/package.json
+++ b/packages/components/psammead-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-brand",
-  "version": "7.3.14",
+  "version": "7.3.15",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -423,6 +423,7 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
       </svg>
       <span
         class="emotion-6 emotion-7"
+        id="BrandLink-null"
       >
         BBC News
       </span>
@@ -555,6 +556,7 @@ exports[`Brand should render correctly with transparent borders 1`] = `
       </svg>
       <span
         class="emotion-6 emotion-7"
+        id="BrandLink-null"
       >
         BBC News
       </span>

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -131,7 +131,7 @@ const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
       <span>{serviceLocalisedName}</span>
     </VisuallyHiddenText>
   ) : (
-    <VisuallyHiddenText>{product}</VisuallyHiddenText>
+    <VisuallyHiddenText id={`BrandLink-${linkId}`}>{product}</VisuallyHiddenText>
   );
 
 LocalisedBrandName.propTypes = {

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -122,19 +122,19 @@ const BrandSvg = styled.svg`
   /* stylelint-enable */
 `;
 
-const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
-  serviceLocalisedName ? (
+const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) => {
+  const brandId = `BrandLink-${linkId}`;
+  return serviceLocalisedName ? (
     // id={`BrandLink-${linkId}` is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
     // eslint-disable-next-line jsx-a11y/aria-role
-    <VisuallyHiddenText role="text" id={`BrandLink-${linkId}`}>
+    <VisuallyHiddenText role="text" id={brandId}>
       <span lang="en-GB">{`${product}, `}</span>
       <span>{serviceLocalisedName}</span>
     </VisuallyHiddenText>
   ) : (
-    <VisuallyHiddenText id={`BrandLink-${linkId}`}>
-      {product}
-    </VisuallyHiddenText>
+    <VisuallyHiddenText id={brandId}>{product}</VisuallyHiddenText>
   );
+};
 
 LocalisedBrandName.propTypes = {
   linkId: string.isRequired,

--- a/packages/components/psammead-brand/src/index.jsx
+++ b/packages/components/psammead-brand/src/index.jsx
@@ -131,7 +131,9 @@ const LocalisedBrandName = ({ linkId, product, serviceLocalisedName }) =>
       <span>{serviceLocalisedName}</span>
     </VisuallyHiddenText>
   ) : (
-    <VisuallyHiddenText id={`BrandLink-${linkId}`}>{product}</VisuallyHiddenText>
+    <VisuallyHiddenText id={`BrandLink-${linkId}`}>
+      {product}
+    </VisuallyHiddenText>
   );
 
 LocalisedBrandName.propTypes = {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/pull/9677

Fix lighthouse issue by adding an id for the aria-labelled by to refer to.


<img width="1282" alt="Screenshot 2021-11-17 at 11 09 46" src="https://user-images.githubusercontent.com/90621252/142189771-4e146090-0ca2-48bf-ad88-76b2d3d41890.png">

**Code changes:**

- Added id to span

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
