### PR TITLE
Fix link to Simorgh repo in first paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">:sparkles: Psammead - BBC Package Library - 🚨 NO LONGER MAINTAINED 🚨:sparkles:</h1>
 
-We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a [legacy folder](https://github.com/bbc/simorgh/tree/latest/src/app/legacy) in our Single Page Application called [Simorgh](www.github.com/bbc/simorgh).
+We have recently migrated most of our Psammead components (except for BBC Web Vitals) to a [legacy folder](https://github.com/bbc/simorgh/tree/latest/src/app/legacy) in our Single Page Application called [Simorgh](https://www.github.com/bbc/simorgh).
 
 Any open source contributions to these components should now be made via the Simorgh repo as they are no longer being maintained in the Psammead repo.
 


### PR DESCRIPTION
Without the https:// the effective link was https://github.com/bbc/psammead/blob/latest/www.github.com/bbc/simorgh

Resolves #NUMBER

**Overall change:** _A very high-level summary of easily-reproducible changes that can be understood by non-devs._

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
