### PR TITLE
Remove special characters from Story Promo - IndexAlsos aria-labels

### DIFF
--- a/.yarn/versions/a84b9864.yml
+++ b/.yarn/versions/a84b9864.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-story-promo"

--- a/.yarn/versions/a84b9864.yml
+++ b/.yarn/versions/a84b9864.yml
@@ -1,3 +1,0 @@
-undecided:
-  - "@bbc/psammead"
-  - "@bbc/psammead-story-promo"

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.50 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
+| 5.0.50 | [PR#4597](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |
 | 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |
 | 5.0.47 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Bumps dependencies |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.50 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |
 | 5.0.47 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Bumps dependencies |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.50 | [PR#4597](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |
+| 5.0.50 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |
 | 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |
 | 5.0.47 | [PR#4591](https://github.com/bbc/psammead/pull/4591) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.49",
+  "version": "5.0.50",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.9",
     "@bbc/psammead-live-label": "2.0.32",
-    "@bbc/psammead-story-promo": "8.0.32",
+    "@bbc/psammead-story-promo": "8.0.33",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.33 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Use 'children' value instead of 'URL' for aria-labelledby |
 | 8.0.32 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Fix TalkBack reading nested spans incorrectly |
 | 8.0.31 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Fix Firefox underline rendering bug |
 | 8.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 8.0.33 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Use 'children' value instead of 'URL' for aria-labelledby |
+| 8.0.33 | [PR#4588](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |
 | 8.0.32 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Fix TalkBack reading nested spans incorrectly |
 | 8.0.31 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Fix Firefox underline rendering bug |
 | 8.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
-| 8.0.33 | [PR#4588](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |
+| 8.0.33 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |
 | 8.0.32 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Fix TalkBack reading nested spans incorrectly |
 | 8.0.31 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Fix Firefox underline rendering bug |
 | 8.0.30 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.32",
+  "version": "8.0.33",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -135,7 +135,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
+          aria-labelledby="IndexAlsosLink-hausalabarai48916590"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-48916590"
         >
@@ -163,7 +163,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
             </div>
           </div>
           <span
-            id="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
+            id="IndexAlsosLink-hausalabarai48916590"
             role="text"
           >
             <span
@@ -182,7 +182,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-Yaushe Obasanjo ya fara yi wa shugabannin kasa baki?"
+          aria-labelledby="IndexAlsosLink-hausalabarai42837051"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-42837051"
         >
@@ -320,7 +320,7 @@ exports[`Index Alsos should render one correctly 1`] = `
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
+        aria-labelledby="IndexAlsosLink-hausalabarai48916590"
         class="emotion-6 emotion-7"
         href="/hausa/labarai-48916590"
       >
@@ -348,7 +348,7 @@ exports[`Index Alsos should render one correctly 1`] = `
           </div>
         </div>
         <span
-          id="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
+          id="IndexAlsosLink-hausalabarai48916590"
           role="text"
         >
           <span

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -135,7 +135,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-/hausa/labarai-48916590"
+          aria-labelledby="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-48916590"
         >
@@ -163,7 +163,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
             </div>
           </div>
           <span
-            id="IndexAlsosLink-/hausa/labarai-48916590"
+            id="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
             role="text"
           >
             <span
@@ -182,7 +182,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-/hausa/labarai-42837051"
+          aria-labelledby="IndexAlsosLink-Yaushe Obasanjo ya fara yi wa shugabannin kasa baki?"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-42837051"
         >
@@ -320,7 +320,7 @@ exports[`Index Alsos should render one correctly 1`] = `
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="IndexAlsosLink-/hausa/labarai-48916590"
+        aria-labelledby="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
         class="emotion-6 emotion-7"
         href="/hausa/labarai-48916590"
       >
@@ -348,7 +348,7 @@ exports[`Index Alsos should render one correctly 1`] = `
           </div>
         </div>
         <span
-          id="IndexAlsosLink-/hausa/labarai-48916590"
+          id="IndexAlsosLink-APC ba ta isa ta kore ni ba – Buba Galadima"
           role="text"
         >
           <span

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -61,7 +61,7 @@ const IndexAlsosLink = ({
       href={url}
       script={script}
       service={service}
-      // Line 63 and id={`IndexAlsosLink-${children}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
+      // Line 63 and id={`IndexAlsosLink-${sanitisedUrl}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
       aria-labelledby={`IndexAlsosLink-${sanitisedUrl}`}
     >
       {mediaIndicator ? (

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -54,18 +54,20 @@ const IndexAlsosLink = ({
   mediaIndicator,
   mediaType,
 }) => {
+  const sanitisedUrl = url.replace(/\W/g, '');
+
   return (
     <StyledIndexAlsosLink
       href={url}
       script={script}
       service={service}
       // Line 63 and id={`IndexAlsosLink-${children}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
-      aria-labelledby={`IndexAlsosLink-${children}`}
+      aria-labelledby={`IndexAlsosLink-${sanitisedUrl}`}
     >
       {mediaIndicator ? (
         <>
           {mediaIndicator}
-          <span role="text" id={`IndexAlsosLink-${children}`}>
+          <span role="text" id={`IndexAlsosLink-${sanitisedUrl}`}>
             <VisuallyHiddenText>{`${mediaType}, `}</VisuallyHiddenText>
             <span>{children}</span>
           </span>

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -59,13 +59,13 @@ const IndexAlsosLink = ({
       href={url}
       script={script}
       service={service}
-      // Line 63 and id={`IndexAlsosLink-${url}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
-      aria-labelledby={`IndexAlsosLink-${url}`}
+      // Line 63 and id={`IndexAlsosLink-${children}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
+      aria-labelledby={`IndexAlsosLink-${children}`}
     >
       {mediaIndicator ? (
         <>
           {mediaIndicator}
-          <span role="text" id={`IndexAlsosLink-${url}`}>
+          <span role="text" id={`IndexAlsosLink-${children}`}>
             <VisuallyHiddenText>{`${mediaType}, `}</VisuallyHiddenText>
             <span>{children}</span>
           </span>

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1521,7 +1521,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
             role="listitem"
           >
             <a
-              aria-labelledby="IndexAlsosLink-/hausa/labarai-48916590"
+              aria-labelledby="IndexAlsosLink-hausalabarai48916590"
               class="emotion-22 emotion-23"
               href="/hausa/labarai-48916590"
             >
@@ -1549,7 +1549,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
                 </div>
               </div>
               <span
-                id="IndexAlsosLink-/hausa/labarai-48916590"
+                id="IndexAlsosLink-hausalabarai48916590"
                 role="text"
               >
                 <span
@@ -1568,7 +1568,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
             role="listitem"
           >
             <a
-              aria-labelledby="IndexAlsosLink-/hausa/labarai-42837051"
+              aria-labelledby="IndexAlsosLink-hausalabarai42837051"
               class="emotion-22 emotion-23"
               href="/hausa/labarai-42837051"
             >
@@ -1934,7 +1934,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
           class="emotion-18 emotion-19"
         >
           <a
-            aria-labelledby="IndexAlsosLink-/hausa/labarai-48916590"
+            aria-labelledby="IndexAlsosLink-hausalabarai48916590"
             class="emotion-20 emotion-21"
             href="/hausa/labarai-48916590"
           >
@@ -1962,7 +1962,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
               </div>
             </div>
             <span
-              id="IndexAlsosLink-/hausa/labarai-48916590"
+              id="IndexAlsosLink-hausalabarai48916590"
               role="text"
             >
               <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.9
     "@bbc/psammead-live-label": 2.0.32
-    "@bbc/psammead-story-promo": 8.0.32
+    "@bbc/psammead-story-promo": 8.0.33
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
@@ -2092,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-story-promo@8.0.32, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
+"@bbc/psammead-story-promo@8.0.33, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo"
   dependencies:


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9696

**Overall change:**

Removes special characters from IndexAlsos aria-labels as IDs cannot contain them.

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
