### PR TITLE
Add `primaryMimeType` and `fallbackMimeType` props to `psammead-image`

### DIFF
--- a/.yarn/versions/853c8102.yml
+++ b/.yarn/versions/853c8102.yml
@@ -1,5 +1,0 @@
-undecided:
-  - "@bbc/psammead"
-  - "@bbc/psammead-bulletin"
-  - "@bbc/psammead-grid"
-  - "@bbc/psammead-image"

--- a/.yarn/versions/853c8102.yml
+++ b/.yarn/versions/853c8102.yml
@@ -1,0 +1,5 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-bulletin"
+  - "@bbc/psammead-grid"
+  - "@bbc/psammead-image"

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.55 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 5.0.54 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 5.0.53 | [PR#4600](https://github.com/bbc/psammead/pull/4600) Fix TalkBack reading nested spans incorrectly |
 | 5.0.52 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 5.0.55 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
+| 5.0.55 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies |
 | 5.0.54 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 5.0.53 | [PR#4600](https://github.com/bbc/psammead/pull/4600) Fix TalkBack reading nested spans incorrectly |
 | 5.0.52 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.54",
+  "version": "5.0.55",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -22,7 +22,7 @@
     "@bbc/gel-foundations": "7.0.0",
     "@bbc/psammead-assets": "3.1.10",
     "@bbc/psammead-live-label": "2.0.32",
-    "@bbc/psammead-story-promo": "8.0.35",
+    "@bbc/psammead-story-promo": "8.0.36",
     "@bbc/psammead-styles": "8.0.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },

--- a/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -274,9 +274,11 @@ exports[`Bulletin should render audio correctly 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -625,9 +627,11 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -986,9 +990,11 @@ exports[`Bulletin should render live audio correctly 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -1355,9 +1361,11 @@ exports[`Bulletin should render live video correctly 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -1709,9 +1717,11 @@ exports[`Bulletin should render radio bulletin without ariaId 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -2029,9 +2039,11 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"
@@ -2377,9 +2389,11 @@ exports[`Bulletin should render video correctly 1`] = `
       >
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+          type="image/webp"
         />
         <source
           srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+          type="image/jpeg"
         />
         <img
           alt="Iron man"

--- a/packages/components/psammead-bulletin/src/index.stories.jsx
+++ b/packages/components/psammead-bulletin/src/index.stories.jsx
@@ -35,6 +35,8 @@ const BulletinComponent = ({
       fallbackSrcset={imageSizes
         .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
         .join(', ')}
+      primaryMimeType="image/webp"
+      fallbackMimeType="image/jpeg"
     />
   );
 

--- a/packages/components/psammead-bulletin/src/index.test.jsx
+++ b/packages/components/psammead-bulletin/src/index.test.jsx
@@ -36,6 +36,8 @@ const BulletinComponent = ({
       fallbackSrcset={imageSizes
         .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
         .join(', ')}
+      primaryMimeType="image/webp"
+      fallbackMimeType="image/jpeg"
     />
   );
   return (

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.13 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
+| 3.1.13 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies |
 | 3.1.12 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 3.1.11 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 3.1.10 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-grid/CHANGELOG.md
+++ b/packages/components/psammead-grid/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.13 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 3.1.12 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 3.1.11 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 3.1.10 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-grid/package.json
+++ b/packages/components/psammead-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-grid",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "description": "Grid component",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -1858,9 +1858,11 @@ exports[`Grid component should render Grid with enableGelGutters & margins on on
         >
           <source
             srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg.webp 1024w"
+            type="image/webp"
           />
           <source
             srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/11897/production/_106613817_999_al_.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/11897/production/_106613817_999_al_.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/11897/production/_106613817_999_al_.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/11897/production/_106613817_999_al_.jpg 1024w"
+            type="image/jpeg"
           />
           <img
             alt="Robert Downey Junior in Iron Man"

--- a/packages/components/psammead-grid/src/testHelpers.jsx
+++ b/packages/components/psammead-grid/src/testHelpers.jsx
@@ -46,6 +46,8 @@ export const ExampleImage = () => {
         fallbackSrcset={imageSizes
           .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
           .join(', ')}
+        primaryMimeType="image/webp"
+        fallbackMimeType="image/jpeg"
       />
     </ImageSpacing>
   );

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.0 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |
 | 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |
 | 2.0.8 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.0 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Derive mime type from srcset |
+| 3.1.0 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |
 | 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |
 | 2.0.8 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/components/psammead-image/README.md
+++ b/packages/components/psammead-image/README.md
@@ -66,6 +66,8 @@ const WrappingContainer = ({ alt, src, height, width, sizes }) => (
 | `src`    | string        | Yes | -     | "https://bbc.com/300/cat.jpg" |
 | `srcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg.webp 300w, https://bbc.com/450/cat.jpg.webp 450w, https://bbc.com/600/cat.jpg.webp 600w" |
 | `fallbackSrcset` | string        | No  | null  | "https://bbc.com/300/cat.jpg 300w, https://bbc.com/450/cat.jpg 450w, https://bbc.com/600/cat.jpg 600w" |
+| `primaryMimeType` | string        | No  | null  | "image/webp" |
+| `fallbackMimeType` | string        | No  | null  | "image/jpeg" |
 | `width`  | number/string | No  | null  | 600 |
 | `fade`   |  boolean      | No  | false | true |
 

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -51,7 +51,6 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -148,7 +147,6 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -177,7 +175,6 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -206,7 +203,6 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
@@ -270,7 +266,6 @@ exports[`Image - imported as default 'Image' should render image with custom dim
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -367,7 +362,6 @@ exports[`Image - imported as default 'Image' should render landscape image corre
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -396,7 +390,6 @@ exports[`Image - imported as default 'Image' should render portrait image correc
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -425,7 +418,6 @@ exports[`Image - imported as default 'Image' should render square image correctl
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
@@ -489,7 +481,6 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
@@ -586,7 +577,6 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
@@ -615,7 +605,6 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
@@ -644,7 +633,6 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
   <picture
     class="emotion-0 emotion-1"
   >
-    <source />
     <img
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -18,9 +18,11 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"
@@ -80,6 +82,7 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <img
       alt="Student sitting an exam"
@@ -111,9 +114,11 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"
@@ -232,9 +237,11 @@ exports[`Image - imported as default 'Image' should render image correctly witho
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"
@@ -294,6 +301,7 @@ exports[`Image - imported as default 'Image' should render image with only srcse
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <img
       alt="Student sitting an exam"
@@ -325,9 +333,11 @@ exports[`Image - imported as default 'Image' should render image with srcset and
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"
@@ -446,9 +456,11 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"
@@ -508,6 +520,7 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <img
       alt="Student sitting an exam"
@@ -539,9 +552,11 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
   >
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
+      type="image/webp"
     />
     <source
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
+      type="image/jpeg"
     />
     <img
       alt="Student sitting an exam"

--- a/packages/components/psammead-image/src/index.amp.jsx
+++ b/packages/components/psammead-image/src/index.amp.jsx
@@ -3,7 +3,11 @@ import omit from 'ramda/src/omit';
 import { number, string } from 'prop-types';
 
 // Prevents component outputting invalid HTML when styled with emotion
-const omitInvalidProps = omit(['classname']);
+const omitInvalidProps = omit([
+  'classname',
+  'primaryMimeType',
+  'fallbackMimeType',
+]);
 
 const AmpImg = props => {
   const { srcset, fallbackSrcset, ...otherProps } = props;

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -45,7 +45,7 @@ export const Img = props => {
 
   return (
     <StyledPicture onLoad={onLoad}>
-      <source srcSet={srcset} type={primaryMimeType} />
+      {srcset && <source srcSet={srcset} type={primaryMimeType} />}
       {fallbackSrcset && (
         <source srcSet={fallbackSrcset} type={fallbackMimeType} />
       )}
@@ -74,8 +74,8 @@ Img.defaultProps = {
   sizes: null,
   srcset: null,
   fallbackSrcset: null,
-  primaryMimeType: null,
-  fallbackMimeType: null,
+  primaryMimeType: 'image/jpeg',
+  fallbackMimeType: 'image/jpeg',
   width: null,
   onLoad: () => {},
 };

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -32,13 +32,43 @@ const StyledImg = styled.img`
   width: 100%;
 `;
 
+const getMimeType = srcset => {
+  if (!srcset) return null;
+
+  const firstSrcsetUrl = srcset.split(',')[0].split(' ')[0];
+  const urlFileExtension = firstSrcsetUrl.split('.').pop();
+
+  switch (urlFileExtension) {
+    case 'webp':
+      return 'image/webp';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    default:
+      return null;
+  }
+};
+
 export const Img = props => {
   const { src, srcset, fallbackSrcset, onLoad, ...otherProps } = props;
 
+  const primaryMimeType = getMimeType(srcset);
+  const secondaryMimeType = getMimeType(fallbackSrcset);
+
   return (
     <StyledPicture onLoad={onLoad}>
-      <source srcSet={srcset} />
-      {fallbackSrcset && <source srcSet={fallbackSrcset} />}
+      <source
+        srcSet={srcset}
+        {...(primaryMimeType && { type: primaryMimeType })}
+      />
+      {fallbackSrcset && (
+        <source
+          srcSet={fallbackSrcset}
+          {...(secondaryMimeType && { type: secondaryMimeType })}
+        />
+      )}
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>
   );

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -32,38 +32,22 @@ const StyledImg = styled.img`
   width: 100%;
 `;
 
-const getMimeType = srcset => {
-  if (!srcset) return null;
-
-  const firstSrcsetUrl = srcset.split(',')[0].split(' ')[0];
-  const urlFileExtension = firstSrcsetUrl.split('.').pop();
-
-  switch (urlFileExtension) {
-    case 'webp':
-      return 'image/webp';
-    case 'jpg':
-    case 'jpeg':
-      return 'image/jpeg';
-    case 'png':
-      return 'image/png';
-    case 'gif':
-      return 'image/gif';
-    default:
-      return null;
-  }
-};
-
 export const Img = props => {
-  const { src, srcset, fallbackSrcset, onLoad, ...otherProps } = props;
-
-  const primaryMimeType = getMimeType(srcset);
-  const secondaryMimeType = getMimeType(fallbackSrcset);
+  const {
+    src,
+    srcset,
+    fallbackSrcset,
+    primaryMimeType,
+    fallbackMimeType,
+    onLoad,
+    ...otherProps
+  } = props;
 
   return (
     <StyledPicture onLoad={onLoad}>
       <source srcSet={srcset} type={primaryMimeType} />
       {fallbackSrcset && (
-        <source srcSet={fallbackSrcset} type={secondaryMimeType} />
+        <source srcSet={fallbackSrcset} type={fallbackMimeType} />
       )}
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>
@@ -78,6 +62,8 @@ Img.propTypes = {
   src: string.isRequired,
   srcset: string,
   fallbackSrcset: string,
+  primaryMimeType: string,
+  fallbackMimeType: string,
   width: oneOfType([string, number]),
   onLoad: func,
 };
@@ -88,6 +74,8 @@ Img.defaultProps = {
   sizes: null,
   srcset: null,
   fallbackSrcset: null,
+  primaryMimeType: null,
+  fallbackMimeType: null,
   width: null,
   onLoad: () => {},
 };

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -46,6 +46,8 @@ const getMimeType = srcset => {
       return 'image/jpeg';
     case 'png':
       return 'image/png';
+    case 'gif':
+      return 'image/gif';
     default:
       return null;
   }

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -61,15 +61,9 @@ export const Img = props => {
 
   return (
     <StyledPicture onLoad={onLoad}>
-      <source
-        srcSet={srcset}
-        {...(primaryMimeType && { type: primaryMimeType })}
-      />
+      <source srcSet={srcset} type={primaryMimeType} />
       {fallbackSrcset && (
-        <source
-          srcSet={fallbackSrcset}
-          {...(secondaryMimeType && { type: secondaryMimeType })}
-        />
+        <source srcSet={fallbackSrcset} type={secondaryMimeType} />
       )}
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>

--- a/packages/components/psammead-image/src/index.test.jsx
+++ b/packages/components/psammead-image/src/index.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { render } from '@testing-library/react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import snapshotTests from './testHelpers/snapshotTests';
 import { landscape } from './testHelpers/fixtureData';
@@ -29,4 +30,16 @@ describe("Image - with Fade-in effect'", () => {
     <Img {...props} />,
   );
   snapshotTests(Image);
+});
+
+describe("Image - should have mime-types set'", () => {
+  const props = { ...landscape, width: null, fade: true };
+
+  const { container } = render(<Img {...props} />);
+
+  const sourceTags = container.querySelectorAll('source');
+
+  expect(sourceTags).toHaveLength(2);
+  expect(sourceTags[0].type).toEqual('image/webp');
+  expect(sourceTags[1].type).toEqual('image/jpeg');
 });

--- a/packages/components/psammead-image/src/index.test.jsx
+++ b/packages/components/psammead-image/src/index.test.jsx
@@ -33,7 +33,7 @@ describe("Image - with Fade-in effect'", () => {
 });
 
 describe("Image - should have mime-types set'", () => {
-  const props = { ...landscape, width: null, fade: true };
+  const props = { ...landscape, width: null };
 
   const { container } = render(<Img {...props} />);
 

--- a/packages/components/psammead-image/src/index.test.jsx
+++ b/packages/components/psammead-image/src/index.test.jsx
@@ -6,7 +6,10 @@ import { landscape } from './testHelpers/fixtureData';
 import Image, { Img } from '.';
 
 describe("Image - imported as default 'Image'", () => {
-  const props = { ...landscape, width: null };
+  const props = {
+    ...landscape,
+    width: null,
+  };
   shouldMatchSnapshot(
     'should render image correctly without width',
     <Image {...props} />,
@@ -15,7 +18,10 @@ describe("Image - imported as default 'Image'", () => {
 });
 
 describe("Image - imported as '{ Img }'", () => {
-  const props = { ...landscape, width: null };
+  const props = {
+    ...landscape,
+    width: null,
+  };
   shouldMatchSnapshot(
     'should render image correctly without width',
     <Img {...props} />,
@@ -24,7 +30,11 @@ describe("Image - imported as '{ Img }'", () => {
 });
 
 describe("Image - with Fade-in effect'", () => {
-  const props = { ...landscape, width: null, fade: true };
+  const props = {
+    ...landscape,
+    width: null,
+    fade: true,
+  };
   shouldMatchSnapshot(
     'should render image correctly without width',
     <Img {...props} />,
@@ -33,7 +43,10 @@ describe("Image - with Fade-in effect'", () => {
 });
 
 describe("Image - should have mime-types set'", () => {
-  const props = { ...landscape, width: null };
+  const props = {
+    ...landscape,
+    width: null,
+  };
 
   const { container } = render(<Img {...props} />);
 
@@ -42,4 +55,21 @@ describe("Image - should have mime-types set'", () => {
   expect(sourceTags).toHaveLength(2);
   expect(sourceTags[0].type).toEqual('image/webp');
   expect(sourceTags[1].type).toEqual('image/jpeg');
+});
+
+describe("Image - should have no mime-types set'", () => {
+  const props = {
+    ...landscape,
+    width: null,
+    primaryMimeType: null,
+    fallbackMimeType: null,
+  };
+
+  const { container } = render(<Img {...props} />);
+
+  const sourceTags = container.querySelectorAll('source');
+
+  expect(sourceTags).toHaveLength(2);
+  expect(sourceTags[0].type).toEqual('');
+  expect(sourceTags[1].type).toEqual('');
 });

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -15,6 +15,8 @@ export const landscape = {
   fallbackSrcset: sizes
     .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
+  primaryMimeType: 'image/webp',
+  fallbackMimeType: 'image/jpeg',
   width: 1024,
   height: 576,
 };
@@ -31,6 +33,8 @@ export const portrait = {
   fallbackSrcset: sizes
     .map(size => `${portraitImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
+  primaryMimeType: 'image/webp',
+  fallbackMimeType: 'image/jpeg',
   width: 1024,
   height: 1280,
 };
@@ -46,6 +50,8 @@ export const square = {
   fallbackSrcset: sizes
     .map(size => `${squareImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
+  primaryMimeType: 'image/webp',
+  fallbackMimeType: 'image/jpeg',
   width: 1024,
   height: 1024,
 };
@@ -61,6 +67,8 @@ export const custom = {
   fallbackSrcset: sizes
     .map(size => `${customImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
+  primaryMimeType: 'image/webp',
+  fallbackMimeType: 'image/jpeg',
   width: 445,
   height: 547,
 };
@@ -73,6 +81,7 @@ export const noFallbackSrcset = {
   srcset: sizes
     .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
+  primaryMimeType: 'image/jpeg',
   width: 1024,
   height: 576,
 };

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -73,6 +73,6 @@ export const noFallbackSrcset = {
   srcset: sizes
     .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)} ${size}w`)
     .join(', '),
-  width: 445,
-  height: 547,
+  width: 1024,
+  height: 576,
 };

--- a/packages/components/psammead-image/src/testHelpers/fixtureData.js
+++ b/packages/components/psammead-image/src/testHelpers/fixtureData.js
@@ -64,3 +64,15 @@ export const custom = {
   width: 445,
   height: 547,
 };
+
+export const noFallbackSrcset = {
+  alt: 'Student sitting an exam',
+  attribution: '',
+  sizes: '100vw',
+  src: landscapeImageUrl.replace('[WIDTH]', sizes[0]),
+  srcset: sizes
+    .map(size => `${landscapeImageUrl.replace('[WIDTH]', size)} ${size}w`)
+    .join(', '),
+  width: 445,
+  height: 547,
+};

--- a/packages/components/psammead-image/src/testHelpers/snapshotTests.jsx
+++ b/packages/components/psammead-image/src/testHelpers/snapshotTests.jsx
@@ -60,6 +60,8 @@ const snapshotTests = (Component, additionalProps) => {
       src={landscape.src}
       srcset={landscape.srcset}
       fallbackSrcset={landscape.fallbackSrcset}
+      primaryMimeType={landscape.primaryMimeType}
+      fallbackMimeType={landscape.fallbackMimeType}
       height={landscape.height}
       width={landscape.width}
       {...additionalProps}
@@ -73,6 +75,7 @@ const snapshotTests = (Component, additionalProps) => {
       sizes={landscape.sizes}
       src={landscape.src}
       srcset={landscape.srcset}
+      primaryMimeType={landscape.primaryMimeType}
       height={landscape.height}
       width={landscape.width}
       {...additionalProps}

--- a/packages/components/psammead-image/src/testHelpers/stories.jsx
+++ b/packages/components/psammead-image/src/testHelpers/stories.jsx
@@ -17,6 +17,8 @@ export function getProps(image, includeHeight, type) {
     src: image.src,
     srcset: image.srcset,
     fallbackSrcset: image.fallbackSrcset,
+    primaryMimeType: image.primaryMimeType,
+    fallbackMimeType: image.fallbackMimeType,
     width: image.width,
     fade: type === 'Img' ? boolean('Fade', false) : null,
   };

--- a/packages/components/psammead-image/src/testHelpers/stories.jsx
+++ b/packages/components/psammead-image/src/testHelpers/stories.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean } from '@storybook/addon-knobs';
 import notes from '../../README.md';
-import { custom, landscape, portrait, square } from './fixtureData';
+import {
+  custom,
+  landscape,
+  portrait,
+  square,
+  noFallbackSrcset,
+} from './fixtureData';
 
 export function getProps(image, includeHeight, type) {
   const props = {
@@ -76,6 +82,17 @@ export const stories = ({
         <Component
           {...getProps(landscape, includeHeight, type)}
           srcset={landscape.srcset}
+          {...additionalProps}
+        />
+      ),
+      { notes },
+    )
+    .add(
+      'image with no fallbackSrcset',
+      () => (
+        <Component
+          {...getProps(noFallbackSrcset, includeHeight, type)}
+          srcset={noFallbackSrcset.srcset}
           {...additionalProps}
         />
       ),

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.2| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|
 | 6.0.1| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|
 | 6.0.0| [PR#4606](https://github.com/bbc/psammead/pull/4606) Adds support for WebP |
 | 5.1.13 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 6.0.2| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|
+| 6.0.2| [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies|
 | 6.0.1| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|
 | 6.0.0| [PR#4606](https://github.com/bbc/psammead/pull/4606) Adds support for WebP |
 | 5.1.13 | [PR#4601](https://github.com/bbc/psammead/pull/4601) Bumps dependencies |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-assets": "3.1.10",
-    "@bbc/psammead-image": "3.0.1",
+    "@bbc/psammead-image": "3.1.0",
     "@bbc/psammead-image-placeholder": "3.4.10",
     "@bbc/psammead-play-button": "3.0.32"
   },

--- a/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/Placeholder/__snapshots__/index.test.jsx.snap
@@ -160,7 +160,6 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
     <picture
       class="emotion-17 emotion-18"
     >
-      <source />
       <img
         alt=""
         class="emotion-19 emotion-20"
@@ -363,7 +362,6 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
     <picture
       class="emotion-19 emotion-20"
     >
-      <source />
       <img
         alt=""
         class="emotion-21 emotion-22"
@@ -521,7 +519,6 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
     <picture
       class="emotion-15 emotion-16"
     >
-      <source />
       <img
         alt=""
         class="emotion-17 emotion-18"
@@ -695,7 +692,6 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
     <picture
       class="emotion-17 emotion-18"
     >
-      <source />
       <img
         alt=""
         class="emotion-19 emotion-20"
@@ -856,7 +852,6 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
     <picture
       class="emotion-15 emotion-16"
     >
-      <source />
       <img
         alt=""
         class="emotion-17 emotion-18"
@@ -1076,7 +1071,6 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
     <picture
       class="emotion-19 emotion-20"
     >
-      <source />
       <img
         alt=""
         class="emotion-21 emotion-22"

--- a/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-media-player/src/__snapshots__/index.test.jsx.snap
@@ -287,7 +287,6 @@ exports[`Media Player: Canonical Entry renders a landscape container with a plac
       <picture
         class="emotion-19 emotion-20"
       >
-        <source />
         <img
           alt=""
           class="emotion-21 emotion-22"
@@ -501,7 +500,6 @@ exports[`Media Player: Canonical Entry renders a placeholder image with guidance
       <picture
         class="emotion-21 emotion-22"
       >
-        <source />
         <img
           alt=""
           class="emotion-23 emotion-24"
@@ -683,7 +681,6 @@ exports[`Media Player: Canonical Entry renders a portrait container with a place
       <picture
         class="emotion-19 emotion-20"
       >
-        <source />
         <img
           alt=""
           class="emotion-21 emotion-22"
@@ -990,7 +987,6 @@ exports[`Media Player: Canonical Entry renders with no-js styles when noJsClassN
       <picture
         class="emotion-21 emotion-22"
       >
-        <source />
         <img
           alt=""
           class="emotion-23 emotion-24"

--- a/packages/components/psammead-story-promo-list/CHANGELOG.md
+++ b/packages/components/psammead-story-promo-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.0.30 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Bumps psammead-styles |
 | 6.0.29 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bumps psammead-styles |
 | 6.0.28 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 6.0.27 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-story-promo-list/package.json
+++ b/packages/components/psammead-story-promo-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo-list",
-  "version": "6.0.29",
+  "version": "6.0.30",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo-list/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo-list/src/index.stories.jsx
@@ -18,6 +18,8 @@ const ImageComponent = ({ alt, src }) => (
     width="640"
     srcset={`${src}.webp 640w`}
     fallbackSrcset={`${src} 640w`}
+    primaryMimeType="image/webp"
+    fallbackMimeType="image/jpeg"
   />
 );
 

--- a/packages/components/psammead-story-promo/CHANGELOG.md
+++ b/packages/components/psammead-story-promo/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 8.0.36 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies |
 | 8.0.35 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Bump dependencies |
 | 8.0.34 | [PR#4603](https://github.com/bbc/psammead/pull/4603) Conditionally add aria-labelledby attribute |
 | 8.0.33 | [PR#4602](https://github.com/bbc/psammead/pull/4602) Use 'children' value instead of 'URL' for aria-labelledby |

--- a/packages/components/psammead-story-promo/package.json
+++ b/packages/components/psammead-story-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-story-promo",
-  "version": "8.0.35",
+  "version": "8.0.36",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-story-promo/src/index.stories.jsx
+++ b/packages/components/psammead-story-promo/src/index.stories.jsx
@@ -30,6 +30,8 @@ const buildImg = () => {
       fallbackSrcset={imageSizes
         .map(size => `${imageSrc.replace('[WIDTH]', size)} ${size}w`)
         .join(', ')}
+      primaryMimeType="image/webp"
+      fallbackMimeType="image/jpeg"
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image@3.0.1, @bbc/psammead-image@workspace:packages/components/psammead-image":
+"@bbc/psammead-image@3.1.0, @bbc/psammead-image@workspace:packages/components/psammead-image":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image@workspace:packages/components/psammead-image"
   dependencies:
@@ -1953,7 +1953,7 @@ __metadata:
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
     "@bbc/psammead-assets": 3.1.10
-    "@bbc/psammead-image": 3.0.1
+    "@bbc/psammead-image": 3.1.0
     "@bbc/psammead-image-placeholder": 3.4.10
     "@bbc/psammead-play-button": 3.0.32
     "@emotion/styled": ^11.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
     "@bbc/gel-foundations": 7.0.0
     "@bbc/psammead-assets": 3.1.10
     "@bbc/psammead-live-label": 2.0.32
-    "@bbc/psammead-story-promo": 8.0.35
+    "@bbc/psammead-story-promo": 8.0.36
     "@bbc/psammead-styles": 8.0.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
@@ -2092,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-story-promo@8.0.35, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
+"@bbc/psammead-story-promo@8.0.36, @bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-story-promo@workspace:packages/components/psammead-story-promo"
   dependencies:


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/9628

**Overall change:**
Derives the `<source />` mime-type by checking the srcsets of the image. This appears to be required by some older browsers that cannot derive the mime-type themselves from the server response.

**Code changes:**

- Updates the `psammead-image` canonical component to check the `srcset` and `fallbackSrcset` URLs to determine what the mime-type of the respective `<source />` tag should be set to.
---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
