### PR TITLE
Social embed fix for when no ID is provided

### DIFF
--- a/packages/components/psammead-social-embed/CHANGELOG.md
+++ b/packages/components/psammead-social-embed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 3.3.10 | [PR#4605](https://github.com/bbc/psammead/pull/4605) render null when no social embed id is provided |
 | 3.3.9 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 3.3.8 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 3.3.7 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-social-embed/package.json
+++ b/packages/components/psammead-social-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-social-embed",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -455,6 +455,8 @@ exports[`AmpSocialEmbed should render correctly for YouTube 1`] = `
 </div>
 `;
 
+exports[`AmpSocialEmbed should render null when no social embed ID is provided 1`] = `<div />`;
+
 exports[`CanonicalSocialEmbed Instagram should render correctly for Instagram 1`] = `
 .emotion-0 {
   position: relative;

--- a/packages/components/psammead-social-embed/src/index.jsx
+++ b/packages/components/psammead-social-embed/src/index.jsx
@@ -64,6 +64,10 @@ export const AmpSocialEmbed = ({
   caption,
   fallback,
 }) => {
+  if (!id) {
+    return null;
+  }
+
   const AmpElement = AmpElements[provider];
   const hasCaption = caption && caption.text;
 

--- a/packages/components/psammead-social-embed/src/index.test.jsx
+++ b/packages/components/psammead-social-embed/src/index.test.jsx
@@ -301,4 +301,24 @@ describe('AmpSocialEmbed', () => {
       service="news"
     />,
   );
+
+  shouldMatchSnapshot(
+    'should render null when no social embed ID is provided',
+    <AmpSocialEmbed
+      provider="unknown"
+      id={undefined}
+      skipLink={{
+        text: 'Skip %provider_name% content',
+        endTextId: 'skip-%provider%-content',
+        endTextVisuallyHidden: 'End of %provider_name% content',
+      }}
+      fallback={{
+        text: "Sorry but we're having trouble displaying this content",
+        linkText: 'View content on %provider_name%',
+        linkHref: 'embed-url',
+        warningText: 'Warning: BBC is not responsible for third party content',
+      }}
+      service="news"
+    />,
+  );
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9724

**Overall change:** 
Fixes invalid AMP pages when social embed ID is not provided.

**Code changes:**

- Check for social embed ID before rendering. Return null if no ID provided
- Update test suite with a test to cover not rendering the `amp-youtube` element.

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
