### PR TITLE
Adds amp script in amp boilerplate

### DIFF
--- a/.yarn/versions/4a2fc102.yml
+++ b/.yarn/versions/4a2fc102.yml
@@ -1,0 +1,9 @@
+undecided:
+  - "@bbc/psammead"
+  - "@bbc/psammead-bulletin"
+  - "@bbc/psammead-embed-error"
+  - "@bbc/psammead-image-placeholder"
+  - "@bbc/psammead-media-indicator"
+  - "@bbc/psammead-media-player"
+  - "@bbc/psammead-navigation"
+  - "@bbc/psammead-assets"

--- a/.yarn/versions/4a2fc102.yml
+++ b/.yarn/versions/4a2fc102.yml
@@ -1,9 +1,0 @@
-undecided:
-  - "@bbc/psammead"
-  - "@bbc/psammead-bulletin"
-  - "@bbc/psammead-embed-error"
-  - "@bbc/psammead-image-placeholder"
-  - "@bbc/psammead-media-indicator"
-  - "@bbc/psammead-media-player"
-  - "@bbc/psammead-navigation"
-  - "@bbc/psammead-assets"

--- a/packages/components/psammead-bulletin/CHANGELOG.md
+++ b/packages/components/psammead-bulletin/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 5.0.60 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 5.0.59 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 5.0.58 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 5.0.57 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-bulletin/package.json
+++ b/packages/components/psammead-bulletin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-bulletin",
-  "version": "5.0.59",
+  "version": "5.0.60",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/BBC-News/psammead/blob/latest/packages/components/psammead-bulletin/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-live-label": "2.0.35",
     "@bbc/psammead-story-promo": "8.0.38",
     "@bbc/psammead-styles": "8.1.1",

--- a/packages/components/psammead-embed-error/CHANGELOG.md
+++ b/packages/components/psammead-embed-error/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version        | Description                                                                                                                                       |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.0.37 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 3.0.36 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 3.0.35         | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles                                                                         |
 | 3.0.34         | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump                                                                         |

--- a/packages/components/psammead-embed-error/package.json
+++ b/packages/components/psammead-embed-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-embed-error",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-styles": "8.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-image-placeholder/CHANGELOG.md
+++ b/packages/components/psammead-image-placeholder/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.4.15 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 3.4.14 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 3.4.13 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 3.4.12 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-image-placeholder/package.json
+++ b/packages/components/psammead-image-placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-image-placeholder",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-image-placeholder/README.md",
   "dependencies": {
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-styles": "8.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-indicator/CHANGELOG.md
+++ b/packages/components/psammead-media-indicator/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------- | ----------- |
+| 6.1.18 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 6.1.17 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 6.1.16 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 6.1.15 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-media-indicator/package.json
+++ b/packages/components/psammead-media-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-indicator",
-  "version": "6.1.17",
+  "version": "6.1.18",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "sideEffects": false,
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-media-indicator/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-styles": "8.1.1"
   },
   "peerDependencies": {

--- a/packages/components/psammead-media-player/CHANGELOG.md
+++ b/packages/components/psammead-media-player/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version       | Description                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.0.10 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 6.0.9 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 6.0.8 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 6.0.7 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-media-player/package.json
+++ b/packages/components/psammead-media-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-media-player",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "description": "Provides a media player with optional placeholder",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -29,10 +29,10 @@
     "react": ">=16.9.0"
   },
   "dependencies": {
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-image": "3.1.3",
-    "@bbc/psammead-image-placeholder": "3.4.14",
-    "@bbc/psammead-play-button": "3.0.36"
+    "@bbc/psammead-image-placeholder": "3.4.15",
+    "@bbc/psammead-play-button": "3.0.37"
   },
   "devDependencies": {
     "@emotion/styled": "^11.3.0",

--- a/packages/components/psammead-navigation/CHANGELOG.md
+++ b/packages/components/psammead-navigation/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 9.2.22 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 9.2.21 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 9.2.20 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 9.2.19 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-navigation/package.json
+++ b/packages/components/psammead-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-navigation",
-  "version": "9.2.21",
+  "version": "9.2.22",
   "description": "A navigation bar to use on index pages",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-navigation/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-styles": "8.1.1",
     "@bbc/psammead-visually-hidden-text": "2.0.7"
   },

