### PR TITLE
Component Migration Info Updates to Psammead Readme [WSTEAMA-51]

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -2,7 +2,7 @@
 
 We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a legacy package in our Single Page Application called Simorgh (www.github.com/bbc/simorgh).
 
-Any open source contributions to these components should now be made via the Simorgh repo.
+Any open source contributions to these components should now be made via the Simorgh repo as they are no longer being maintained in the Psammead repo.
 
 # Psammead Packages Directory...
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,6 +1,6 @@
 # 🚨 --- NO LONGER MAINTAINED ---- Psammead ---- NO LONGER MAINTAINED --- 🚨
 
-We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a legacy package in our Single Page Application called Simorgh (www.github.com/bbc/simorgh).
+We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a [legacy folder](https://github.com/bbc/simorgh/tree/latest/src/app/legacy) in our Single Page Application called [Simorgh](www.github.com/bbc/simorgh).
 
 Any open source contributions to these components should now be made via the Simorgh repo as they are no longer being maintained in the Psammead repo.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,3 +1,9 @@
+# 🚨 --- NO LONGER MAINTAINED ---- Psammead ---- NO LONGER MAINTAINED --- 🚨
+
+We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a legacy package in our Single Page Application called Simorgh (www.github.com/bbc/simorgh).
+
+Any open source contributions to these components should now be made via the Simorgh repo.
+
 # Psammead Packages Directory...
 
 NB all Development Dependencies are in the top level package.json, none are in the packages.


### PR DESCRIPTION
Related to WSTEAMA-51

**Overall change:** 

Updates the psammead repo to announce that components are now being maintained via Simorgh

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
