### PR TITLE
Conditional aria-labelledby for StoryPromo - IndexAlsos

### DIFF
--- a/.yarn/versions/c2b81b81.yml
+++ b/.yarn/versions/c2b81b81.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-bulletin"

--- a/.yarn/versions/c2b81b81.yml
+++ b/.yarn/versions/c2b81b81.yml
@@ -1,3 +1,0 @@
-undecided:
-  - "@bbc/psammead"
-  - "@bbc/psammead-bulletin"

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.50 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Bumps dependencies |
 | 5.0.50 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |
 | 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.50 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Bumps dependencies |
+| 5.0.51 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Bumps dependencies |
 | 5.0.50 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |
 | 5.0.49 | [PR#4597](https://github.com/bbc/psammead/pull/4597) Bumps dependencies |
 | 5.0.48 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.50",
+  "version": "5.0.51",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.9",
     "@bbc/psammead-live-label": "2.0.32",
-    "@bbc/psammead-story-promo": "8.0.33",
+    "@bbc/psammead-story-promo": "8.0.34",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.34 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Conditionally add aria-labelledby attribute |
 | 8.0.33 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |
 | 8.0.32 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Fix TalkBack reading nested spans incorrectly |
 | 8.0.31 | [PR#4578](https://github.com/bbc/psammead/pull/4578) Fix Firefox underline rendering bug |

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.33",
+  "version": "8.0.34",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -135,6 +135,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
+          aria-labelledby="IndexAlsosLink-hausalabarai48916590"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-48916590"
         >
@@ -318,6 +319,7 @@ exports[`Index Alsos should render one correctly 1`] = `
       class="emotion-4 emotion-5"
     >
       <a
+        aria-labelledby="IndexAlsosLink-hausalabarai48916590"
         class="emotion-6 emotion-7"
         href="/hausa/labarai-48916590"
       >

--- a/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -135,7 +135,6 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-hausalabarai48916590"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-48916590"
         >
@@ -182,7 +181,6 @@ exports[`Index Alsos should render multiple correctly 1`] = `
         role="listitem"
       >
         <a
-          aria-labelledby="IndexAlsosLink-hausalabarai42837051"
           class="emotion-8 emotion-9"
           href="/hausa/labarai-42837051"
         >
@@ -320,7 +318,6 @@ exports[`Index Alsos should render one correctly 1`] = `
       class="emotion-4 emotion-5"
     >
       <a
-        aria-labelledby="IndexAlsosLink-hausalabarai48916590"
         class="emotion-6 emotion-7"
         href="/hausa/labarai-48916590"
       >

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -62,7 +62,9 @@ const IndexAlsosLink = ({
       script={script}
       service={service}
       // Line 63 and id={`IndexAlsosLink-${sanitisedUrl}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
-      aria-labelledby={`IndexAlsosLink-${sanitisedUrl}`}
+      {...(mediaIndicator && {
+        ariaLabelledby: `IndexAlsosLink-${sanitisedUrl}`,
+      })}
     >
       {mediaIndicator ? (
         <>

--- a/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
+++ b/packages/components/psammead-story-promo/src/IndexAlsos/index.jsx
@@ -63,7 +63,7 @@ const IndexAlsosLink = ({
       service={service}
       // Line 63 and id={`IndexAlsosLink-${sanitisedUrl}`} in line 68 are temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
       {...(mediaIndicator && {
-        ariaLabelledby: `IndexAlsosLink-${sanitisedUrl}`,
+        'aria-labelledby': `IndexAlsosLink-${sanitisedUrl}`,
       })}
     >
       {mediaIndicator ? (

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1521,6 +1521,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
             role="listitem"
           >
             <a
+              aria-labelledby="IndexAlsosLink-hausalabarai48916590"
               class="emotion-22 emotion-23"
               href="/hausa/labarai-48916590"
             >
@@ -1932,6 +1933,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
           class="emotion-18 emotion-19"
         >
           <a
+            aria-labelledby="IndexAlsosLink-hausalabarai48916590"
             class="emotion-20 emotion-21"
             href="/hausa/labarai-48916590"
           >

--- a/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1521,7 +1521,6 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
             role="listitem"
           >
             <a
-              aria-labelledby="IndexAlsosLink-hausalabarai48916590"
               class="emotion-22 emotion-23"
               href="/hausa/labarai-48916590"
             >
@@ -1568,7 +1567,6 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
             role="listitem"
           >
             <a
-              aria-labelledby="IndexAlsosLink-hausalabarai42837051"
               class="emotion-22 emotion-23"
               href="/hausa/labarai-42837051"
             >
@@ -1934,7 +1932,6 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
           class="emotion-18 emotion-19"
         >
           <a
-            aria-labelledby="IndexAlsosLink-hausalabarai48916590"
             class="emotion-20 emotion-21"
             href="/hausa/labarai-48916590"
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.9
     "@bbc/psammead-live-label": 2.0.32
-    "@bbc/psammead-story-promo": 8.0.33
+    "@bbc/psammead-story-promo": 8.0.34
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
@@ -2092,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-story-promo@8.0.33, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
+"@bbc/psammead-story-promo@8.0.34, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo"
   dependencies:


### PR DESCRIPTION
Related to [#9696](https://github.com/bbc/simorgh/issues/9696)

**Overall change:**

Conditionally applies the `aria-labelledby` attribute if the `mediaIndicator` value is set

With mediaIndicator value present:
<img width="2015" alt="Screenshot 2021-11-25 at 16 26 02" src="https://user-images.githubusercontent.com/11633031/143476587-b4c3253e-8b8c-4270-90e6-c6b5c6da4f6d.png">

Without mediaIndicator value present, still trying to link elements:
<img width="2017" alt="Screenshot 2021-11-25 at 16 26 14" src="https://user-images.githubusercontent.com/11633031/143476621-198e9ee8-bc33-4568-8af9-5b3ed6e09e03.png">

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