--- a/packages/components/psammead-play-button/CHANGELOG.md
+++ b/packages/components/psammead-play-button/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 | ------------- | ----------- |
+| 3.0.37 | [PR#4636](https://github.com/bbc/psammead/pull/4636) Bumps from psammead-assets |
 | 3.0.36 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Bumps psammead-assets |
 | 3.0.35 | [PR#4633](https://github.com/bbc/psammead/pull/4633) bump psammead-styles |
 | 3.0.34 | [PR#4632](https://github.com/bbc/psammead/pull/4632) psammead-styles bump |

--- a/packages/components/psammead-play-button/package.json
+++ b/packages/components/psammead-play-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-play-button",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "description": "Provides a play button, with optional duration, for playable media.",
   "main": "dist/index.js",
   "module": "esm/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/bbc/psammead/blob/latest/packages/components/psammead-play-button/README.md",
   "dependencies": {
     "@bbc/gel-foundations": "7.0.0",
-    "@bbc/psammead-assets": "3.2.0",
+    "@bbc/psammead-assets": "3.3.0",
     "@bbc/psammead-styles": "8.1.1"
   },
   "peerDependencies": {

--- a/packages/utilities/psammead-assets/CHANGELOG.md
+++ b/packages/utilities/psammead-assets/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- prettier-ignore -->
 | Version | Description |
 |---------|-------------|
+| 3.3.0 | [PR#](https://github.com/bbc/psammead/pull/) Add AMP_SCRIPT_JS script |
 | 3.2.0 | [PR#4634](https://github.com/bbc/psammead/pull/4634) Reduces dark mode BBC block size |
 | 3.1.10 | [PR#4601](https://github.com/bbc/psammead/pull/4601) SVG size adjustments |
 | 3.1.9 | [PR#4486](https://github.com/bbc/psammead/pull/4486) upgrade minor/patch dependencies |

--- a/packages/utilities/psammead-assets/index.test.jsx
+++ b/packages/utilities/psammead-assets/index.test.jsx
@@ -13,6 +13,7 @@ const ampBoilerplateExpectedExports = {
   AMP_MUSTACHE_JS: 'object',
   AMP_ADS_JS: 'object',
   AMP_AD: 'object',
+  AMP_SCRIPT_JS: 'object',
 };
 
 const svgsExpectedExports = {

--- a/packages/utilities/psammead-assets/package.json
+++ b/packages/utilities/psammead-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/psammead-assets",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "sideEffects": false,
   "description": "A collection of common assets that are likely to be required by many Psammead components or users, such as SVGs or small scripts.",
   "repository": {

--- a/packages/utilities/psammead-assets/src/__snapshots__/amp-boilerplate.test.jsx.snap
+++ b/packages/utilities/psammead-assets/src/__snapshots__/amp-boilerplate.test.jsx.snap
@@ -89,6 +89,16 @@ exports[`AMP Boilerplate JavaScript should render AMP Mustache JS 1`] = `
 </div>
 `;
 
+exports[`AMP Boilerplate JavaScript should render AMP SCRIPT JS 1`] = `
+<div>
+  <script
+    async=""
+    custom-element="amp-script"
+    src="https://cdn.ampproject.org/v0/amp-script-0.1.js"
+  />
+</div>
+`;
+
 exports[`AMP Boilerplate JavaScript should render AMP ads JS 1`] = `
 <div>
   <script

--- a/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
+++ b/packages/utilities/psammead-assets/src/amp-boilerplate.jsx
@@ -71,3 +71,11 @@ export const AMP_AD = (
     src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"
   />
 );
+
+export const AMP_SCRIPT_JS = (
+  <script
+    async
+    custom-element="amp-script"
+    src="https://cdn.ampproject.org/v0/amp-script-0.1.js"
+  />
+);

--- a/packages/utilities/psammead-assets/src/amp-boilerplate.test.jsx
+++ b/packages/utilities/psammead-assets/src/amp-boilerplate.test.jsx
@@ -32,5 +32,9 @@ describe('AMP Boilerplate', () => {
     );
     shouldMatchSnapshot('should render AMP ads JS', boilerplate.AMP_ADS_JS);
     shouldMatchSnapshot('should render AMP AD', boilerplate.AMP_AD);
+    shouldMatchSnapshot(
+      'should render AMP SCRIPT JS',
+      boilerplate.AMP_SCRIPT_JS,
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,7 +1644,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-assets@3.2.0, @bbc/psammead-assets@workspace:packages/utilities/psammead-assets":
+"@bbc/psammead-assets@3.3.0, @bbc/psammead-assets@workspace:packages/utilities/psammead-assets":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-assets@workspace:packages/utilities/psammead-assets"
   dependencies:
@@ -1691,7 +1691,7 @@ __metadata:
   resolution: "@bbc/psammead-bulletin@workspace:packages/components/psammead-bulletin"
   dependencies:
     "@bbc/gel-foundations": 7.0.0
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-live-label": 2.0.35
     "@bbc/psammead-story-promo": 8.0.38
     "@bbc/psammead-styles": 8.1.1
@@ -1805,7 +1805,7 @@ __metadata:
   resolution: "@bbc/psammead-embed-error@workspace:packages/components/psammead-embed-error"
   dependencies:
     "@bbc/gel-foundations": 7.0.0
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-styles": 8.1.1
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
@@ -1862,11 +1862,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-image-placeholder@3.4.14, @bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder":
+"@bbc/psammead-image-placeholder@3.4.15, @bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-image-placeholder@workspace:packages/components/psammead-image-placeholder"
   dependencies:
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-styles": 8.1.1
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
@@ -1938,7 +1938,7 @@ __metadata:
   resolution: "@bbc/psammead-media-indicator@workspace:packages/components/psammead-media-indicator"
   dependencies:
     "@bbc/gel-foundations": 7.0.0
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-styles": 8.1.1
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
@@ -1952,10 +1952,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-media-player@workspace:packages/components/psammead-media-player"
   dependencies:
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-image": 3.1.3
-    "@bbc/psammead-image-placeholder": 3.4.14
-    "@bbc/psammead-play-button": 3.0.36
+    "@bbc/psammead-image-placeholder": 3.4.15
+    "@bbc/psammead-play-button": 3.0.37
     "@emotion/styled": ^11.3.0
     react: ^17.0.2
   peerDependencies:
@@ -1969,7 +1969,7 @@ __metadata:
   resolution: "@bbc/psammead-navigation@workspace:packages/components/psammead-navigation"
   dependencies:
     "@bbc/gel-foundations": 7.0.0
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-styles": 8.1.1
     "@bbc/psammead-visually-hidden-text": 2.0.7
     "@emotion/styled": ^11.3.0
@@ -2005,12 +2005,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bbc/psammead-play-button@3.0.36, @bbc/psammead-play-button@workspace:packages/components/psammead-play-button":
+"@bbc/psammead-play-button@3.0.37, @bbc/psammead-play-button@workspace:packages/components/psammead-play-button":
   version: 0.0.0-use.local
   resolution: "@bbc/psammead-play-button@workspace:packages/components/psammead-play-button"
   dependencies:
     "@bbc/gel-foundations": 7.0.0
-    "@bbc/psammead-assets": 3.2.0
+    "@bbc/psammead-assets": 3.3.0
     "@bbc/psammead-styles": 8.1.1
     "@emotion/styled": ^11.3.0
     react: ^17.0.2


### PR DESCRIPTION
Part Of: https://github.com/bbc/simorgh/issues/10011 

**Overall change:** added amp script export to amp boilerplate to use it in Simorgh.

**Code changes:**

- Update tests
- Added amp script to amp boilerplate exports as AMP_SCRIPT_JS

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
