### PR TITLE
Fix `<amp-img>` fallback value

### DIFF
--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |
 | 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |
 | 2.0.8 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |
 | 2.0.7 | [PR#4420](https://github.com/bbc/psammead/pull/4420) bumps 3rd-party dependencies |

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.amp.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`Image - AmpImg should render image with srcset and fallbackSrcset corre
     <amp-img
       alt="Student sitting an exam"
       attribution=""
-      fallback="true"
+      fallback=""
       height="576"
       layout="responsive"
       sizes="100vw"

--- a/packages/components/psammead-image/src/index.amp.jsx
+++ b/packages/components/psammead-image/src/index.amp.jsx
@@ -12,7 +12,7 @@ const AmpImg = props => {
     <amp-img srcSet={srcset} {...omitInvalidProps(otherProps)}>
       {fallbackSrcset && (
         <amp-img
-          fallback
+          fallback=""
           srcSet={fallbackSrcset}
           {...omitInvalidProps(otherProps)}
         />

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.1| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|
 | 6.0.0| [PR#4606](https://github.com/bbc/psammead/pull/4606) Adds support for WebP |
 | 5.1.13 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |
 | 5.1.13 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles transitive packages |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-assets": "3.1.10",
-    "@bbc/psammead-image": "3.0.0",
+    "@bbc/psammead-image": "3.0.1",
     "@bbc/psammead-image-placeholder": "3.4.10",
     "@bbc/psammead-play-button": "3.0.32"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image@3.0.0, @bbc/psammead-image@workspace:packages/components/psammead-image":
+"@bbc/psammead-image@3.0.1, @bbc/psammead-image@workspace:packages/components/psammead-image":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image@workspace:packages/components/psammead-image"
   dependencies:
@@ -1953,7 +1953,7 @@ __metadata:
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
     "@bbc/psammead-assets": 3.1.10
-    "@bbc/psammead-image": 3.0.0
+    "@bbc/psammead-image": 3.0.1
     "@bbc/psammead-image-placeholder": 3.4.10
     "@bbc/psammead-play-button": 3.0.32
     "@emotion/styled": ^11.3.0


### PR DESCRIPTION
Follow up fix for https://github.com/bbc/psammead/pull/4606

**Overall change:** Sets an explicit empty value for the `fallback` attribute on `<amp-img />`, as this value is defaulted to `true` by React if set without an explicit value. AMP validator fails if it finds a value associated with `fallback`

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
