### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -4,8 +4,14 @@ on:
     branches-ignore:
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: ubuntu-latest
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/psammead-change-scanner.yml
+++ b/.github/workflows/psammead-change-scanner.yml
@@ -10,6 +10,9 @@ on:
       - '**'
       - '!latest'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Change Scanner

--- a/.github/workflows/psammead-publish.yml
+++ b/.github/workflows/psammead-publish.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/psammead-unit-tests.yml
+++ b/.github/workflows/psammead-unit-tests.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
