### PR TITLE
Add WebP support to psammead-image component

### DIFF
--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.53 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 5.0.52 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |
 | 5.0.51 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Bumps dependencies |
 | 5.0.50 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.53",
+  "version": "5.0.54",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.52",
+  "version": "5.0.53",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.10",
     "@bbc/psammead-live-label": "2.0.32",
-    "@bbc/psammead-story-promo": "8.0.34",
+    "@bbc/psammead-story-promo": "8.0.35",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -272,12 +272,16 @@ exports[`Bulletin should render audio correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>
@@ -617,12 +621,16 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>
@@ -972,12 +980,16 @@ exports[`Bulletin should render live audio correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>
@@ -1335,12 +1347,16 @@ exports[`Bulletin should render live video correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>
@@ -1652,12 +1668,16 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>
@@ -1994,12 +2014,16 @@ exports[`Bulletin should render video correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source />
-        <source />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+        />
+        <source
+          srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+        />
         <img
           alt="Iron man"
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+          src="https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg"
         />
       </picture>
     </div>

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -49,32 +49,37 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -86,28 +91,28 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -115,7 +120,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -127,17 +132,17 @@ exports[`Bulletin should render audio correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -148,7 +153,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-14 {
+.emotion-16 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -160,26 +165,26 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-left: 0;
   }
 }
 
-.emotion-16 {
+.emotion-18 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -204,21 +209,21 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-18 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -228,7 +233,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +245,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-18>svg {
+.emotion-20>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -248,7 +253,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -264,29 +269,37 @@ exports[`Bulletin should render audio correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="ltr"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
             >
               Listen, 
             </span>
@@ -297,23 +310,23 @@ exports[`Bulletin should render audio correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-14 emotion-15"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-16 emotion-17"
+        class="emotion-18 emotion-19"
         dir="ltr"
       >
         <span
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-20 emotion-21"
+            class="emotion-22 emotion-23"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -383,32 +396,37 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -420,28 +438,28 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-right: 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -449,7 +467,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -461,17 +479,17 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -482,7 +500,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   margin: 0;
 }
 
-.emotion-14 {
+.emotion-16 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -494,26 +512,26 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-right: 0;
   }
 }
 
-.emotion-16 {
+.emotion-18 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -538,21 +556,21 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-18 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -562,7 +580,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -574,7 +592,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   padding-left: 0.5rem;
 }
 
-.emotion-18>svg {
+.emotion-20>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -582,7 +600,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -598,29 +616,37 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="rtl"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="rtl"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               lang="en-GB"
             >
               Listen, 
@@ -632,23 +658,23 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-14 emotion-15"
+        class="emotion-16 emotion-17"
         dir="rtl"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-16 emotion-17"
+        class="emotion-18 emotion-19"
         dir="rtl"
       >
         <span
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           dir="rtl"
         >
           <svg
             aria-hidden="true"
-            class="emotion-20 emotion-21"
+            class="emotion-22 emotion-23"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1416,32 +1442,37 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -1453,28 +1484,28 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1482,7 +1513,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1494,17 +1525,17 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1515,7 +1546,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   margin: 0;
 }
 
-.emotion-14 {
+.emotion-16 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -1540,21 +1571,21 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-14 {
+  .emotion-16 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -1564,7 +1595,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1576,7 +1607,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-16>svg {
+.emotion-18>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1584,7 +1615,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   margin: 0;
 }
 
-.emotion-18 {
+.emotion-20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1600,29 +1631,37 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="ltr"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
             >
               Listen, 
             </span>
@@ -1634,16 +1673,16 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       </h3>
       <div
         aria-hidden="true"
-        class="emotion-14 emotion-15"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         <span
-          class="emotion-16 emotion-17"
+          class="emotion-18 emotion-19"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-18 emotion-19"
+            class="emotion-20 emotion-21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1718,32 +1757,37 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 50%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 4/span 3;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -1755,26 +1799,26 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 0 0.5rem 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1782,7 +1826,7 @@ exports[`Bulletin should render video correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1794,17 +1838,17 @@ exports[`Bulletin should render video correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1815,7 +1859,7 @@ exports[`Bulletin should render video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-14 {
+.emotion-16 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -1827,27 +1871,27 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-16 {
+.emotion-18 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -1872,21 +1916,21 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -1895,7 +1939,7 @@ exports[`Bulletin should render video correctly 1`] = `
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1907,7 +1951,7 @@ exports[`Bulletin should render video correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-18>svg {
+.emotion-20>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1915,7 +1959,7 @@ exports[`Bulletin should render video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1931,29 +1975,37 @@ exports[`Bulletin should render video correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="ltr"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
             >
               Watch, 
             </span>
@@ -1964,23 +2016,23 @@ exports[`Bulletin should render video correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-14 emotion-15"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-16 emotion-17"
+        class="emotion-18 emotion-19"
         dir="ltr"
       >
         <span
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-20 emotion-21"
+            class="emotion-22 emotion-23"
             focusable="false"
             height="12px"
             viewBox="0 0 32 32"

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -272,9 +272,7 @@ exports[`Bulletin should render audio correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt="Iron man"
@@ -619,9 +617,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt="Iron man"
@@ -744,32 +740,37 @@ exports[`Bulletin should render live audio correctly 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -781,28 +782,28 @@ exports[`Bulletin should render live audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -810,7 +811,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -822,17 +823,17 @@ exports[`Bulletin should render live audio correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -841,7 +842,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.emotion-14 {
+.emotion-16 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -852,7 +853,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -864,26 +865,26 @@ exports[`Bulletin should render live audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-18 {
     padding-left: 0;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   background-color: #B80000;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -908,21 +909,21 @@ exports[`Bulletin should render live audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -932,7 +933,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   }
 }
 
-.emotion-20 {
+.emotion-22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -944,7 +945,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-20>svg {
+.emotion-22>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -952,7 +953,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-24 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -968,22 +969,28 @@ exports[`Bulletin should render live audio correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="ltr"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
@@ -991,13 +998,13 @@ exports[`Bulletin should render live audio correctly 1`] = `
           >
             <span
               aria-hidden="true"
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="ltr"
             >
               LIVE 
             </span>
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               lang="en-GB"
             >
               Listen LIVE, 
@@ -1007,23 +1014,23 @@ exports[`Bulletin should render live audio correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-16 emotion-17"
+        class="emotion-18 emotion-19"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-18 emotion-19"
+        class="emotion-20 emotion-21"
         dir="ltr"
       >
         <span
-          class="emotion-20 emotion-21"
+          class="emotion-22 emotion-23"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-22 emotion-23"
+            class="emotion-24 emotion-25"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1098,32 +1105,37 @@ exports[`Bulletin should render live video correctly 1`] = `
 }
 
 .emotion-6 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-6 {
+  .emotion-8 {
     width: 50%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-6 {
+  .emotion-8 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-6 {
+    .emotion-8 {
       grid-column: 4/span 3;
       padding: 0;
     }
   }
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -1135,26 +1147,26 @@ exports[`Bulletin should render live video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 0 0.5rem 0;
   }
 }
 
-.emotion-10 {
+.emotion-12 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1162,7 +1174,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-10:before {
+.emotion-12:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1174,17 +1186,17 @@ exports[`Bulletin should render live video correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-10:hover,
-.emotion-10:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #6E6E73;
 }
 
-.emotion-12 {
+.emotion-14 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1193,7 +1205,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   margin-right: 0.5rem;
 }
 
-.emotion-14 {
+.emotion-16 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1204,7 +1216,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -1216,27 +1228,27 @@ exports[`Bulletin should render live video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-18 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   background-color: #B80000;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -1261,21 +1273,21 @@ exports[`Bulletin should render live video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -1284,7 +1296,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   }
 }
 
-.emotion-20 {
+.emotion-22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1296,7 +1308,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-20>svg {
+.emotion-22>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1304,7 +1316,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-24 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1320,22 +1332,28 @@ exports[`Bulletin should render live video correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <img
-        alt="Iron man"
+      <picture
         class="emotion-4 emotion-5"
-        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      />
+      >
+        <source />
+        <source />
+        <img
+          alt="Iron man"
+          class="emotion-6 emotion-7"
+          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+        />
+      </picture>
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="emotion-8 emotion-9"
       dir="ltr"
     >
       <h3
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
         <a
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           href="https://bbc.co.uk"
         >
           <span
@@ -1343,13 +1361,13 @@ exports[`Bulletin should render live video correctly 1`] = `
           >
             <span
               aria-hidden="true"
-              class="emotion-12 emotion-13"
+              class="emotion-14 emotion-15"
               dir="ltr"
             >
               LIVE 
             </span>
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               lang="en-GB"
             >
               Watch LIVE, 
@@ -1359,23 +1377,23 @@ exports[`Bulletin should render live video correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-16 emotion-17"
+        class="emotion-18 emotion-19"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-18 emotion-19"
+        class="emotion-20 emotion-21"
         dir="ltr"
       >
         <span
-          class="emotion-20 emotion-21"
+          class="emotion-22 emotion-23"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-22 emotion-23"
+            class="emotion-24 emotion-25"
             focusable="false"
             height="12px"
             viewBox="0 0 32 32"
@@ -1634,9 +1652,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt="Iron man"
@@ -1978,9 +1994,7 @@ exports[`Bulletin should render video correctly 1`] = `
       <picture
         class="emotion-4 emotion-5"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt="Iron man"

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -49,37 +49,32 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-}
-
-.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-8 {
+  .emotion-6 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-8 {
+    .emotion-6 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -91,28 +86,28 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0;
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -120,7 +115,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-12:before {
+.emotion-10:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -132,17 +127,17 @@ exports[`Bulletin should render audio correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-10:hover,
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-12:visited {
+.emotion-10:visited {
   color: #6E6E73;
 }
 
-.emotion-14 {
+.emotion-12 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -153,7 +148,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-14 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -165,26 +160,26 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-14 {
     padding-left: 0;
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -209,21 +204,21 @@ exports[`Bulletin should render audio correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -233,7 +228,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   }
 }
 
-.emotion-20 {
+.emotion-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -245,7 +240,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-20>svg {
+.emotion-18>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -253,7 +248,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -269,37 +264,29 @@ exports[`Bulletin should render audio correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <picture
+      <img
+        alt="Iron man"
         class="emotion-4 emotion-5"
-      >
-        <source
-          type="image/webp"
-        />
-        <source />
-        <img
-          alt="Iron man"
-          class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-        />
-      </picture>
+        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      />
     </div>
     <div
-      class="emotion-8 emotion-9"
+      class="emotion-6 emotion-7"
       dir="ltr"
     >
       <h3
-        class="emotion-10 emotion-11"
+        class="emotion-8 emotion-9"
         dir="ltr"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-10 emotion-11"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
             >
               Listen, 
             </span>
@@ -310,23 +297,23 @@ exports[`Bulletin should render audio correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-16 emotion-17"
+        class="emotion-14 emotion-15"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-18 emotion-19"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         <span
-          class="emotion-20 emotion-21"
+          class="emotion-18 emotion-19"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-22 emotion-23"
+            class="emotion-20 emotion-21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -396,37 +383,32 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-}
-
-.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-8 {
+  .emotion-6 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-8 {
+    .emotion-6 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -438,28 +420,28 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-right: 0;
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -467,7 +449,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-12:before {
+.emotion-10:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -479,17 +461,17 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   z-index: 1;
 }
 
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-10:hover,
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-12:visited {
+.emotion-10:visited {
   color: #6E6E73;
 }
 
-.emotion-14 {
+.emotion-12 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -500,7 +482,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-14 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -512,26 +494,26 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-14 {
     padding-right: 0;
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -556,21 +538,21 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -580,7 +562,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   }
 }
 
-.emotion-20 {
+.emotion-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -592,7 +574,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   padding-left: 0.5rem;
 }
 
-.emotion-20>svg {
+.emotion-18>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -600,7 +582,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -616,37 +598,29 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <picture
+      <img
+        alt="Iron man"
         class="emotion-4 emotion-5"
-      >
-        <source
-          type="image/webp"
-        />
-        <source />
-        <img
-          alt="Iron man"
-          class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-        />
-      </picture>
+        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      />
     </div>
     <div
-      class="emotion-8 emotion-9"
+      class="emotion-6 emotion-7"
       dir="rtl"
     >
       <h3
-        class="emotion-10 emotion-11"
+        class="emotion-8 emotion-9"
         dir="rtl"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-10 emotion-11"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
               lang="en-GB"
             >
               Listen, 
@@ -658,23 +632,23 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-16 emotion-17"
+        class="emotion-14 emotion-15"
         dir="rtl"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-18 emotion-19"
+        class="emotion-16 emotion-17"
         dir="rtl"
       >
         <span
-          class="emotion-20 emotion-21"
+          class="emotion-18 emotion-19"
           dir="rtl"
         >
           <svg
             aria-hidden="true"
-            class="emotion-22 emotion-23"
+            class="emotion-20 emotion-21"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1442,37 +1416,32 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-}
-
-.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 66.67%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-8 {
+  .emotion-6 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-8 {
+    .emotion-6 {
       grid-column: 3/span 4;
       padding: 0;
     }
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -1484,28 +1453,28 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0;
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1513,7 +1482,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-12:before {
+.emotion-10:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1525,17 +1494,17 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-10:hover,
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-12:visited {
+.emotion-10:visited {
   color: #6E6E73;
 }
 
-.emotion-14 {
+.emotion-12 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1546,7 +1515,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-14 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -1571,21 +1540,21 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16 {
+  .emotion-14 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -1595,7 +1564,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1607,7 +1576,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-18>svg {
+.emotion-16>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1615,7 +1584,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1631,37 +1600,29 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <picture
+      <img
+        alt="Iron man"
         class="emotion-4 emotion-5"
-      >
-        <source
-          type="image/webp"
-        />
-        <source />
-        <img
-          alt="Iron man"
-          class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-        />
-      </picture>
+        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      />
     </div>
     <div
-      class="emotion-8 emotion-9"
+      class="emotion-6 emotion-7"
       dir="ltr"
     >
       <h3
-        class="emotion-10 emotion-11"
+        class="emotion-8 emotion-9"
         dir="ltr"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-10 emotion-11"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
             >
               Listen, 
             </span>
@@ -1673,16 +1634,16 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       </h3>
       <div
         aria-hidden="true"
-        class="emotion-16 emotion-17"
+        class="emotion-14 emotion-15"
         dir="ltr"
       >
         <span
-          class="emotion-18 emotion-19"
+          class="emotion-16 emotion-17"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-20 emotion-21"
+            class="emotion-18 emotion-19"
             focusable="false"
             height="12px"
             viewBox="0 0 13 12"
@@ -1757,37 +1718,32 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-}
-
-.emotion-8 {
   display: inline-block;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     width: 50%;
     padding-right: 1rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-8 {
+  .emotion-6 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-8 {
+    .emotion-6 {
       grid-column: 4/span 3;
       padding: 0;
     }
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   color: #222222;
   margin: 0;
   padding: 0.5rem;
@@ -1799,26 +1755,26 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding: 0 0 0.5rem 0;
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1826,7 +1782,7 @@ exports[`Bulletin should render video correctly 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-12:before {
+.emotion-10:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1838,17 +1794,17 @@ exports[`Bulletin should render video correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-10:hover,
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-12:visited {
+.emotion-10:visited {
   color: #6E6E73;
 }
 
-.emotion-14 {
+.emotion-12 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1859,7 +1815,7 @@ exports[`Bulletin should render video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-16 {
+.emotion-14 {
   color: #3F3F42;
   margin: 0;
   padding: 0 0.5rem 1rem;
@@ -1871,27 +1827,27 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-14 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-14 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   background-color: #222222;
   border: 0.0625rem solid transparent;
   color: #FFFFFF;
@@ -1916,21 +1872,21 @@ exports[`Bulletin should render video correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: -ms-inline-flexbox;
@@ -1939,7 +1895,7 @@ exports[`Bulletin should render video correctly 1`] = `
   }
 }
 
-.emotion-20 {
+.emotion-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1951,7 +1907,7 @@ exports[`Bulletin should render video correctly 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-20>svg {
+.emotion-18>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1959,7 +1915,7 @@ exports[`Bulletin should render video correctly 1`] = `
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-20 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1975,37 +1931,29 @@ exports[`Bulletin should render video correctly 1`] = `
     <div
       class="emotion-2 emotion-3"
     >
-      <picture
+      <img
+        alt="Iron man"
         class="emotion-4 emotion-5"
-      >
-        <source
-          type="image/webp"
-        />
-        <source />
-        <img
-          alt="Iron man"
-          class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-        />
-      </picture>
+        src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      />
     </div>
     <div
-      class="emotion-8 emotion-9"
+      class="emotion-6 emotion-7"
       dir="ltr"
     >
       <h3
-        class="emotion-10 emotion-11"
+        class="emotion-8 emotion-9"
         dir="ltr"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-10 emotion-11"
           href="https://bbc.co.uk"
         >
           <span
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
             >
               Watch, 
             </span>
@@ -2016,23 +1964,23 @@ exports[`Bulletin should render video correctly 1`] = `
         </a>
       </h3>
       <p
-        class="emotion-16 emotion-17"
+        class="emotion-14 emotion-15"
         dir="ltr"
       >
         This is the summary text
       </p>
       <div
         aria-hidden="true"
-        class="emotion-18 emotion-19"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         <span
-          class="emotion-20 emotion-21"
+          class="emotion-18 emotion-19"
           dir="ltr"
         >
           <svg
             aria-hidden="true"
-            class="emotion-22 emotion-23"
+            class="emotion-20 emotion-21"
             focusable="false"
             height="12px"
             viewBox="0 0 32 32"

--- a/packages/components/psammead-bulletin/src/index.stories.jsx
+++ b/packages/components/psammead-bulletin/src/index.stories.jsx
@@ -21,11 +21,20 @@ const BulletinComponent = ({
   const withSummary = boolean('With summary', true);
   const ctaText = mediaType === 'audio' ? 'Listen' : 'Watch';
   const offScreenText = isLive ? `${ctaText} Live` : ctaText;
+  const imageSizes = [300, 450, 600, 1024];
+  const imageSrc =
+    'https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg';
 
   const image = (
     <Image
-      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      src={imageSrc.replace('[WIDTH]', 660)}
       alt="Iron man"
+      srcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)}.webp ${size}w`)
+        .join(', ')}
+      fallbackSrcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
+        .join(', ')}
     />
   );
 

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -18,14 +18,23 @@ const BulletinComponent = ({
   const summaryText = 'This is the summary text';
   const headlineText = 'This is the headline';
   const ctaLink = 'https://bbc.co.uk';
+  const imageSizes = [300, 450, 600, 1024];
+  const imageSrc =
+    'https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg';
 
   const playCtaText = isLive ? `${ctaText} Live` : ctaText;
   const offScreenText = isLive ? `${ctaText} LIVE` : ctaText;
 
   const image = (
     <Image
-      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+      src={imageSrc}
       alt="Iron man"
+      srcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)}.webp ${size}w`)
+        .join(', ')}
+      fallbackSrcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
+        .join(', ')}
     />
   );
   return (

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.12 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 3.1.11 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 3.1.10 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 3.1.9 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -1856,9 +1856,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
         <picture
           class="emotion-6 emotion-7"
         >
-          <source
-            type="image/webp"
-          />
+          <source />
           <source />
           <img
             alt="Robert Downey Junior in Iron Man"

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -1730,8 +1730,13 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
   visibility: visible;
 }
 
+.emotion-8 {
+  display: block;
+  width: 100%;
+}
+
 @media (max-width: 14.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 0.5rem;
     width: calc(100%);
     display: inline-block;
@@ -1740,7 +1745,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 0.5rem;
     width: calc(100%);
     display: inline-block;
@@ -1749,7 +1754,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 1rem;
     width: calc(100%);
     display: inline-block;
@@ -1758,7 +1763,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     padding: 0 1rem;
     width: calc(100%);
     display: inline-block;
@@ -1767,7 +1772,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-8 {
+  .emotion-10 {
     width: calc(75%);
     display: inline-block;
     vertical-align: top;
@@ -1775,7 +1780,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @media (min-width: 80rem) {
-  .emotion-8 {
+  .emotion-10 {
     width: calc(75%);
     display: inline-block;
     vertical-align: top;
@@ -1783,14 +1788,14 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
 }
 
 @supports (display: grid) {
-  .emotion-8 {
+  .emotion-10 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -1798,7 +1803,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -1806,7 +1811,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -1814,7 +1819,7 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -1822,14 +1827,14 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-8 {
+    .emotion-10 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
@@ -1848,16 +1853,24 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
       <div
         class="emotion-4 emotion-5"
       >
-        <img
-          alt="Robert Downey Junior in Iron Man"
+        <picture
           class="emotion-6 emotion-7"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-          width="640"
-        />
+        >
+          <source
+            type="image/webp"
+          />
+          <source />
+          <img
+            alt="Robert Downey Junior in Iron Man"
+            class="emotion-8 emotion-9"
+            src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
+            width="640"
+          />
+        </picture>
       </div>
     </div>
     <div
-      class="emotion-8 emotion-1"
+      class="emotion-10 emotion-1"
       dir="ltr"
     >
       <p>

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -1856,8 +1856,12 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
         <picture
           class="emotion-6 emotion-7"
         >
-          <source />
-          <source />
+          <source
+            srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          />
+          <source
+            srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          />
           <img
             alt="Robert Downey Junior in Iron Man"
             class="emotion-8 emotion-9"

--- a/packages/components/psammead-grid/src/index.stories.jsx
+++ b/packages/components/psammead-grid/src/index.stories.jsx
@@ -1275,17 +1275,9 @@ storiesOf(STORY_KIND, module)
           </>
         );
 
-        const Img = (
-          <Image
-            alt="Robert Downey Junior in Iron Man"
-            src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-            width="640"
-          />
-        );
-
         return (
           <StoryPromo
-            image={Img}
+            image={<ExampleImage />}
             info={Info}
             promoType={promoType}
             dir={dir}
@@ -1473,11 +1465,7 @@ storiesOf(STORY_KIND, module)
           group5: 6,
         }}
       >
-        <Image
-          alt="Robert Downey Junior in Iron Man"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-          width="640"
-        />
+        <ExampleImage />
       </Grid>
       <Grid
         dir={dir}
@@ -1532,11 +1520,7 @@ storiesOf(STORY_KIND, module)
             group5: 6,
           }}
         >
-          <Image
-            alt="Robert Downey Junior in Iron Man"
-            src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-            width="640"
-          />
+          <ExampleImage />
         </Grid>
         <Grid
           dir={dir}
@@ -1590,11 +1574,7 @@ storiesOf(STORY_KIND, module)
           group5: 6,
         }}
       >
-        <Image
-          alt="Robert Downey Junior in Iron Man"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-          width="640"
-        />
+        <ExampleImage />
       </Grid>
       <Grid
         dir={dir}
@@ -1608,11 +1588,7 @@ storiesOf(STORY_KIND, module)
           group5: 2,
         }}
       >
-        <Image
-          alt="Robert Downey Junior in Iron Man"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-          width="640"
-        />
+        <ExampleImage />
       </Grid>
       <Grid
         dir={dir}
@@ -1626,11 +1602,7 @@ storiesOf(STORY_KIND, module)
           group5: 2,
         }}
       >
-        <Image
-          alt="Robert Downey Junior in Iron Man"
-          src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-          width="640"
-        />
+        <ExampleImage />
       </Grid>
     </Grid>
   ));

--- a/packages/components/psammead-grid/src/index.stories.jsx
+++ b/packages/components/psammead-grid/src/index.stories.jsx
@@ -5,7 +5,6 @@ import {
   withServicesKnob,
   buildRTLSubstories,
 } from '@bbc/psammead-storybook-helpers';
-import Image from '@bbc/psammead-image';
 import StoryPromo, { Headline, Summary, Link } from '@bbc/psammead-story-promo';
 import Grid from '.';
 import {

--- a/packages/components/psammead-grid/src/testHelpers.jsx
+++ b/packages/components/psammead-grid/src/testHelpers.jsx
@@ -29,15 +29,27 @@ const ImageSpacing = styled.div`
   padding: 0 0 ${GEL_SPACING} 0;
 `;
 
-export const ExampleImage = () => (
-  <ImageSpacing>
-    <Image
-      alt="Robert Downey Junior in Iron Man"
-      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg"
-      width="640"
-    />
-  </ImageSpacing>
-);
+export const ExampleImage = () => {
+  const imageSizes = [300, 450, 600, 1024];
+  const imageSrc =
+    'https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg';
+
+  return (
+    <ImageSpacing>
+      <Image
+        alt="Robert Downey Junior in Iron Man"
+        src={imageSrc.replace('[WIDTH]', 660)}
+        width="640"
+        srcset={imageSizes
+          .map(size => `${imageSrc.replace('[WIDTH]', size)}.webp ${size}w`)
+          .join(', ')}
+        fallbackSrcset={imageSizes
+          .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
+          .join(', ')}
+      />
+    </ImageSpacing>
+  );
+};
 
 export const ExampleMediaIndicator = styled(MediaIndicator)``;
 

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |
 | 2.0.8 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 2.0.7 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |
 | 2.0.6 | [PR#4368](https://github.com/bbc/psammead/pull/4368) use Yarn Workspaces |

--- a/packages/components/psammead-image/README.md
+++ b/packages/components/psammead-image/README.md
@@ -56,6 +56,7 @@ const WrappingContainer = ({ alt, src, height, width, sizes }) => (
 ## Props
 
 ### Img
+
 <!-- prettier-ignore -->
 | Prop | Type | Required | Default | Example |
 |:-----|:-----|:---------|:--------|:--------|
@@ -63,7 +64,8 @@ const WrappingContainer = ({ alt, src, height, width, sizes }) => (
 | `height` | number/string | No  | null  | 450 |
 | `sizes`  | string        | No  | null  | "100vw" |
 | `src`    | string        | Yes | -     | "https://bbc.com/300/cat.jpg" |
-| `srcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w" |
+| `srcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg.webp 300w, https://bbc.com/450/cat.jpg.webp 450w, https://bbc.com/600/cat.jpg.webp 600w" |
+| `fallbackSrcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w" |
 | `width`  | number/string | No  | null  | 600 |
 | `fade`   |  boolean      | No  | false | true |
 
@@ -80,6 +82,7 @@ The `sizes` prop is optional since some projects might not want to use the sizes
 The `fade` prop is optional and set to `false` by default. It's been used to apply a fade-in animation effect on the `Img` component.
 
 ### AmpImg
+
 <!-- prettier-ignore -->
 | Prop | Type | Required | Default | Example |
 |:-----|:-----|:---------|:--------|:--------|
@@ -89,7 +92,8 @@ The `fade` prop is optional and set to `false` by default. It's been used to app
 | `layout`      | string        | Yes | -    | "responsive" |
 | `sizes`       | string        | No  | null | "100vw" |
 | `src`         | string        | Yes | -    | "https://bbc.com/300/cat.jpg" |
-| `srcset`      | string        | No  | null | "https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w" |
+| `srcset`      | string        | No  | null | "https://bbc.com/300/cat.jpg.webp 300w, https://bbc.com/450/cat.jpg.webp 450w, https://bbc.com/600/cat.jpg.webp 600w" |
+| `fallbackSrcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w" |
 | `width`       | number/string | Yes | -    | 600 |
 
 The `attribution` prop is available to pass in strings to include the image source. [For further details, please refer to the `amp-img` attribute docs](https://www.ampproject.org/docs/reference/components/amp-img#attributes).

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
@@ -8,9 +8,20 @@ exports[`Image - AmpImg should render image with custom dimensions correctly 1`]
     height="547"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
     width="445"
-  />
+  >
+    <amp-img
+      alt="By Elisa Decker, from her series \\"Sidewalk\\""
+      attribution="Elisa Decker"
+      fallback="true"
+      height="547"
+      layout="responsive"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      width="445"
+    />
+  </amp-img>
 </div>
 `;
 
@@ -22,10 +33,21 @@ exports[`Image - AmpImg should render image with srcset correctly 1`] = `
     height="576"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     width="1024"
-  />
+  >
+    <amp-img
+      alt="Student sitting an exam"
+      attribution=""
+      fallback="true"
+      height="576"
+      layout="responsive"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </amp-img>
 </div>
 `;
 
@@ -37,9 +59,20 @@ exports[`Image - AmpImg should render landscape image correctly 1`] = `
     height="576"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     width="1024"
-  />
+  >
+    <amp-img
+      alt="Student sitting an exam"
+      attribution=""
+      fallback="true"
+      height="576"
+      layout="responsive"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </amp-img>
 </div>
 `;
 
@@ -51,9 +84,20 @@ exports[`Image - AmpImg should render portrait image correctly 1`] = `
     height="1280"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
     width="1024"
-  />
+  >
+    <amp-img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      attribution="BBC"
+      fallback="true"
+      height="1280"
+      layout="responsive"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      width="1024"
+    />
+  </amp-img>
 </div>
 `;
 
@@ -65,8 +109,19 @@ exports[`Image - AmpImg should render square image correctly 1`] = `
     height="1024"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
     width="1024"
-  />
+  >
+    <amp-img
+      alt="Tracks through the snow"
+      attribution="BBC"
+      fallback="true"
+      height="1024"
+      layout="responsive"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      width="1024"
+    />
+  </amp-img>
 </div>
 `;

--- a/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
@@ -10,22 +10,26 @@ exports[`Image - AmpImg should render image with custom dimensions correctly 1`]
     sizes="100vw"
     src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
     width="445"
-  >
-    <amp-img
-      alt="By Elisa Decker, from her series \\"Sidewalk\\""
-      attribution="Elisa Decker"
-      fallback="true"
-      height="547"
-      layout="responsive"
-      sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
-      width="445"
-    />
-  </amp-img>
+  />
 </div>
 `;
 
-exports[`Image - AmpImg should render image with srcset correctly 1`] = `
+exports[`Image - AmpImg should render image with only srcset correctly 1`] = `
+<div>
+  <amp-img
+    alt="Student sitting an exam"
+    attribution=""
+    height="576"
+    layout="responsive"
+    sizes="100vw"
+    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    width="1024"
+  />
+</div>
+`;
+
+exports[`Image - AmpImg should render image with srcset and fallbackSrcset correctly 1`] = `
 <div>
   <amp-img
     alt="Student sitting an exam"
@@ -45,6 +49,7 @@ exports[`Image - AmpImg should render image with srcset correctly 1`] = `
       layout="responsive"
       sizes="100vw"
       src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       width="1024"
     />
   </amp-img>
@@ -61,18 +66,7 @@ exports[`Image - AmpImg should render landscape image correctly 1`] = `
     sizes="100vw"
     src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     width="1024"
-  >
-    <amp-img
-      alt="Student sitting an exam"
-      attribution=""
-      fallback="true"
-      height="576"
-      layout="responsive"
-      sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-      width="1024"
-    />
-  </amp-img>
+  />
 </div>
 `;
 
@@ -86,18 +80,7 @@ exports[`Image - AmpImg should render portrait image correctly 1`] = `
     sizes="100vw"
     src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
     width="1024"
-  >
-    <amp-img
-      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-      attribution="BBC"
-      fallback="true"
-      height="1280"
-      layout="responsive"
-      sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-      width="1024"
-    />
-  </amp-img>
+  />
 </div>
 `;
 
@@ -111,17 +94,6 @@ exports[`Image - AmpImg should render square image correctly 1`] = `
     sizes="100vw"
     src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
     width="1024"
-  >
-    <amp-img
-      alt="Tracks through the snow"
-      attribution="BBC"
-      fallback="true"
-      height="1024"
-      layout="responsive"
-      sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
-      width="1024"
-    />
-  </amp-img>
+  />
 </div>
 `;

--- a/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`Image - AmpImg should render image with custom dimensions correctly 1`]
     height="547"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
     width="445"
   />
 </div>
@@ -22,8 +22,8 @@ exports[`Image - AmpImg should render image with only srcset correctly 1`] = `
     height="576"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     width="1024"
   />
 </div>
@@ -37,8 +37,8 @@ exports[`Image - AmpImg should render image with srcset and fallbackSrcset corre
     height="576"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     width="1024"
   >
     <amp-img
@@ -48,8 +48,8 @@ exports[`Image - AmpImg should render image with srcset and fallbackSrcset corre
       height="576"
       layout="responsive"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       width="1024"
     />
   </amp-img>
@@ -64,7 +64,7 @@ exports[`Image - AmpImg should render landscape image correctly 1`] = `
     height="576"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     width="1024"
   />
 </div>
@@ -78,7 +78,7 @@ exports[`Image - AmpImg should render portrait image correctly 1`] = `
     height="1280"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
     width="1024"
   />
 </div>
@@ -92,7 +92,7 @@ exports[`Image - AmpImg should render square image correctly 1`] = `
     height="1024"
     layout="responsive"
     sizes="100vw"
-    src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
     width="1024"
   />
 </div>

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -17,17 +17,17 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
 </div>
@@ -55,7 +55,7 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
       class="emotion-2 emotion-3"
       height="547"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
   </picture>
@@ -79,14 +79,14 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -110,17 +110,17 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -149,7 +149,7 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -178,7 +178,7 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
       class="emotion-2 emotion-3"
       height="1280"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
   </picture>
@@ -207,7 +207,7 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
       class="emotion-2 emotion-3"
       height="1024"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
   </picture>
@@ -231,17 +231,17 @@ exports[`Image - imported as default 'Image' should render image correctly witho
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
 </div>
@@ -269,7 +269,7 @@ exports[`Image - imported as default 'Image' should render image with custom dim
       class="emotion-2 emotion-3"
       height="547"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
   </picture>
@@ -293,14 +293,14 @@ exports[`Image - imported as default 'Image' should render image with only srcse
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -324,17 +324,17 @@ exports[`Image - imported as default 'Image' should render image with srcset and
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -363,7 +363,7 @@ exports[`Image - imported as default 'Image' should render landscape image corre
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -392,7 +392,7 @@ exports[`Image - imported as default 'Image' should render portrait image correc
       class="emotion-2 emotion-3"
       height="1280"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
   </picture>
@@ -421,7 +421,7 @@ exports[`Image - imported as default 'Image' should render square image correctl
       class="emotion-2 emotion-3"
       height="1024"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
   </picture>
@@ -445,17 +445,17 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
 </div>
@@ -483,7 +483,7 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
       class="emotion-2 emotion-3"
       height="547"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
   </picture>
@@ -507,14 +507,14 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -538,17 +538,17 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
     class="emotion-0 emotion-1"
   >
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
     <source
-      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
     />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -577,7 +577,7 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
       class="emotion-2 emotion-3"
       height="576"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
   </picture>
@@ -606,7 +606,7 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
       class="emotion-2 emotion-3"
       height="1280"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
   </picture>
@@ -635,7 +635,7 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
       class="emotion-2 emotion-3"
       height="1024"
       sizes="100vw"
-      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
   </picture>

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,6 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
@@ -50,9 +49,7 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
@@ -84,7 +81,6 @@ exports[`Image - imported as '{ Img }' should render image with srcset correctly
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source />
     <img
@@ -115,9 +111,7 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -147,9 +141,7 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
@@ -179,9 +171,7 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Tracks through the snow"
@@ -213,7 +203,6 @@ exports[`Image - imported as default 'Image' should render image correctly witho
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
@@ -245,9 +234,7 @@ exports[`Image - imported as default 'Image' should render image with custom dim
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
@@ -279,7 +266,6 @@ exports[`Image - imported as default 'Image' should render image with srcset cor
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source />
     <img
@@ -310,9 +296,7 @@ exports[`Image - imported as default 'Image' should render landscape image corre
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -342,9 +326,7 @@ exports[`Image - imported as default 'Image' should render portrait image correc
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
@@ -374,9 +356,7 @@ exports[`Image - imported as default 'Image' should render square image correctl
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Tracks through the snow"
@@ -408,7 +388,6 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
@@ -440,9 +419,7 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
@@ -474,7 +451,6 @@ exports[`Image - with Fade-in effect' should render image with srcset correctly 
   >
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
-      type="image/webp"
     />
     <source />
     <img
@@ -505,9 +481,7 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -537,9 +511,7 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
@@ -569,9 +541,7 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
   <picture
     class="emotion-0 emotion-1"
   >
-    <source
-      type="image/webp"
-    />
+    <source />
     <source />
     <img
       alt="Tracks through the snow"

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -50,7 +50,6 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -63,7 +62,7 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
 </div>
 `;
 
-exports[`Image - imported as '{ Img }' should render image with srcset correctly 1`] = `
+exports[`Image - imported as '{ Img }' should render image with only srcset correctly 1`] = `
 .emotion-0 {
   display: block;
   width: 100%;
@@ -82,7 +81,40 @@ exports[`Image - imported as '{ Img }' should render image with srcset correctly
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
-    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
+</div>
+`;
+
+exports[`Image - imported as '{ Img }' should render image with srcset and fallbackSrcset correctly 1`] = `
+.emotion-0 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
+<div>
+  <picture
+    class="emotion-0 emotion-1"
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -111,7 +143,6 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -142,7 +173,6 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -171,7 +201,6 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Tracks through the snow"
@@ -235,7 +264,6 @@ exports[`Image - imported as default 'Image' should render image with custom dim
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -248,7 +276,7 @@ exports[`Image - imported as default 'Image' should render image with custom dim
 </div>
 `;
 
-exports[`Image - imported as default 'Image' should render image with srcset correctly 1`] = `
+exports[`Image - imported as default 'Image' should render image with only srcset correctly 1`] = `
 .emotion-0 {
   display: block;
   width: 100%;
@@ -267,7 +295,40 @@ exports[`Image - imported as default 'Image' should render image with srcset cor
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
-    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
+</div>
+`;
+
+exports[`Image - imported as default 'Image' should render image with srcset and fallbackSrcset correctly 1`] = `
+.emotion-0 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
+<div>
+  <picture
+    class="emotion-0 emotion-1"
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -296,7 +357,6 @@ exports[`Image - imported as default 'Image' should render landscape image corre
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -327,7 +387,6 @@ exports[`Image - imported as default 'Image' should render portrait image correc
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -356,7 +415,6 @@ exports[`Image - imported as default 'Image' should render square image correctl
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Tracks through the snow"
@@ -420,7 +478,6 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -433,7 +490,7 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
 </div>
 `;
 
-exports[`Image - with Fade-in effect' should render image with srcset correctly 1`] = `
+exports[`Image - with Fade-in effect' should render image with only srcset correctly 1`] = `
 .emotion-0 {
   display: block;
   width: 100%;
@@ -452,7 +509,40 @@ exports[`Image - with Fade-in effect' should render image with srcset correctly 
     <source
       srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
     />
-    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
+</div>
+`;
+
+exports[`Image - with Fade-in effect' should render image with srcset and fallbackSrcset correctly 1`] = `
+.emotion-0 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
+<div>
+  <picture
+    class="emotion-0 emotion-1"
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -481,7 +571,6 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Student sitting an exam"
@@ -512,7 +601,6 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
     class="emotion-0 emotion-1"
   >
     <source />
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -541,7 +629,6 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <source />
     <img
       alt="Tracks through the snow"

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -7,15 +7,30 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    />
+  </picture>
 </div>
 `;
 
@@ -26,15 +41,28 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="By Elisa Decker, from her series \\"Sidewalk\\""
+  <picture
     class="emotion-0 emotion-1"
-    height="547"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
-    width="445"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="By Elisa Decker, from her series \\"Sidewalk\\""
+      class="emotion-2 emotion-3"
+      height="547"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      width="445"
+    />
+  </picture>
 </div>
 `;
 
@@ -45,16 +73,29 @@ exports[`Image - imported as '{ Img }' should render image with srcset correctly
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-    width="1024"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -65,15 +106,28 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -84,15 +138,28 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <picture
     class="emotion-0 emotion-1"
-    height="1280"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      class="emotion-2 emotion-3"
+      height="1280"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -103,15 +170,28 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Tracks through the snow"
+  <picture
     class="emotion-0 emotion-1"
-    height="1024"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Tracks through the snow"
+      class="emotion-2 emotion-3"
+      height="1024"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -122,15 +202,30 @@ exports[`Image - imported as default 'Image' should render image correctly witho
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    />
+  </picture>
 </div>
 `;
 
@@ -141,15 +236,28 @@ exports[`Image - imported as default 'Image' should render image with custom dim
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="By Elisa Decker, from her series \\"Sidewalk\\""
+  <picture
     class="emotion-0 emotion-1"
-    height="547"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
-    width="445"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="By Elisa Decker, from her series \\"Sidewalk\\""
+      class="emotion-2 emotion-3"
+      height="547"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      width="445"
+    />
+  </picture>
 </div>
 `;
 
@@ -160,16 +268,29 @@ exports[`Image - imported as default 'Image' should render image with srcset cor
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-    width="1024"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -180,15 +301,28 @@ exports[`Image - imported as default 'Image' should render landscape image corre
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -199,15 +333,28 @@ exports[`Image - imported as default 'Image' should render portrait image correc
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <picture
     class="emotion-0 emotion-1"
-    height="1280"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      class="emotion-2 emotion-3"
+      height="1280"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -218,48 +365,62 @@ exports[`Image - imported as default 'Image' should render square image correctl
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Tracks through the snow"
+  <picture
     class="emotion-0 emotion-1"
-    height="1024"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Tracks through the snow"
+      class="emotion-2 emotion-3"
+      height="1024"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
 exports[`Image - with Fade-in effect' should render image correctly without width 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-0 {
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
+}
+
+.emotion-2 {
+  display: block;
+  width: 100%;
 }
 
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+    />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+    />
+  </picture>
 </div>
 `;
 
@@ -270,15 +431,28 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="By Elisa Decker, from her series \\"Sidewalk\\""
+  <picture
     class="emotion-0 emotion-1"
-    height="547"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
-    width="445"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="By Elisa Decker, from her series \\"Sidewalk\\""
+      class="emotion-2 emotion-3"
+      height="547"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
+      width="445"
+    />
+  </picture>
 </div>
 `;
 
@@ -289,16 +463,29 @@ exports[`Image - with Fade-in effect' should render image with srcset correctly 
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
-    width="1024"
-  />
+  >
+    <source
+      srcset="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.test.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.test.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.test.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -309,15 +496,28 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Student sitting an exam"
+  <picture
     class="emotion-0 emotion-1"
-    height="576"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Student sitting an exam"
+      class="emotion-2 emotion-3"
+      height="576"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -328,15 +528,28 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <picture
     class="emotion-0 emotion-1"
-    height="1280"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      class="emotion-2 emotion-3"
+      height="1280"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+      width="1024"
+    />
+  </picture>
 </div>
 `;
 
@@ -347,14 +560,27 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
   visibility: visible;
 }
 
+.emotion-2 {
+  display: block;
+  width: 100%;
+}
+
 <div>
-  <img
-    alt="Tracks through the snow"
+  <picture
     class="emotion-0 emotion-1"
-    height="1024"
-    sizes="100vw"
-    src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
-    width="1024"
-  />
+  >
+    <source
+      type="image/webp"
+    />
+    <source />
+    <img
+      alt="Tracks through the snow"
+      class="emotion-2 emotion-3"
+      height="1024"
+      sizes="100vw"
+      src="https://ichef.test.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
+      width="1024"
+    />
+  </picture>
 </div>
 `;

--- a/packages/components/psammead-image/src/index.amp.jsx
+++ b/packages/components/psammead-image/src/index.amp.jsx
@@ -6,9 +6,17 @@ import { number, string } from 'prop-types';
 const omitInvalidProps = omit(['classname']);
 
 const AmpImg = props => {
-  const { srcset, ...otherProps } = props;
+  const { srcset, fallbackSrcset, ...otherProps } = props;
 
-  return <amp-img srcSet={srcset} {...omitInvalidProps(otherProps)} />;
+  return (
+    <amp-img srcSet={srcset} {...omitInvalidProps(otherProps)}>
+      <amp-img
+        fallback
+        srcSet={fallbackSrcset}
+        {...omitInvalidProps(otherProps)}
+      />
+    </amp-img>
+  );
 };
 
 AmpImg.propTypes = {
@@ -19,6 +27,7 @@ AmpImg.propTypes = {
   sizes: string,
   src: string.isRequired,
   srcset: string,
+  fallbackSrcset: string,
   width: number.isRequired,
 };
 
@@ -26,6 +35,7 @@ AmpImg.defaultProps = {
   attribution: '',
   sizes: null,
   srcset: null,
+  fallbackSrcset: null,
 };
 
 export default AmpImg;

--- a/packages/components/psammead-image/src/index.amp.jsx
+++ b/packages/components/psammead-image/src/index.amp.jsx
@@ -10,11 +10,13 @@ const AmpImg = props => {
 
   return (
     <amp-img srcSet={srcset} {...omitInvalidProps(otherProps)}>
-      <amp-img
-        fallback
-        srcSet={fallbackSrcset}
-        {...omitInvalidProps(otherProps)}
-      />
+      {fallbackSrcset && (
+        <amp-img
+          fallback
+          srcSet={fallbackSrcset}
+          {...omitInvalidProps(otherProps)}
+        />
+      )}
     </amp-img>
   );
 };

--- a/packages/components/psammead-image/src/index.amp.stories.jsx
+++ b/packages/components/psammead-image/src/index.amp.stories.jsx
@@ -6,10 +6,10 @@ const additionalProps = {
   layout: 'responsive',
 };
 
-stories(
-  AmpImg,
-  'Components/Images/Image - AmpImg',
-  true,
+stories({
+  Component: AmpImg,
+  title: 'Components/Images/Image - AmpImg',
+  includeHeight: true,
   additionalProps,
-  ampDecorator,
-);
+  styleDecorator: ampDecorator,
+});

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -20,17 +20,28 @@ const fadeIn = css`
   transition: visibility 0.2s linear;
 `;
 
-const StyledImg = styled.img`
+const StyledPicture = styled.picture`
   display: block;
   width: 100%;
   visibility: visible;
   ${props => props.fade && fadeIn};
 `;
 
-export const Img = props => {
-  const { srcset, ...otherProps } = props;
+const StyledImg = styled.img`
+  display: block;
+  width: 100%;
+`;
 
-  return <StyledImg srcSet={srcset} {...otherProps} />;
+export const Img = props => {
+  const { src, srcset, fallbackSrcset, alt, ...otherProps } = props;
+
+  return (
+    <StyledPicture {...otherProps}>
+      <source srcSet={srcset} type="image/webp" />
+      <source srcSet={fallbackSrcset} />
+      <StyledImg src={src} alt={alt} />
+    </StyledPicture>
+  );
 };
 
 Img.propTypes = {

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -51,6 +51,7 @@ Img.propTypes = {
   sizes: string,
   src: string.isRequired,
   srcset: string,
+  fallbackSrcset: string,
   width: oneOfType([string, number]),
 };
 
@@ -59,6 +60,7 @@ Img.defaultProps = {
   height: null,
   sizes: null,
   srcset: null,
+  fallbackSrcset: null,
   width: null,
 };
 

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -38,7 +38,7 @@ export const Img = props => {
   return (
     <StyledPicture onLoad={onLoad}>
       <source srcSet={srcset} />
-      <source srcSet={fallbackSrcset} />
+      {fallbackSrcset && <source srcSet={fallbackSrcset} />}
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>
   );

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -37,7 +37,7 @@ export const Img = props => {
 
   return (
     <StyledPicture onLoad={onLoad}>
-      <source srcSet={srcset} type="image/webp" />
+      <source srcSet={srcset} />
       <source srcSet={fallbackSrcset} />
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -33,13 +33,13 @@ const StyledImg = styled.img`
 `;
 
 export const Img = props => {
-  const { src, srcset, fallbackSrcset, alt, ...otherProps } = props;
+  const { src, srcset, fallbackSrcset, ...otherProps } = props;
 
   return (
-    <StyledPicture {...otherProps}>
+    <StyledPicture>
       <source srcSet={srcset} type="image/webp" />
       <source srcSet={fallbackSrcset} />
-      <StyledImg src={src} alt={alt} />
+      <StyledImg src={src} {...otherProps} />
     </StyledPicture>
   );
 };

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -33,10 +33,10 @@ const StyledImg = styled.img`
 `;
 
 export const Img = props => {
-  const { src, srcset, fallbackSrcset, ...otherProps } = props;
+  const { src, srcset, fallbackSrcset, onLoad, ...otherProps } = props;
 
   return (
-    <StyledPicture>
+    <StyledPicture onLoad={onLoad}>
       <source srcSet={srcset} type="image/webp" />
       <source srcSet={fallbackSrcset} />
       <StyledImg src={src} {...otherProps} />

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { number, oneOfType, string, bool } from 'prop-types';
+import { number, oneOfType, string, bool, func } from 'prop-types';
 import styled from '@emotion/styled';
 import { keyframes, css } from '@emotion/react';
 
@@ -53,6 +53,7 @@ Img.propTypes = {
   srcset: string,
   fallbackSrcset: string,
   width: oneOfType([string, number]),
+  onLoad: func,
 };
 
 Img.defaultProps = {
@@ -62,6 +63,7 @@ Img.defaultProps = {
   srcset: null,
   fallbackSrcset: null,
   width: null,
+  onLoad: () => {},
 };
 
 export default Img;

--- a/packages/components/psammead-image/src/index.stories.jsx
+++ b/packages/components/psammead-image/src/index.stories.jsx
@@ -1,21 +1,7 @@
-import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { Img } from '.';
-import { stories, getProps } from './testHelpers/stories';
-import { landscape } from './testHelpers/fixtureData';
-import notes from '../README.md';
+import { stories } from './testHelpers/stories';
 
 const type = 'Img';
 
-stories(
-  Img,
-  'Components/Images/Image - Img',
-  false,
-  {},
-  withKnobs,
-  type,
-).add(
-  'image without width',
-  () => <Img {...getProps(landscape, false, type)} width={null} />,
-  { notes },
-);
+stories(Img, 'Components/Images/Image - Img', false, {}, withKnobs, type);

--- a/packages/components/psammead-image/src/index.stories.jsx
+++ b/packages/components/psammead-image/src/index.stories.jsx
@@ -4,4 +4,12 @@ import { stories } from './testHelpers/stories';
 
 const type = 'Img';
 
-stories(Img, 'Components/Images/Image - Img', false, {}, withKnobs, type);
+stories({
+  Component: Img,
+  title: 'Components/Images/Image - Img',
+  includeHeight: false,
+  additionalProps: {},
+  styleDecorator: withKnobs,
+  type,
+  isCanonical: true,
+});

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -10,6 +10,9 @@ export const landscape = {
   sizes: '100vw',
   src: landscapeImageUrl.replace('[WIDTH]', sizes[0]),
   srcset: sizes
+    .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)}.webp ${size}w`)
+    .join(', '),
+  fallbackSrcset: sizes
     .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
   width: 1024,

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -1,8 +1,8 @@
 const sizes = [300, 450, 600, 1024];
-const landscapeImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/7098/production/_104842882_students.jpg`;
-const portraitImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png`;
-const squareImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/114FE/production/_104801907_79010.jpg`;
-const customImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg`;
+const landscapeImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/7098/production/_104842882_students.jpg`;
+const portraitImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png`;
+const squareImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/114FE/production/_104801907_79010.jpg`;
+const customImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg`;
 
 export const landscape = {
   alt: 'Student sitting an exam',

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -1,8 +1,8 @@
 const sizes = [300, 450, 600, 1024];
-const landscapeImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/7098/production/_104842882_students.jpg`;
-const portraitImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png`;
-const squareImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/114FE/production/_104801907_79010.jpg`;
-const customImageUrl = `https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg`;
+const landscapeImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/7098/production/_104842882_students.jpg`;
+const portraitImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png`;
+const squareImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/114FE/production/_104801907_79010.jpg`;
+const customImageUrl = `https://ichef.test.bbci.co.uk/news/[WIDTH]/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg`;
 
 export const landscape = {
   alt: 'Student sitting an exam',
@@ -26,6 +26,9 @@ export const portrait = {
   sizes: '100vw',
   src: portraitImageUrl.replace('[WIDTH]', sizes[0]),
   srcset: sizes
+    .map(size => `${portraitImageUrl.replace('[WIDTH]', size)}.webp ${size}w`)
+    .join(', '),
+  fallbackSrcset: sizes
     .map(size => `${portraitImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
   width: 1024,
@@ -38,6 +41,9 @@ export const square = {
   sizes: '100vw',
   src: squareImageUrl.replace('[WIDTH]', sizes[0]),
   srcset: sizes
+    .map(size => `${squareImageUrl.replace('[WIDTH]', size)}.webp ${size}w`)
+    .join(', '),
+  fallbackSrcset: sizes
     .map(size => `${squareImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
   width: 1024,
@@ -50,6 +56,9 @@ export const custom = {
   sizes: '100vw',
   src: customImageUrl.replace('[WIDTH]', sizes[0]),
   srcset: sizes
+    .map(size => `${customImageUrl.replace('[WIDTH]', size)}.webp ${size}w`)
+    .join(', '),
+  fallbackSrcset: sizes
     .map(size => `${customImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
   width: 445,

--- a/packages/components/psammead-image/src/testHelpers/snapshotTests.jsx
+++ b/packages/components/psammead-image/src/testHelpers/snapshotTests.jsx
@@ -52,7 +52,21 @@ const snapshotTests = (Component, additionalProps) => {
     />,
   );
   shouldMatchSnapshot(
-    'should render image with srcset correctly',
+    'should render image with srcset and fallbackSrcset correctly',
+    <Component
+      alt={landscape.alt}
+      attribution={landscape.attribution}
+      sizes={landscape.sizes}
+      src={landscape.src}
+      srcset={landscape.srcset}
+      fallbackSrcset={landscape.fallbackSrcset}
+      height={landscape.height}
+      width={landscape.width}
+      {...additionalProps}
+    />,
+  );
+  shouldMatchSnapshot(
+    'should render image with only srcset correctly',
     <Component
       alt={landscape.alt}
       attribution={landscape.attribution}

--- a/packages/components/psammead-image/src/testHelpers/stories.jsx
+++ b/packages/components/psammead-image/src/testHelpers/stories.jsx
@@ -79,4 +79,15 @@ export const stories = (
         />
       ),
       { notes },
+    )
+    .add(
+      'image without width',
+      () => (
+        <Component
+          {...getProps(landscape, includeHeight, type)}
+          width={null}
+          {...additionalProps}
+        />
+      ),
+      { notes },
     );

--- a/packages/components/psammead-image/src/testHelpers/stories.jsx
+++ b/packages/components/psammead-image/src/testHelpers/stories.jsx
@@ -10,6 +10,7 @@ export function getProps(image, includeHeight, type) {
     sizes: image.sizes,
     src: image.src,
     srcset: image.srcset,
+    fallbackSrcset: image.fallbackSrcset,
     width: image.width,
     fade: type === 'Img' ? boolean('Fade', false) : null,
   };

--- a/packages/components/psammead-image/src/testHelpers/stories.jsx
+++ b/packages/components/psammead-image/src/testHelpers/stories.jsx
@@ -19,14 +19,15 @@ export function getProps(image, includeHeight, type) {
   return props;
 }
 
-export const stories = (
+export const stories = ({
   Component,
   title,
   includeHeight = false,
   additionalProps = {},
   styleDecorator = storyFn => storyFn(),
   type,
-) =>
+  isCanonical = false,
+}) =>
   storiesOf(title, module)
     .addDecorator(styleDecorator)
     .add(
@@ -81,13 +82,7 @@ export const stories = (
       { notes },
     )
     .add(
-      'image without width',
-      () => (
-        <Component
-          {...getProps(landscape, includeHeight, type)}
-          width={null}
-          {...additionalProps}
-        />
-      ),
+      isCanonical && 'image without width',
+      () => <Component {...getProps(landscape, false, type)} width={null} />,
       { notes },
     );

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.0| [PR#4606](https://github.com/bbc/psammead/pull/4606) Adds support for WebP |
 | 5.1.13 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |
 | 5.1.13 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles transitive packages |
 | 5.1.12 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump from psammead-styles |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "5.1.14",
+  "version": "6.0.0",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-assets": "3.1.10",
-    "@bbc/psammead-image": "2.0.8",
+    "@bbc/psammead-image": "3.0.0",
     "@bbc/psammead-image-placeholder": "3.4.10",
     "@bbc/psammead-play-button": "3.0.32"
   },

--- a/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
@@ -22,19 +22,7 @@ exports[`Media Player: Amp should render an amp-iframe with an amp-img nested in
       src="https://foo.bar/placeholder.png"
       srcset="https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w"
       width="16"
-    >
-      <amp-img
-        alt=""
-        attribution=""
-        data-e2e="media-player__placeholder"
-        fallback="true"
-        height="9"
-        layout="fill"
-        placeholder="true"
-        src="https://foo.bar/placeholder.png"
-        width="16"
-      />
-    </amp-img>
+    />
     <noscript />
   </amp-iframe>
 </div>

--- a/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Amp/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,19 @@ exports[`Media Player: Amp should render an amp-iframe with an amp-img nested in
       src="https://foo.bar/placeholder.png"
       srcset="https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w"
       width="16"
-    />
+    >
+      <amp-img
+        alt=""
+        attribution=""
+        data-e2e="media-player__placeholder"
+        fallback="true"
+        height="9"
+        layout="fill"
+        placeholder="true"
+        src="https://foo.bar/placeholder.png"
+        width="16"
+      />
+    </amp-img>
     <noscript />
   </amp-iframe>
 </div>

--- a/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
@@ -160,9 +160,7 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
     <picture
       class="emotion-17 emotion-18"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""
@@ -366,9 +364,7 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
     <picture
       class="emotion-19 emotion-20"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""
@@ -527,9 +523,7 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
     <picture
       class="emotion-15 emotion-16"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""
@@ -704,9 +698,7 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
     <picture
       class="emotion-17 emotion-18"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""
@@ -868,9 +860,7 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
     <picture
       class="emotion-15 emotion-16"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""
@@ -1091,9 +1081,7 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
     <picture
       class="emotion-19 emotion-20"
     >
-      <source
-        type="image/webp"
-      />
+      <source />
       <source />
       <img
         alt=""

--- a/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
@@ -161,7 +161,6 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
       class="emotion-17 emotion-18"
     >
       <source />
-      <source />
       <img
         alt=""
         class="emotion-19 emotion-20"
@@ -365,7 +364,6 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
       class="emotion-19 emotion-20"
     >
       <source />
-      <source />
       <img
         alt=""
         class="emotion-21 emotion-22"
@@ -523,7 +521,6 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
     <picture
       class="emotion-15 emotion-16"
     >
-      <source />
       <source />
       <img
         alt=""
@@ -699,7 +696,6 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
       class="emotion-17 emotion-18"
     >
       <source />
-      <source />
       <img
         alt=""
         class="emotion-19 emotion-20"
@@ -860,7 +856,6 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
     <picture
       class="emotion-15 emotion-16"
     >
-      <source />
       <source />
       <img
         alt=""
@@ -1081,7 +1076,6 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
     <picture
       class="emotion-19 emotion-20"
     >
-      <source />
       <source />
       <img
         alt=""

--- a/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
@@ -106,6 +106,11 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
   visibility: visible;
 }
 
+.emotion-19 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -152,11 +157,19 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
         2:30
       </time>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-17 emotion-18"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-19 emotion-20"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;
@@ -293,6 +306,11 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
   visibility: visible;
 }
 
+.emotion-21 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -345,11 +363,19 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
         2:30
       </time>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-19 emotion-20"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-21 emotion-22"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;
@@ -454,6 +480,11 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
   visibility: visible;
 }
 
+.emotion-17 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -493,11 +524,19 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
         </svg>
       </div>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-15 emotion-16"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-17 emotion-18"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;
@@ -608,6 +647,11 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
   visibility: visible;
 }
 
+.emotion-19 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -657,11 +701,19 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
         2:30
       </time>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-17 emotion-18"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-19 emotion-20"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;
@@ -766,6 +818,11 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
   visibility: visible;
 }
 
+.emotion-17 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -808,11 +865,19 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
         </svg>
       </div>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-15 emotion-16"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-17 emotion-18"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;
@@ -966,6 +1031,11 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
   visibility: visible;
 }
 
+.emotion-21 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -1018,11 +1088,19 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
         2:30
       </time>
     </button>
-    <img
-      alt=""
+    <picture
       class="emotion-19 emotion-20"
-      src="http://foo.bar/placeholder.png"
-    />
+    >
+      <source
+        type="image/webp"
+      />
+      <source />
+      <img
+        alt=""
+        class="emotion-21 emotion-22"
+        src="http://foo.bar/placeholder.png"
+      />
+    </picture>
   </div>
 </div>
 `;

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -30,7 +30,19 @@ exports[`Media Player: AMP Entry renders a landscape container with an amp-ifram
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="9"
-      />
+      >
+        <amp-img
+          alt=""
+          attribution=""
+          data-e2e="media-player__placeholder"
+          fallback="true"
+          height="16"
+          layout="fill"
+          placeholder="true"
+          src="http://foo.bar/placeholder.png"
+          width="9"
+        />
+      </amp-img>
       <noscript />
     </amp-iframe>
   </div>
@@ -67,7 +79,19 @@ exports[`Media Player: AMP Entry renders a portrait container with amp-iframe an
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="16"
-      />
+      >
+        <amp-img
+          alt=""
+          attribution=""
+          data-e2e="media-player__placeholder"
+          fallback="true"
+          height="9"
+          layout="fill"
+          placeholder="true"
+          src="http://foo.bar/placeholder.png"
+          width="16"
+        />
+      </amp-img>
       <noscript />
     </amp-iframe>
   </div>
@@ -110,7 +134,19 @@ exports[`Media Player: AMP Entry renders the audio skin 1`] = `
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="9"
-      />
+      >
+        <amp-img
+          alt=""
+          attribution=""
+          data-e2e="media-player__placeholder"
+          fallback="true"
+          height="16"
+          layout="fill"
+          placeholder="true"
+          src="http://foo.bar/placeholder.png"
+          width="9"
+        />
+      </amp-img>
       <noscript />
     </amp-iframe>
   </div>
@@ -229,6 +265,11 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
   visibility: visible;
 }
 
+.emotion-21 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -279,11 +320,19 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
           2:30
         </time>
       </button>
-      <img
-        alt=""
+      <picture
         class="emotion-19 emotion-20"
-        src="http://foo.bar/placeholder.png"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt=""
+          class="emotion-21 emotion-22"
+          src="http://foo.bar/placeholder.png"
+        />
+      </picture>
     </div>
   </div>
 </div>
@@ -427,6 +476,11 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
   visibility: visible;
 }
 
+.emotion-23 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -483,11 +537,19 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
           2:30
         </time>
       </button>
-      <img
-        alt=""
+      <picture
         class="emotion-21 emotion-22"
-        src="http://foo.bar/placeholder.png"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt=""
+          class="emotion-23 emotion-24"
+          src="http://foo.bar/placeholder.png"
+        />
+      </picture>
     </div>
   </div>
 </div>
@@ -605,6 +667,11 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
   visibility: visible;
 }
 
+.emotion-21 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -655,11 +722,19 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
           2:30
         </time>
       </button>
-      <img
-        alt=""
+      <picture
         class="emotion-19 emotion-20"
-        src="http://foo.bar/placeholder.png"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt=""
+          class="emotion-21 emotion-22"
+          src="http://foo.bar/placeholder.png"
+        />
+      </picture>
     </div>
   </div>
 </div>
@@ -896,6 +971,11 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
   visibility: visible;
 }
 
+.emotion-23 {
+  display: block;
+  width: 100%;
+}
+
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -952,11 +1032,19 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
           2:30
         </time>
       </button>
-      <img
-        alt=""
+      <picture
         class="emotion-21 emotion-22"
-        src="http://foo.bar/placeholder.png"
-      />
+      >
+        <source
+          type="image/webp"
+        />
+        <source />
+        <img
+          alt=""
+          class="emotion-23 emotion-24"
+          src="http://foo.bar/placeholder.png"
+        />
+      </picture>
     </div>
   </div>
 </div>

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -324,7 +324,6 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
         class="emotion-19 emotion-20"
       >
         <source />
-        <source />
         <img
           alt=""
           class="emotion-21 emotion-22"
@@ -539,7 +538,6 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
         class="emotion-21 emotion-22"
       >
         <source />
-        <source />
         <img
           alt=""
           class="emotion-23 emotion-24"
@@ -721,7 +719,6 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
       <picture
         class="emotion-19 emotion-20"
       >
-        <source />
         <source />
         <img
           alt=""
@@ -1029,7 +1026,6 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
       <picture
         class="emotion-21 emotion-22"
       >
-        <source />
         <source />
         <img
           alt=""

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -323,9 +323,7 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
       <picture
         class="emotion-19 emotion-20"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt=""
@@ -540,9 +538,7 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
       <picture
         class="emotion-21 emotion-22"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt=""
@@ -725,9 +721,7 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
       <picture
         class="emotion-19 emotion-20"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt=""
@@ -1035,9 +1029,7 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
       <picture
         class="emotion-21 emotion-22"
       >
-        <source
-          type="image/webp"
-        />
+        <source />
         <source />
         <img
           alt=""

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -30,19 +30,7 @@ exports[`Media Player: AMP Entry renders a landscape container with an amp-ifram
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="9"
-      >
-        <amp-img
-          alt=""
-          attribution=""
-          data-e2e="media-player__placeholder"
-          fallback="true"
-          height="16"
-          layout="fill"
-          placeholder="true"
-          src="http://foo.bar/placeholder.png"
-          width="9"
-        />
-      </amp-img>
+      />
       <noscript />
     </amp-iframe>
   </div>
@@ -79,19 +67,7 @@ exports[`Media Player: AMP Entry renders a portrait container with amp-iframe an
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="16"
-      >
-        <amp-img
-          alt=""
-          attribution=""
-          data-e2e="media-player__placeholder"
-          fallback="true"
-          height="9"
-          layout="fill"
-          placeholder="true"
-          src="http://foo.bar/placeholder.png"
-          width="16"
-        />
-      </amp-img>
+      />
       <noscript />
     </amp-iframe>
   </div>
@@ -134,19 +110,7 @@ exports[`Media Player: AMP Entry renders the audio skin 1`] = `
         placeholder="true"
         src="http://foo.bar/placeholder.png"
         width="9"
-      >
-        <amp-img
-          alt=""
-          attribution=""
-          data-e2e="media-player__placeholder"
-          fallback="true"
-          height="16"
-          layout="fill"
-          placeholder="true"
-          src="http://foo.bar/placeholder.png"
-          width="9"
-        />
-      </amp-img>
+      />
       <noscript />
     </amp-iframe>
   </div>

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.29 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bumps psammead-styles |
 | 6.0.28 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 6.0.27 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |
 | 6.0.26 | [PR#4565](https://github.com/bbc/psammead/pull/4565) Bump from psammead-styles |

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "6.0.28",
+  "version": "6.0.29",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.stories.jsx
@@ -12,7 +12,13 @@ import notes from '../README.md';
 
 // eslint-disable-next-line react/prop-types
 const ImageComponent = ({ alt, src }) => (
-  <Image alt={alt} src={src} width="640" />
+  <Image
+    alt={alt}
+    src={src}
+    width="640"
+    srcset={`${src}.webp 640w`}
+    fallbackSrcset={`${src} 640w`}
+  />
 );
 
 // eslint-disable-next-line react/prop-types

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.35 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 8.0.34 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Conditionally add aria-labelledby attribute |
 | 8.0.33 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |
 | 8.0.32 | [PR#4588](https://github.com/bbc/psammead/pull/4588) Fix TalkBack reading nested spans incorrectly |

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.34",
+  "version": "8.0.35",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -14,16 +14,25 @@ import relatedItems from '../testHelpers/relatedItems';
 import IndexAlsosContainer from '../testHelpers/IndexAlsosContainer';
 import notes from '../README.md';
 
-const buildImg = () => (
-  <Image
-    alt={text('Image alt text', 'Robert Downey Junior in Iron Man')}
-    src={text(
-      'Image src',
-      'https://ichef.bbci.co.uk/news/660/cpsprodpb/11897/production/_106613817_999_al_.jpg',
-    )}
-    width="640"
-  />
-);
+const buildImg = () => {
+  const imageSizes = [300, 450, 600, 1024];
+  const imageSrc =
+    'https://ichef.bbci.co.uk/news/[WIDTH]/cpsprodpb/11897/production/_106613817_999_al_.jpg';
+
+  return (
+    <Image
+      alt={text('Image alt text', 'Robert Downey Junior in Iron Man')}
+      src={text('Image src', imageSrc.replace('[WIDTH]', 660))}
+      width="640"
+      srcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)}.webp ${size}w`)
+        .join(', ')}
+      fallbackSrcset={imageSizes
+        .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
+        .join(', ')}
+    />
+  );
+};
 
 const StyledTime = styled.time`
   padding: 0 ${GEL_SPACING_HLF};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.10
     "@bbc/psammead-live-label": 2.0.32
-    "@bbc/psammead-story-promo": 8.0.34
+    "@bbc/psammead-story-promo": 8.0.35
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
@@ -2092,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-story-promo@8.0.34, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
+"@bbc/psammead-story-promo@8.0.35, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image@2.0.8, @bbc/psammead-image@workspace:packages/components/psammead-image":
+"@bbc/psammead-image@3.0.0, @bbc/psammead-image@workspace:packages/components/psammead-image":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image@workspace:packages/components/psammead-image"
   dependencies:
@@ -1953,7 +1953,7 @@ __metadata:
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
     "@bbc/psammead-assets": 3.1.10
-    "@bbc/psammead-image": 2.0.8
+    "@bbc/psammead-image": 3.0.0
     "@bbc/psammead-image-placeholder": 3.4.10
     "@bbc/psammead-play-button": 3.0.32
     "@emotion/styled": ^11.3.0


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/9628

**Overall change:** 
- Updates the `psammead-image` component to use a `<picture>` element with 2 sources. 1 for WebP srcsets and 1 fallback srcset for JPG/PNG.
- Adds similar fallback handling to the AMP version of the image component
- Bumps `psammead-image` and `psammead-media-player` major versions

**Code changes:**

- Added `<picture>` tag to the `psammead-image` component
- Added `<amp-img fallback.../>` nested component to handle image format fallback in AMP
- Updated various test sets and Storybook stories that use the image component to reflect the new `fallbackSrcset` prop

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
