### PR TITLE
Bumping `psammead-image` version

### DIFF
--- a/.yarn/versions/cc36261f.yml
+++ b/.yarn/versions/cc36261f.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@bbc/psammead"

--- a/.yarn/versions/cc36261f.yml
+++ b/.yarn/versions/cc36261f.yml
@@ -1,2 +1,0 @@
-undecided:
-  - "@bbc/psammead"

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.1.2 | [PR#4626](https://github.com/bbc/psammead/pull/4626) Version bump |
 | 3.1.1 | [PR#4626](https://github.com/bbc/psammead/pull/4626) Elevate `sizes` attribute to `source` tags |
 | 3.1.0 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |

--- a/packages/components/psammead-image/CHANGELOG.md
+++ b/packages/components/psammead-image/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 3.1.2 | [PR#4626](https://github.com/bbc/psammead/pull/4626) Version bump |
+| 3.1.2 | [PR#4627](https://github.com/bbc/psammead/pull/4627) Version bump |
 | 3.1.1 | [PR#4626](https://github.com/bbc/psammead/pull/4626) Elevate `sizes` attribute to `source` tags |
 | 3.1.0 | [PR#4608](https://github.com/bbc/psammead/pull/4608) Derive mime type from srcset |
 | 3.0.1 | [PR#4607](https://github.com/bbc/psammead/pull/4607) Fix amp-img fallback value |

--- a/packages/components/psammead-image/package.json
+++ b/packages/components/psammead-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.5| [PR#4626](https://github.com/bbc/psammead/pull/4626) Bump dependencies|
 | 6.0.4| [PR#4626](https://github.com/bbc/psammead/pull/4626) Bump dependencies|
 | 6.0.3 | [PR#4609](https://github.com/bbc/psammead/pull/4609) Bump from psammead-styles |
 | 6.0.2| [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies|

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 6.0.5| [PR#4626](https://github.com/bbc/psammead/pull/4626) Bump dependencies|
+| 6.0.5| [PR#4627](https://github.com/bbc/psammead/pull/4627) Bump dependencies|
 | 6.0.4| [PR#4626](https://github.com/bbc/psammead/pull/4626) Bump dependencies|
 | 6.0.3 | [PR#4609](https://github.com/bbc/psammead/pull/4609) Bump from psammead-styles |
 | 6.0.2| [PR#4608](https://github.com/bbc/psammead/pull/4608) Bump dependencies|

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bbc/psammead-assets": "3.1.10",
-    "@bbc/psammead-image": "3.1.1",
+    "@bbc/psammead-image": "3.1.2",
     "@bbc/psammead-image-placeholder": "3.4.11",
     "@bbc/psammead-play-button": "3.0.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,7 +1876,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image@3.1.1, @bbc/psammead-image@workspace:packages/components/psammead-image":
+"@bbc/psammead-image@3.1.2, @bbc/psammead-image@workspace:packages/components/psammead-image":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image@workspace:packages/components/psammead-image"
   dependencies:
@@ -1953,7 +1953,7 @@ __metadata:
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
     "@bbc/psammead-assets": 3.1.10
-    "@bbc/psammead-image": 3.1.1
+    "@bbc/psammead-image": 3.1.2
     "@bbc/psammead-image-placeholder": 3.4.11
     "@bbc/psammead-play-button": 3.0.33
     "@emotion/styled": ^11.3.0


### PR DESCRIPTION
Related to https://github.com/bbc/simorgh/issues/9858

**Overall change:** 

- Bumps the version of `psammead-image` as `3.1.1` is still referencing a reverted version https://github.com/bbc/psammead/pull/4618

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
