### PR TITLE
Moving image `sizes` attribute to `source` tags

### DIFF
--- a/.yarn/versions/fbc06d94.yml
+++ b/.yarn/versions/fbc06d94.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@bbc/psammead"

--- a/.yarn/versions/fbc06d94.yml
+++ b/.yarn/versions/fbc06d94.yml
@@ -1,2 +1,0 @@
-undecided:
-  - "@bbc/psammead"

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.1 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Elevate `sizes` attribute to `source` tags |
+| 3.1.1 | [PR#4626](https://github.com/bbc/psammead/pull/4626) Elevate `sizes` attribute to `source` tags |
 | 3.1.0 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |
 | 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.1 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Elevate `sizes` attribute to `source` tags |
 | 3.1.0 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |
 | 3.0.0 | [PR#4606](https://github.com/bbc/psammead/pull/4606) Add support for WebP |

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -56,6 +57,7 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -88,6 +90,7 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -125,6 +128,7 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -152,6 +156,7 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -179,6 +184,7 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -206,6 +212,7 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -243,6 +250,7 @@ exports[`Image - imported as default 'Image' should render image correctly witho
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -269,6 +277,7 @@ exports[`Image - imported as default 'Image' should render image with custom dim
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -301,6 +310,7 @@ exports[`Image - imported as default 'Image' should render image with only srcse
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -338,6 +348,7 @@ exports[`Image - imported as default 'Image' should render image with srcset and
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -365,6 +376,7 @@ exports[`Image - imported as default 'Image' should render landscape image corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -392,6 +404,7 @@ exports[`Image - imported as default 'Image' should render portrait image correc
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -419,6 +432,7 @@ exports[`Image - imported as default 'Image' should render square image correctl
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -456,6 +470,7 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -482,6 +497,7 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -514,6 +530,7 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -551,6 +568,7 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -578,6 +596,7 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -605,6 +624,7 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -632,6 +652,7 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
+      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -30,7 +30,6 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -57,7 +56,6 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -90,7 +88,6 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -128,7 +125,6 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -156,7 +152,6 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -184,7 +179,6 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -212,7 +206,6 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -250,7 +243,6 @@ exports[`Image - imported as default 'Image' should render image correctly witho
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -277,7 +269,6 @@ exports[`Image - imported as default 'Image' should render image with custom dim
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -310,7 +301,6 @@ exports[`Image - imported as default 'Image' should render image with only srcse
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -348,7 +338,6 @@ exports[`Image - imported as default 'Image' should render image with srcset and
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -376,7 +365,6 @@ exports[`Image - imported as default 'Image' should render landscape image corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -404,7 +392,6 @@ exports[`Image - imported as default 'Image' should render portrait image correc
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -432,7 +419,6 @@ exports[`Image - imported as default 'Image' should render square image correctl
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -470,7 +456,6 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -497,7 +482,6 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -530,7 +514,6 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -568,7 +551,6 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -596,7 +578,6 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -624,7 +605,6 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -652,7 +632,6 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />

--- a/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-image/src/__snapshots__/index.test.jsx.snap
@@ -17,10 +17,12 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -28,7 +30,6 @@ exports[`Image - imported as '{ Img }' should render image correctly without wid
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -55,7 +56,6 @@ exports[`Image - imported as '{ Img }' should render image with custom dimension
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -80,6 +80,7 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
@@ -87,7 +88,6 @@ exports[`Image - imported as '{ Img }' should render image with only srcset corr
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -112,10 +112,12 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -123,7 +125,6 @@ exports[`Image - imported as '{ Img }' should render image with srcset and fallb
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -151,7 +152,6 @@ exports[`Image - imported as '{ Img }' should render landscape image correctly 1
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -179,7 +179,6 @@ exports[`Image - imported as '{ Img }' should render portrait image correctly 1`
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -207,7 +206,6 @@ exports[`Image - imported as '{ Img }' should render square image correctly 1`] 
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -232,10 +230,12 @@ exports[`Image - imported as default 'Image' should render image correctly witho
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -243,7 +243,6 @@ exports[`Image - imported as default 'Image' should render image correctly witho
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -270,7 +269,6 @@ exports[`Image - imported as default 'Image' should render image with custom dim
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -295,6 +293,7 @@ exports[`Image - imported as default 'Image' should render image with only srcse
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
@@ -302,7 +301,6 @@ exports[`Image - imported as default 'Image' should render image with only srcse
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -327,10 +325,12 @@ exports[`Image - imported as default 'Image' should render image with srcset and
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -338,7 +338,6 @@ exports[`Image - imported as default 'Image' should render image with srcset and
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -366,7 +365,6 @@ exports[`Image - imported as default 'Image' should render landscape image corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -394,7 +392,6 @@ exports[`Image - imported as default 'Image' should render portrait image correc
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -422,7 +419,6 @@ exports[`Image - imported as default 'Image' should render square image correctl
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />
@@ -447,10 +443,12 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -458,7 +456,6 @@ exports[`Image - with Fade-in effect' should render image correctly without widt
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
     />
   </picture>
@@ -485,7 +482,6 @@ exports[`Image - with Fade-in effect' should render image with custom dimensions
       alt="By Elisa Decker, from her series \\"Sidewalk\\""
       class="emotion-2 emotion-3"
       height="547"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/164BB/production/_104032319_03270dcc-9dda-4bd4-96a0-db89f6b915ae.jpg"
       width="445"
     />
@@ -510,6 +506,7 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
@@ -517,7 +514,6 @@ exports[`Image - with Fade-in effect' should render image with only srcset corre
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -542,10 +538,12 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
     class="emotion-0 emotion-1"
   >
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg.webp 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg.webp 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg.webp 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg.webp 1024w"
       type="image/webp"
     />
     <source
+      sizes="100vw"
       srcset="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg 300w, https://ichef.bbci.co.uk/news/450/cpsprodpb/7098/production/_104842882_students.jpg 450w, https://ichef.bbci.co.uk/news/600/cpsprodpb/7098/production/_104842882_students.jpg 600w, https://ichef.bbci.co.uk/news/1024/cpsprodpb/7098/production/_104842882_students.jpg 1024w"
       type="image/jpeg"
     />
@@ -553,7 +551,6 @@ exports[`Image - with Fade-in effect' should render image with srcset and fallba
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -581,7 +578,6 @@ exports[`Image - with Fade-in effect' should render landscape image correctly 1`
       alt="Student sitting an exam"
       class="emotion-2 emotion-3"
       height="576"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/7098/production/_104842882_students.jpg"
       width="1024"
     />
@@ -609,7 +605,6 @@ exports[`Image - with Fade-in effect' should render portrait image correctly 1`]
       alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
       class="emotion-2 emotion-3"
       height="1280"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
       width="1024"
     />
@@ -637,7 +632,6 @@ exports[`Image - with Fade-in effect' should render square image correctly 1`] =
       alt="Tracks through the snow"
       class="emotion-2 emotion-3"
       height="1024"
-      sizes="100vw"
       src="https://ichef.bbci.co.uk/news/300/cpsprodpb/114FE/production/_104801907_79010.jpg"
       width="1024"
     />

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -52,7 +52,7 @@ export const Img = props => {
       {fallbackSrcset && (
         <source srcSet={fallbackSrcset} type={fallbackMimeType} sizes={sizes} />
       )}
-      <StyledImg src={src} {...otherProps} />
+      <StyledImg src={src} sizes={sizes} {...otherProps} />
     </StyledPicture>
   );
 };

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -52,7 +52,7 @@ export const Img = props => {
       {fallbackSrcset && (
         <source srcSet={fallbackSrcset} type={fallbackMimeType} sizes={sizes} />
       )}
-      <StyledImg src={src} sizes={sizes} {...otherProps} />
+      <StyledImg src={src} {...otherProps} />
     </StyledPicture>
   );
 };

--- a/packages/components/psammead-image/src/index.jsx
+++ b/packages/components/psammead-image/src/index.jsx
@@ -36,6 +36,7 @@ export const Img = props => {
   const {
     src,
     srcset,
+    sizes,
     fallbackSrcset,
     primaryMimeType,
     fallbackMimeType,
@@ -45,9 +46,11 @@ export const Img = props => {
 
   return (
     <StyledPicture onLoad={onLoad}>
-      {srcset && <source srcSet={srcset} type={primaryMimeType} />}
+      {srcset && (
+        <source srcSet={srcset} type={primaryMimeType} sizes={sizes} />
+      )}
       {fallbackSrcset && (
-        <source srcSet={fallbackSrcset} type={fallbackMimeType} />
+        <source srcSet={fallbackSrcset} type={fallbackMimeType} sizes={sizes} />
       )}
       <StyledImg src={src} {...otherProps} />
     </StyledPicture>

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.4| [PR#4626](https://github.com/bbc/psammead/pull/4626) Bump dependencies|
 | 6.0.3 | [PR#4609](https://github.com/bbc/psammead/pull/4609) Bump from psammead-styles |
 | 6.0.2| [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies|
 | 6.0.1| [PR#4607](https://github.com/bbc/psammead/pull/4607) Bump dependencies|

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-assets": "3.1.10",
-    "@bbc/psammead-image": "3.1.0",
+    "@bbc/psammead-image": "3.1.1",
     "@bbc/psammead-image-placeholder": "3.4.11",
     "@bbc/psammead-play-button": "3.0.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image@3.1.0, @bbc/psammead-image@workspace:packages/components/psammead-image":
+"@bbc/psammead-image@3.1.1, @bbc/psammead-image@workspace:packages/components/psammead-image":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image@workspace:packages/components/psammead-image"
   dependencies:
@@ -1953,7 +1953,7 @@ __metadata:
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
     "@bbc/psammead-assets": 3.1.10
-    "@bbc/psammead-image": 3.1.0
+    "@bbc/psammead-image": 3.1.1
     "@bbc/psammead-image-placeholder": 3.4.11
     "@bbc/psammead-play-button": 3.0.33
     "@emotion/styled": ^11.3.0


### PR DESCRIPTION
Resolves [#9858](https://github.com/bbc/simorgh/issues/9858)

**Overall change:** Adds the `sizes` attribute to the `<source />` tags for our images. This was previously on the `<img />` tag, which meant that the `<source />` tags couldn't determine which size of image to use

**Code changes:**

- Updates the `psammead-image` component to set the `sizes` attributes on `<source />` tags instead of the fallback `<img />` tag

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
