### PR TITLE
Update caption's text color

### DIFF
--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
-| 4.1.24| [PR#4630](https://github.com/bbc/psammead/pull/4630) Update text colour to C_GREY_6 |
+| 4.1.25| [PR#4630](https://github.com/bbc/psammead/pull/4630) Update text colour to C_GREY_6 |
 | 4.1.24| [PR#4609](https://github.com/bbc/psammead/pull/4609) Bump from psammead-styles |
 | 4.1.23 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 4.1.22 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-caption/CHANGELOG.md
+++ b/packages/components/psammead-caption/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 4.1.24| [PR#4630](https://github.com/bbc/psammead/pull/4630) Update text colour to C_GREY_6 |
 | 4.1.24| [PR#4609](https://github.com/bbc/psammead/pull/4609) Bump from psammead-styles |
 | 4.1.23 | [PR#4574](https://github.com/bbc/psammead/pull/4574) Bumps psammead-styles |
 | 4.1.22 | [PR#4568](https://github.com/bbc/psammead/pull/4568) Bump dependencies |

--- a/packages/components/psammead-caption/package.json
+++ b/packages/components/psammead-caption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-caption",
-  "version": "4.1.24",
+  "version": "4.1.25",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,

--- a/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/packages/components/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`Caption should render with some offscreen text 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #6E6E73;
+  color: #545658;
   margin-top: 0.5rem;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -96,7 +96,7 @@ exports[`Caption should render with some offscreen text and arabic script typogr
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #6E6E73;
+  color: #545658;
   margin-top: 0.5rem;
   padding-left: 0.5rem;
   padding-right: 0.5rem;

--- a/packages/components/psammead-caption/src/index.jsx
+++ b/packages/components/psammead-caption/src/index.jsx
@@ -12,7 +12,7 @@ import {
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import { getLongPrimer } from '@bbc/gel-foundations/typography';
-import { C_METAL } from '@bbc/psammead-styles/colours';
+import { C_METAL, C_GREY_6 } from '@bbc/psammead-styles/colours';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 
@@ -53,7 +53,7 @@ const ltrStyles = `
 const Caption = styled.figcaption`
   ${({ script }) => script && getLongPrimer(script)}
   ${({ service }) => getSansRegular(service)}
-  color: ${C_METAL};
+  color: ${C_GREY_6};
   margin-top: ${GEL_SPACING};
   padding-left: ${GEL_MARGIN_BELOW_400PX};
   padding-right: ${GEL_MARGIN_BELOW_400PX};


### PR DESCRIPTION
Resolves [#9925](https://github.com/bbc/simorgh/issues/9925)

Update caption's text colour from `C_METAL` to `C_GREY_6`

**Code changes:**

- As above

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
